### PR TITLE
NewSession() fixed to return value with Nano Second

### DIFF
--- a/internal/memory/providers/inmemory.go
+++ b/internal/memory/providers/inmemory.go
@@ -184,7 +184,7 @@ func (m *InMemoryProvider) GetHistory(ctx context.Context, limit ...int) ([]core
 }
 
 func (m *InMemoryProvider) NewSession() string {
-	return generateID()
+	return core.GenerateSessionID()
 }
 
 func (m *InMemoryProvider) SetSession(ctx context.Context, sessionID string) context.Context {

--- a/internal/memory/providers/weaviate.go
+++ b/internal/memory/providers/weaviate.go
@@ -45,7 +45,7 @@ func (w *WeaviateProvider) GetHistory(ctx context.Context, limit ...int) ([]core
 }
 
 func (w *WeaviateProvider) NewSession() string {
-	return generateID()
+	return core.GenerateSessionID()
 }
 
 func (w *WeaviateProvider) SetSession(ctx context.Context, sessionID string) context.Context {
@@ -79,4 +79,3 @@ func (w *WeaviateProvider) SearchAll(ctx context.Context, query string, options 
 func (w *WeaviateProvider) BuildContext(ctx context.Context, query string, options ...core.ContextOption) (*core.RAGContext, error) {
 	return nil, fmt.Errorf("Weaviate provider not yet implemented")
 }
-


### PR DESCRIPTION
**Description**:
The `InMemoryProvider.GetHistory()` method did NOT properly respect session isolation. When multiple sessions were created on the same provider instance, `GetHistory()` returned messages from ALL sessions instead of filtering to only the current session's messages.

**Root Cause**:
The issue was in the `generateID()` function used by `NewSession()`. The function used `time.Now().UnixNano()` which could generate identical IDs when called in rapid succession (within the same nanosecond), causing session ID collisions.