### PR TITLE
Add OpenRouter LLM provider integration with vNext example

### DIFF
--- a/core/llm.go
+++ b/core/llm.go
@@ -174,6 +174,10 @@ type LLMProviderConfig struct {
 	// Ollama-specific fields
 	BaseURL string `json:"base_url,omitempty" toml:"base_url,omitempty"`
 
+	// OpenRouter-specific fields
+	SiteURL  string `json:"site_url,omitempty" toml:"site_url,omitempty"`
+	SiteName string `json:"site_name,omitempty" toml:"site_name,omitempty"`
+
 	// HTTP client configuration
 	HTTPTimeout time.Duration `json:"http_timeout,omitempty" toml:"http_timeout,omitempty"`
 }
@@ -351,6 +355,21 @@ func NewLLMProvider(config AgentLLMConfig) (ModelProvider, error) {
 			providerConfig.BaseURL = baseURL
 		} else {
 			providerConfig.BaseURL = "http://localhost:11434"
+		}
+	case "openrouter":
+		if apiKey := os.Getenv("OPENROUTER_API_KEY"); apiKey != "" {
+			providerConfig.APIKey = apiKey
+		}
+		if baseURL := os.Getenv("OPENROUTER_BASE_URL"); baseURL != "" {
+			providerConfig.BaseURL = baseURL
+		} else {
+			providerConfig.BaseURL = "https://openrouter.ai/api/v1"
+		}
+		if siteURL := os.Getenv("OPENROUTER_SITE_URL"); siteURL != "" {
+			providerConfig.SiteURL = siteURL
+		}
+		if siteName := os.Getenv("OPENROUTER_SITE_NAME"); siteName != "" {
+			providerConfig.SiteName = siteName
 		}
 	}
 

--- a/core/vnext/config.go
+++ b/core/vnext/config.go
@@ -36,12 +36,14 @@ type Config struct {
 
 // LLMConfig contains LLM provider configuration
 type LLMConfig struct {
-	Provider    string  `toml:"provider"`           // openai, ollama, azure, anthropic
-	Model       string  `toml:"model"`              // Model name
-	Temperature float32 `toml:"temperature"`        // 0.0 to 2.0
-	MaxTokens   int     `toml:"max_tokens"`         // Maximum tokens to generate
-	BaseURL     string  `toml:"base_url,omitempty"` // Custom base URL
-	APIKey      string  `toml:"api_key,omitempty"`  // API key (prefer env vars)
+	Provider    string  `toml:"provider"`            // openai, ollama, azure, anthropic, openrouter
+	Model       string  `toml:"model"`               // Model name
+	Temperature float32 `toml:"temperature"`         // 0.0 to 2.0
+	MaxTokens   int     `toml:"max_tokens"`          // Maximum tokens to generate
+	BaseURL     string  `toml:"base_url,omitempty"`  // Custom base URL
+	APIKey      string  `toml:"api_key,omitempty"`   // API key (prefer env vars)
+	SiteURL     string  `toml:"site_url,omitempty"`  // OpenRouter: Site URL for rankings
+	SiteName    string  `toml:"site_name,omitempty"` // OpenRouter: Site name for analytics
 }
 
 // MemoryConfig contains memory and RAG configuration

--- a/examples/openrouter_usage/main.go
+++ b/examples/openrouter_usage/main.go
@@ -1,0 +1,224 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+
+	"github.com/kunalkushwaha/agenticgokit/core"
+	_ "github.com/kunalkushwaha/agenticgokit/plugins/llm/openrouter"
+)
+
+func main() {
+	// Check for API key in environment
+	apiKey := os.Getenv("OPENROUTER_API_KEY")
+	if apiKey == "" {
+		log.Fatal("OPENROUTER_API_KEY environment variable not set. Please set it with your OpenRouter API key.")
+	}
+
+	// Example 1: Basic usage with API key from environment
+	fmt.Println("Example 1: Basic OpenRouter Usage")
+	fmt.Println("====================================")
+
+	config := core.LLMProviderConfig{
+		Type:        "openrouter",
+		APIKey:      apiKey, // Read from OPENROUTER_API_KEY environment variable
+		Model:       "openai/gpt-3.5-turbo",
+		MaxTokens:   500,
+		Temperature: 0.7,
+	}
+
+	provider, err := core.NewModelProviderFromConfig(config)
+	if err != nil {
+		log.Fatalf("Failed to create provider: %v", err)
+	}
+
+	ctx := context.Background()
+	response, err := provider.Call(ctx, core.Prompt{
+		System: "You are a helpful assistant.",
+		User:   "What is OpenRouter?",
+	})
+
+	if err != nil {
+		log.Fatalf("Call failed: %v", err)
+	}
+
+	fmt.Printf("Response: %s\n", response.Content)
+	fmt.Printf("Tokens used: %d (prompt: %d, completion: %d)\n\n",
+		response.Usage.TotalTokens,
+		response.Usage.PromptTokens,
+		response.Usage.CompletionTokens)
+
+	// Example 2: Using different models
+	fmt.Println("Example 2: Using Different Models")
+	fmt.Println("====================================")
+
+	models := []string{
+		"openai/gpt-3.5-turbo",
+		"anthropic/claude-3-haiku",
+		"google/gemini-2.0-flash-exp:free", // Updated to available free model
+		"meta-llama/llama-3.1-8b-instruct",
+	}
+
+	for _, model := range models {
+		modelConfig := core.LLMProviderConfig{
+			Type:        "openrouter",
+			APIKey:      apiKey,
+			Model:       model,
+			MaxTokens:   100,
+			Temperature: 0.7,
+		}
+
+		modelProvider, err := core.NewModelProviderFromConfig(modelConfig)
+		if err != nil {
+			log.Printf("Failed to create provider for %s: %v", model, err)
+			continue
+		}
+
+		modelResponse, err := modelProvider.Call(ctx, core.Prompt{
+			User: "Say hello in one sentence.",
+		})
+
+		if err != nil {
+			log.Printf("Call to %s failed: %v", model, err)
+			continue
+		}
+
+		fmt.Printf("Model: %s\n", model)
+		fmt.Printf("Response: %s\n", modelResponse.Content)
+		fmt.Printf("Tokens: %d\n\n", modelResponse.Usage.TotalTokens)
+	}
+
+	// Example 3: Streaming responses
+	fmt.Println("Example 3: Streaming Responses")
+	fmt.Println("====================================")
+
+	streamConfig := core.LLMProviderConfig{
+		Type:        "openrouter",
+		APIKey:      apiKey,
+		Model:       "openai/gpt-3.5-turbo",
+		MaxTokens:   200,
+		Temperature: 0.8,
+	}
+
+	streamProvider, err := core.NewModelProviderFromConfig(streamConfig)
+	if err != nil {
+		log.Fatalf("Failed to create stream provider: %v", err)
+	}
+
+	fmt.Print("Streaming response: ")
+	tokenChan, err := streamProvider.Stream(ctx, core.Prompt{
+		User: "Write a haiku about coding.",
+	})
+
+	if err != nil {
+		log.Fatalf("Stream failed: %v", err)
+	}
+
+	for token := range tokenChan {
+		if token.Error != nil {
+			log.Fatalf("Stream error: %v", token.Error)
+		}
+		fmt.Print(token.Content)
+	}
+	fmt.Println("\n")
+
+	// Example 4: Using AgentLLMConfig (automatically reads OPENROUTER_API_KEY)
+	fmt.Println("Example 4: Using AgentLLMConfig")
+	fmt.Println("====================================")
+	fmt.Println("AgentLLMConfig automatically reads OPENROUTER_API_KEY environment variable")
+
+	envConfig := core.AgentLLMConfig{
+		Provider:    "openrouter",
+		Model:       "anthropic/claude-3-haiku",
+		MaxTokens:   300,
+		Temperature: 0.7,
+	}
+
+	envProvider, err := core.NewLLMProvider(envConfig)
+	if err != nil {
+		log.Fatalf("Failed to create provider: %v", err)
+	}
+
+	envResponse, err := envProvider.Call(ctx, core.Prompt{
+		User: "What are the benefits of AI?",
+	})
+
+	if err != nil {
+		log.Fatalf("Call failed: %v", err)
+	}
+
+	fmt.Printf("Response: %s\n", envResponse.Content)
+	fmt.Println()
+
+	// Example 5: Using site tracking for OpenRouter rankings
+	fmt.Println("Example 5: Site Tracking")
+	fmt.Println("====================================")
+
+	trackingConfig := core.LLMProviderConfig{
+		Type:        "openrouter",
+		APIKey:      apiKey,
+		Model:       "openai/gpt-3.5-turbo",
+		MaxTokens:   200,
+		Temperature: 0.7,
+		SiteURL:     "https://myapp.com",
+		SiteName:    "My Awesome App",
+	}
+
+	trackingProvider, err := core.NewModelProviderFromConfig(trackingConfig)
+	if err != nil {
+		log.Fatalf("Failed to create provider with tracking: %v", err)
+	}
+
+	fmt.Println("Provider created with site tracking enabled")
+	fmt.Println("HTTP-Referer: https://myapp.com")
+	fmt.Println("X-Title: My Awesome App")
+	fmt.Println("These headers help with OpenRouter rankings and analytics\n")
+
+	trackingResponse, err := trackingProvider.Call(ctx, core.Prompt{
+		User: "Explain OpenRouter in one sentence.",
+	})
+
+	if err != nil {
+		log.Printf("Call failed: %v", err)
+	} else {
+		fmt.Printf("Response: %s\n", trackingResponse.Content)
+	}
+
+	// Example 6: Parameter overrides
+	fmt.Println("\nExample 6: Parameter Overrides")
+	fmt.Println("====================================")
+
+	// Provider defaults: MaxTokens=500, Temperature=0.7
+	paramProvider, err := core.NewModelProviderFromConfig(core.LLMProviderConfig{
+		Type:        "openrouter",
+		APIKey:      apiKey,
+		Model:       "openai/gpt-3.5-turbo",
+		MaxTokens:   500,
+		Temperature: 0.7,
+	})
+
+	if err != nil {
+		log.Fatalf("Failed to create provider: %v", err)
+	}
+
+	// Override for this specific call
+	maxTokens := int32(50)
+	temperature := float32(0.3)
+
+	paramResponse, err := paramProvider.Call(ctx, core.Prompt{
+		User: "Count from 1 to 5.",
+		Parameters: core.ModelParameters{
+			MaxTokens:   &maxTokens,
+			Temperature: &temperature,
+		},
+	})
+
+	if err != nil {
+		log.Printf("Call failed: %v", err)
+	} else {
+		fmt.Printf("Response with overridden parameters: %s\n", paramResponse.Content)
+		fmt.Printf("Used temperature=0.3 and maxTokens=50 instead of defaults\n")
+	}
+}

--- a/examples/vnext/openrouter-quickstart/README.md
+++ b/examples/vnext/openrouter-quickstart/README.md
@@ -1,0 +1,324 @@
+# OpenRouter QuickStart - vNext API Example
+
+This example demonstrates how to use the AgenticGoKit vNext API with OpenRouter as the LLM provider.
+
+## Overview
+
+OpenRouter provides unified access to multiple LLM providers through a single API. This example shows various patterns for creating and using agents with OpenRouter, including:
+
+1. **Basic Agent Creation** - Using Config struct
+2. **Preset Chat Agent** - Using factory functions with options
+3. **Streaming Responses** - Real-time token streaming
+4. **Multiple Models** - Testing different OpenRouter models
+5. **RunOptions** - Detailed execution results
+6. **Site Tracking** - OpenRouter rankings and analytics
+7. **Custom Handlers** - Custom logic with LLM fallback
+8. **Simple Setup** - Using WithLLM option for quick configuration
+
+## Prerequisites
+
+1. **OpenRouter API Key**: Sign up at [OpenRouter.ai](https://openrouter.ai/) to get your API key
+2. **Set Environment Variable**:
+   ```powershell
+   # PowerShell
+   $env:OPENROUTER_API_KEY = "sk-or-v1-..."
+   ```
+   
+   ```bash
+   # Bash/Linux
+   export OPENROUTER_API_KEY="sk-or-v1-..."
+   ```
+
+## Running the Example
+
+```powershell
+# Navigate to the example directory
+cd examples/vnext/openrouter-quickstart
+
+# Run the example
+go run main.go
+```
+
+## Example Breakdown
+
+### 1. Basic Agent with Config
+
+Creates an agent using a complete `Config` struct with API key from environment:
+
+```go
+// Read API key from environment
+apiKey := os.Getenv("OPENROUTER_API_KEY")
+
+config := &vnext.Config{
+    Name:         "openrouter-assistant",
+    SystemPrompt: "You are a helpful assistant.",
+    Timeout:      30 * time.Second,
+    LLM: vnext.LLMConfig{
+        Provider:    "openrouter",
+        Model:       "openai/gpt-3.5-turbo",
+        APIKey:      apiKey, // Pass API key explicitly
+        Temperature: 0.7,
+        MaxTokens:   500,
+    },
+}
+
+agent, err := vnext.NewBuilder("openrouter-assistant").
+    WithConfig(config).
+    Build()
+```
+
+**Important**: The vNext API requires you to explicitly pass the API key in the config. It does not automatically read from environment variables like the core API does.
+
+### 2. Preset Chat Agent
+
+Uses a complete `Config` struct with the builder pattern:
+
+```go
+chatConfig := &vnext.Config{
+    Name:         "chat-bot",
+    SystemPrompt: "You are a conversational assistant.",
+    Timeout:      30 * time.Second,
+    LLM: vnext.LLMConfig{
+        Provider:    "openrouter",
+        Model:       "anthropic/claude-3-haiku",
+        APIKey:      apiKey, // Must include API key
+        Temperature: 0.7,
+        MaxTokens:   100,
+    },
+}
+
+agent, err := vnext.NewBuilder("chat-bot").
+    WithConfig(chatConfig).
+    Build()
+```
+
+### 3. Streaming Responses
+
+Demonstrates real-time streaming with chunk processing:
+
+```go
+stream, err := agent.RunStream(ctx, "Write a haiku about coding.",
+    vnext.WithBufferSize(10),
+    vnext.WithThoughts(),
+)
+
+for chunk := range stream.Chunks() {
+    if chunk.Type == vnext.ChunkTypeDelta {
+        fmt.Print(chunk.Delta)
+    }
+}
+```
+
+### 4. Multiple Models
+
+Tests different LLM providers available through OpenRouter:
+
+- OpenAI GPT-3.5 Turbo
+- Anthropic Claude 3 Haiku
+- Google Gemini 2.0 Flash (free tier)
+- Meta Llama 3.1 8B Instruct
+
+### 5. RunOptions for Detailed Results
+
+Uses `RunOptions` to get comprehensive execution information:
+
+```go
+opts := vnext.RunWithDetailedResult().
+    SetTimeout(30 * time.Second).
+    AddContext("request_id", "demo-123")
+
+result, err := agent.RunWithOptions(ctx, query, opts)
+```
+
+### 6. Site Tracking
+
+Enables OpenRouter rankings and analytics by providing site information:
+
+```go
+LLM: vnext.LLMConfig{
+    Provider:    "openrouter",
+    Model:       "openai/gpt-3.5-turbo",
+    SiteURL:     "https://myapp.com",     // Your app URL
+    SiteName:    "My Awesome App",        // Your app name
+}
+```
+
+This sets the `HTTP-Referer` and `X-Title` headers in requests to OpenRouter.
+
+### 7. Custom Handler
+
+Implements custom logic with LLM fallback:
+
+```go
+customHandler := func(ctx context.Context, input string, caps *vnext.Capabilities) (string, error) {
+    if len(input) < 10 {
+        // Short query: expand it
+        return caps.LLM(
+            "You are a helpful assistant that expands short queries.",
+            fmt.Sprintf("Expand this query: %s", input),
+        )
+    }
+    // Normal processing
+    return caps.LLM("You are a helpful assistant.", input)
+}
+```
+
+### 8. Preset with Custom Prompt
+
+Uses a preset configuration with custom system prompt:
+
+```go
+config8 := &vnext.Config{
+    Name:         "simple-agent",
+    SystemPrompt: "You are a helpful assistant specialized in programming languages.",
+    Timeout:      30 * time.Second,
+    LLM: vnext.LLMConfig{
+        Provider:    "openrouter",
+        Model:       "openai/gpt-3.5-turbo",
+        APIKey:      apiKey, // API key required
+        Temperature: 0.7,
+        MaxTokens:   200,
+    },
+}
+
+agent, err := vnext.NewBuilder("simple-agent").
+    WithConfig(config8).
+    Build()
+```
+
+**Note**: While the vNext API has `WithLLM()` and `WithLLMConfig()` options, they don't support setting the API key. Always use the full `Config` struct approach for OpenRouter.
+
+## OpenRouter Models
+
+OpenRouter provides access to models from various providers. Some free-tier options include:
+
+- `openai/gpt-3.5-turbo` - Fast and efficient
+- `anthropic/claude-3-haiku` - Balanced performance
+- `google/gemini-2.0-flash-exp:free` - Google's latest
+- `meta-llama/llama-3.1-8b-instruct` - Open source
+
+For the full list of available models and pricing, visit [OpenRouter Models](https://openrouter.ai/models).
+
+## Configuration Options
+
+### LLMConfig Fields
+
+- `Provider`: Set to `"openrouter"`
+- `Model`: Model identifier (e.g., `"openai/gpt-3.5-turbo"`)
+- `APIKey`: **Required** - Your OpenRouter API key (read from environment)
+- `Temperature`: 0.0-2.0 (controls randomness)
+- `MaxTokens`: Maximum tokens to generate
+- `SiteURL`: (Optional) Your application URL for rankings
+- `SiteName`: (Optional) Your application name for analytics
+
+### Agent Configuration
+
+- `Name`: Agent identifier
+- `SystemPrompt`: System-level instructions
+- `Timeout`: Execution timeout duration
+
+### API Key Configuration
+
+**Important**: The vNext framework requires explicit API key configuration. Unlike the core API which automatically reads environment variables, you must:
+
+1. Read the environment variable yourself:
+   ```go
+   apiKey := os.Getenv("OPENROUTER_API_KEY")
+   ```
+
+2. Pass it explicitly in the config:
+   ```go
+   LLM: vnext.LLMConfig{
+       APIKey: apiKey, // Required!
+       // ... other settings
+   }
+   ```
+
+## Best Practices
+
+1. **API Key Security**: Never hardcode API keys - always read from environment variables
+   ```go
+   apiKey := os.Getenv("OPENROUTER_API_KEY")
+   if apiKey == "" {
+       log.Fatal("OPENROUTER_API_KEY not set")
+   }
+   ```
+
+2. **Config Pattern**: Always use the full `Config` struct with API key:
+   ```go
+   config := &vnext.Config{
+       LLM: vnext.LLMConfig{
+           APIKey: apiKey, // Required for vNext API
+           // ... other settings
+       },
+   }
+   ```
+
+3. **Model Selection**: Choose models based on your use case:
+   - GPT-3.5 for general tasks
+   - Claude for reasoning and analysis
+   - Gemini for multimodal tasks
+   - Llama for cost-sensitive applications
+
+4. **Timeout Configuration**: Set appropriate timeouts based on expected response time
+
+5. **Site Tracking**: Always set SiteURL and SiteName for production apps
+
+6. **Error Handling**: Always check for errors and handle them appropriately
+
+7. **Context Management**: Use `defer agent.Cleanup(ctx)` to ensure proper cleanup
+
+## Troubleshooting
+
+### "OPENROUTER_API_KEY environment variable not set"
+
+Set the environment variable:
+```powershell
+# PowerShell
+$env:OPENROUTER_API_KEY = "sk-or-v1-your-api-key-here"
+```
+
+```bash
+# Bash/Linux
+export OPENROUTER_API_KEY="sk-or-v1-your-api-key-here"
+```
+
+### "API key is required for OpenRouter provider"
+
+This means the API key wasn't passed in the config. Make sure you're setting it:
+
+```go
+config := &vnext.Config{
+    LLM: vnext.LLMConfig{
+        Provider: "openrouter",
+        APIKey:   apiKey, // ← Must be set!
+        Model:    "openai/gpt-3.5-turbo",
+    },
+}
+```
+
+**Do not use**: `WithLLM()` or `WithLLMConfig()` options alone - they don't support API keys.
+
+### "404 - No endpoints found" or "400 - not a valid model ID"
+
+The model name is incorrect or unavailable. Check [OpenRouter Models](https://openrouter.ai/models) for valid model IDs.
+
+### Connection Timeout
+
+Increase the timeout in the config:
+```go
+Timeout: 60 * time.Second,  // Increase from 30s to 60s
+```
+
+## Related Documentation
+
+- [vNext Framework README](../../../core/vnext/README.md)
+- [OpenRouter Integration Design](../../../docs/design/OpenRouterIntegration.md)
+- [Streaming Guide](../../../core/vnext/STREAMING_GUIDE.md)
+- [Migration Guide](../../../core/vnext/MIGRATION_GUIDE.md)
+
+## Support
+
+For issues specific to:
+- **AgenticGoKit**: Open an issue on GitHub
+- **OpenRouter API**: Visit [OpenRouter Support](https://openrouter.ai/docs)

--- a/examples/vnext/openrouter-quickstart/main.go
+++ b/examples/vnext/openrouter-quickstart/main.go
@@ -1,0 +1,409 @@
+package main
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"time"
+
+	"github.com/kunalkushwaha/agenticgokit/core/vnext"
+	_ "github.com/kunalkushwaha/agenticgokit/plugins/llm/openrouter"
+)
+
+func main() {
+	fmt.Println("===========================================")
+	fmt.Println("  OpenRouter QuickStart - vNext API")
+	fmt.Println("===========================================")
+	fmt.Println()
+
+	// Check for API key in environment
+	apiKey := os.Getenv("OPENROUTER_API_KEY")
+	if apiKey == "" {
+		log.Fatal("OPENROUTER_API_KEY environment variable not set. Please set it with your OpenRouter API key.")
+	}
+
+	// Initialize vNext with defaults (optional but recommended)
+	if err := vnext.InitializeDefaults(); err != nil {
+		log.Fatalf("Failed to initialize vNext: %v", err)
+	}
+
+	ctx := context.Background()
+
+	// Example 1: Basic Usage with Config
+	fmt.Println("Example 1: Basic Agent with Config")
+	fmt.Println("====================================")
+
+	config1 := &vnext.Config{
+		Name:         "openrouter-assistant",
+		SystemPrompt: "You are a helpful assistant.",
+		Timeout:      30 * time.Second,
+		LLM: vnext.LLMConfig{
+			Provider:    "openrouter",
+			Model:       "openai/gpt-3.5-turbo",
+			APIKey:      apiKey, // Pass the API key from environment
+			Temperature: 0.7,
+			MaxTokens:   500,
+		},
+	}
+
+	agent1, err := vnext.NewBuilder("openrouter-assistant").
+		WithConfig(config1).
+		Build()
+
+	if err != nil {
+		log.Fatalf("Failed to create agent: %v", err)
+	}
+
+	if err := agent1.Initialize(ctx); err != nil {
+		log.Fatalf("Failed to initialize agent: %v", err)
+	}
+	defer agent1.Cleanup(ctx)
+
+	result1, err := agent1.Run(ctx, "What is OpenRouter?")
+	if err != nil {
+		log.Fatalf("Run failed: %v", err)
+	}
+
+	fmt.Printf("Response: %s\n", result1.Content)
+	fmt.Printf("Duration: %v | Tokens: %d\n\n", result1.Duration, result1.TokensUsed)
+
+	// Example 2: Using Preset Chat Agent with Options
+	fmt.Println("Example 2: Preset Chat Agent")
+	fmt.Println("==============================")
+
+	// Create a config first with API key
+	chatConfig := &vnext.Config{
+		Name:         "chat-bot",
+		SystemPrompt: "You are a conversational assistant focused on providing helpful and friendly responses",
+		Timeout:      30 * time.Second,
+		LLM: vnext.LLMConfig{
+			Provider:    "openrouter",
+			Model:       "anthropic/claude-3-haiku",
+			APIKey:      apiKey, // Pass the API key
+			Temperature: 0.7,
+			MaxTokens:   100,
+		},
+	}
+
+	chatAgent, err := vnext.NewBuilder("chat-bot").
+		WithConfig(chatConfig).
+		Build()
+
+	if err != nil {
+		log.Fatalf("Failed to create chat agent: %v", err)
+	}
+
+	if err := chatAgent.Initialize(ctx); err != nil {
+		log.Fatalf("Failed to initialize chat agent: %v", err)
+	}
+	defer chatAgent.Cleanup(ctx)
+
+	result2, err := chatAgent.Run(ctx, "Say hello in one sentence.")
+	if err != nil {
+		log.Fatalf("Run failed: %v", err)
+	}
+
+	fmt.Printf("Response: %s\n", result2.Content)
+	fmt.Printf("Duration: %v\n\n", result2.Duration)
+
+	// Example 3: Streaming Responses
+	fmt.Println("Example 3: Streaming Responses")
+	fmt.Println("================================")
+
+	config3 := &vnext.Config{
+		Name:         "streaming-agent",
+		SystemPrompt: "You are a creative writing assistant.",
+		Timeout:      30 * time.Second,
+		LLM: vnext.LLMConfig{
+			Provider:    "openrouter",
+			Model:       "openai/gpt-3.5-turbo",
+			APIKey:      apiKey, // Pass the API key
+			Temperature: 0.8,
+			MaxTokens:   200,
+		},
+	}
+
+	streamAgent, err := vnext.NewBuilder("streaming-agent").
+		WithConfig(config3).
+		Build()
+
+	if err != nil {
+		log.Fatalf("Failed to create streaming agent: %v", err)
+	}
+
+	if err := streamAgent.Initialize(ctx); err != nil {
+		log.Fatalf("Failed to initialize streaming agent: %v", err)
+	}
+	defer streamAgent.Cleanup(ctx)
+
+	fmt.Print("Streaming response: ")
+	stream, err := streamAgent.RunStream(ctx, "Write a haiku about coding.",
+		vnext.WithBufferSize(10),
+		vnext.WithThoughts(),
+	)
+
+	if err != nil {
+		log.Fatalf("Stream failed: %v", err)
+	}
+
+	for chunk := range stream.Chunks() {
+		if chunk.Error != nil {
+			log.Fatalf("Stream error: %v", chunk.Error)
+		}
+		if chunk.Type == vnext.ChunkTypeDelta {
+			fmt.Print(chunk.Delta)
+		}
+	}
+
+	streamResult, err := stream.Wait()
+	if err != nil {
+		log.Fatalf("Stream wait failed: %v", err)
+	}
+
+	fmt.Printf("\n\nDuration: %v | Success: %v\n\n", streamResult.Duration, streamResult.Success)
+
+	// Example 4: Using Different Models
+	fmt.Println("Example 4: Testing Multiple Models")
+	fmt.Println("====================================")
+
+	models := []struct {
+		name  string
+		model string
+	}{
+		{"OpenAI GPT-3.5", "openai/gpt-3.5-turbo"},
+		{"Claude 3 Haiku", "anthropic/claude-3-haiku"},
+		{"Gemini 2.0 Flash", "google/gemini-2.0-flash-exp:free"},
+		{"Llama 3.1", "meta-llama/llama-3.1-8b-instruct"},
+	}
+
+	for _, m := range models {
+		modelConfig := &vnext.Config{
+			Name:         m.name,
+			SystemPrompt: "You are a helpful assistant.",
+			Timeout:      30 * time.Second,
+			LLM: vnext.LLMConfig{
+				Provider:    "openrouter",
+				Model:       m.model,
+				APIKey:      apiKey, // Pass the API key
+				Temperature: 0.7,
+				MaxTokens:   100,
+			},
+		}
+
+		modelAgent, err := vnext.NewBuilder(m.name).
+			WithConfig(modelConfig).
+			Build()
+
+		if err != nil {
+			log.Printf("Failed to create agent for %s: %v", m.name, err)
+			continue
+		}
+
+		if err := modelAgent.Initialize(ctx); err != nil {
+			log.Printf("Failed to initialize agent for %s: %v", m.name, err)
+			continue
+		}
+
+		result, err := modelAgent.Run(ctx, "What is 2+2?")
+		if err != nil {
+			log.Printf("Call to %s failed: %v", m.name, err)
+			modelAgent.Cleanup(ctx)
+			continue
+		}
+
+		fmt.Printf("\nModel: %s\n", m.name)
+		fmt.Printf("Response: %s\n", result.Content)
+		fmt.Printf("Duration: %v\n", result.Duration)
+
+		modelAgent.Cleanup(ctx)
+	}
+
+	// Example 5: Using RunOptions for Detailed Results
+	fmt.Println("\nExample 5: Detailed Results with RunOptions")
+	fmt.Println("============================================")
+
+	config5 := &vnext.Config{
+		Name:         "detail-agent",
+		SystemPrompt: "You are a helpful assistant.",
+		Timeout:      30 * time.Second,
+		LLM: vnext.LLMConfig{
+			Provider:    "openrouter",
+			Model:       "openai/gpt-3.5-turbo",
+			APIKey:      apiKey, // Pass the API key
+			Temperature: 0.7,
+			MaxTokens:   300,
+		},
+	}
+
+	detailAgent, err := vnext.NewBuilder("detail-agent").
+		WithConfig(config5).
+		Build()
+
+	if err != nil {
+		log.Fatalf("Failed to create detail agent: %v", err)
+	}
+
+	if err := detailAgent.Initialize(ctx); err != nil {
+		log.Fatalf("Failed to initialize detail agent: %v", err)
+	}
+	defer detailAgent.Cleanup(ctx)
+
+	// Use RunOptions for detailed execution information
+	opts := vnext.RunWithDetailedResult().
+		SetTimeout(30*time.Second).
+		AddContext("request_id", "demo-123")
+
+	detailResult, err := detailAgent.RunWithOptions(ctx, "Explain AI in one sentence.", opts)
+	if err != nil {
+		log.Fatalf("Run with options failed: %v", err)
+	}
+
+	fmt.Printf("Response: %s\n", detailResult.Content)
+	fmt.Printf("Duration: %v\n", detailResult.Duration)
+	fmt.Printf("Success: %v\n", detailResult.Success)
+	fmt.Printf("Tokens Used: %d\n", detailResult.TokensUsed)
+	fmt.Printf("Metadata: %v\n", detailResult.Metadata)
+
+	// Example 6: Site Tracking Configuration
+	fmt.Println("\nExample 6: Site Tracking for OpenRouter Rankings")
+	fmt.Println("=================================================")
+
+	// Create a custom config with site tracking
+	trackingConfig := &vnext.Config{
+		Name:         "tracked-agent",
+		SystemPrompt: "You are a helpful assistant.",
+		Timeout:      30 * time.Second,
+		LLM: vnext.LLMConfig{
+			Provider:    "openrouter",
+			Model:       "openai/gpt-3.5-turbo",
+			APIKey:      apiKey, // Pass the API key
+			Temperature: 0.7,
+			MaxTokens:   200,
+			// These fields enable site tracking for OpenRouter rankings
+			SiteURL:  "https://myapp.com",
+			SiteName: "My Awesome App",
+		},
+	}
+
+	trackingAgent, err := vnext.NewBuilder("tracked-agent").
+		WithConfig(trackingConfig).
+		Build()
+
+	if err != nil {
+		log.Fatalf("Failed to create tracking agent: %v", err)
+	}
+
+	if err := trackingAgent.Initialize(ctx); err != nil {
+		log.Fatalf("Failed to initialize tracking agent: %v", err)
+	}
+	defer trackingAgent.Cleanup(ctx)
+
+	fmt.Println("Agent created with site tracking enabled")
+	fmt.Println("HTTP-Referer: https://myapp.com")
+	fmt.Println("X-Title: My Awesome App")
+	fmt.Println("These headers help with OpenRouter rankings and analytics")
+	fmt.Println()
+
+	trackingResult, err := trackingAgent.Run(ctx, "What is machine learning?")
+	if err != nil {
+		log.Printf("Call failed: %v", err)
+	} else {
+		fmt.Printf("Response: %s\n", trackingResult.Content)
+		fmt.Printf("Duration: %v\n", trackingResult.Duration)
+	}
+
+	// Example 7: Using Custom Handler with OpenRouter
+	fmt.Println("\nExample 7: Custom Handler")
+	fmt.Println("==========================")
+
+	customHandler := func(ctx context.Context, input string, caps *vnext.Capabilities) (string, error) {
+		// Custom logic: check for specific keywords
+		if len(input) < 10 {
+			// For short queries, add context via LLM
+			return caps.LLM(
+				"You are a helpful assistant that expands short queries into detailed questions.",
+				fmt.Sprintf("Expand this query: %s", input),
+			)
+		}
+
+		// For longer queries, process normally
+		return caps.LLM("You are a helpful assistant.", input)
+	}
+
+	config7 := &vnext.Config{
+		Name:         "custom-agent",
+		SystemPrompt: "You are a helpful assistant.",
+		Timeout:      30 * time.Second,
+		LLM: vnext.LLMConfig{
+			Provider:    "openrouter",
+			Model:       "openai/gpt-3.5-turbo",
+			APIKey:      apiKey, // Pass the API key
+			Temperature: 0.7,
+			MaxTokens:   200,
+		},
+	}
+
+	customAgent, err := vnext.NewBuilder("custom-agent").
+		WithConfig(config7).
+		WithHandler(customHandler).
+		Build()
+
+	if err != nil {
+		log.Fatalf("Failed to create custom agent: %v", err)
+	}
+
+	if err := customAgent.Initialize(ctx); err != nil {
+		log.Fatalf("Failed to initialize custom agent: %v", err)
+	}
+	defer customAgent.Cleanup(ctx)
+
+	// Test with short input
+	shortResult, err := customAgent.Run(ctx, "AI?")
+	if err != nil {
+		log.Printf("Short query failed: %v", err)
+	} else {
+		fmt.Printf("Short Query Response: %s\n", shortResult.Content)
+	}
+
+	// Example 8: Using Preset with Custom Prompt
+	fmt.Println("\nExample 8: Using Preset with Custom Prompt")
+	fmt.Println("===========================================")
+
+	// Create config for a simple agent
+	config8 := &vnext.Config{
+		Name:         "simple-agent",
+		SystemPrompt: "You are a helpful assistant specialized in programming languages.",
+		Timeout:      30 * time.Second,
+		LLM: vnext.LLMConfig{
+			Provider:    "openrouter",
+			Model:       "openai/gpt-3.5-turbo",
+			APIKey:      apiKey, // Pass the API key
+			Temperature: 0.7,
+			MaxTokens:   200,
+		},
+	}
+
+	agent8, err := vnext.NewBuilder("simple-agent").
+		WithConfig(config8).
+		Build()
+
+	if err != nil {
+		log.Printf("Failed to create agent8: %v", err)
+	} else if err := agent8.Initialize(ctx); err != nil {
+		log.Printf("Failed to initialize agent8: %v", err)
+	} else {
+		defer agent8.Cleanup(ctx)
+		result, err := agent8.Run(ctx, "What is Go programming language?")
+		if err != nil {
+			log.Printf("Run failed: %v", err)
+		} else {
+			fmt.Printf("Response: %s\n", result.Content)
+			fmt.Printf("Duration: %v\n", result.Duration)
+		}
+	}
+
+	fmt.Println("\n===========================================")
+	fmt.Println("  OpenRouter vNext examples completed!")
+	fmt.Println("===========================================")
+}

--- a/internal/llm/openrouter_adapter_test.go
+++ b/internal/llm/openrouter_adapter_test.go
@@ -1,0 +1,442 @@
+package llm
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestNewOpenRouterAdapter(t *testing.T) {
+	tests := []struct {
+		name        string
+		apiKey      string
+		model       string
+		baseURL     string
+		maxTokens   int
+		temperature float32
+		siteURL     string
+		siteName    string
+		wantErr     bool
+		errContains string
+	}{
+		{
+			name:        "valid configuration",
+			apiKey:      "test-key",
+			model:       "openai/gpt-3.5-turbo",
+			baseURL:     "https://openrouter.ai/api/v1",
+			maxTokens:   2000,
+			temperature: 0.7,
+			siteURL:     "https://myapp.com",
+			siteName:    "My App",
+			wantErr:     false,
+		},
+		{
+			name:        "missing api key",
+			apiKey:      "",
+			model:       "openai/gpt-3.5-turbo",
+			baseURL:     "https://openrouter.ai/api/v1",
+			maxTokens:   2000,
+			temperature: 0.7,
+			wantErr:     true,
+			errContains: "API key cannot be empty",
+		},
+		{
+			name:        "defaults applied",
+			apiKey:      "test-key",
+			model:       "",
+			baseURL:     "",
+			maxTokens:   0,
+			temperature: 0,
+			wantErr:     false,
+		},
+		{
+			name:        "optional site fields empty",
+			apiKey:      "test-key",
+			model:       "anthropic/claude-3-sonnet",
+			baseURL:     "https://openrouter.ai/api/v1",
+			maxTokens:   1500,
+			temperature: 0.5,
+			siteURL:     "",
+			siteName:    "",
+			wantErr:     false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			adapter, err := NewOpenRouterAdapter(
+				tt.apiKey,
+				tt.model,
+				tt.baseURL,
+				tt.maxTokens,
+				tt.temperature,
+				tt.siteURL,
+				tt.siteName,
+			)
+
+			if tt.wantErr {
+				if err == nil {
+					t.Errorf("NewOpenRouterAdapter() expected error but got nil")
+					return
+				}
+				if tt.errContains != "" && !strings.Contains(err.Error(), tt.errContains) {
+					t.Errorf("NewOpenRouterAdapter() error = %v, should contain %v", err, tt.errContains)
+				}
+				return
+			}
+
+			if err != nil {
+				t.Errorf("NewOpenRouterAdapter() unexpected error = %v", err)
+				return
+			}
+
+			if adapter == nil {
+				t.Error("NewOpenRouterAdapter() returned nil adapter")
+				return
+			}
+
+			// Verify defaults were applied
+			if tt.model == "" && adapter.model != "openai/gpt-3.5-turbo" {
+				t.Errorf("Expected default model 'openai/gpt-3.5-turbo', got %v", adapter.model)
+			}
+			if tt.baseURL == "" && adapter.baseURL != "https://openrouter.ai/api/v1" {
+				t.Errorf("Expected default baseURL 'https://openrouter.ai/api/v1', got %v", adapter.baseURL)
+			}
+			if tt.maxTokens == 0 && adapter.maxTokens != 2000 {
+				t.Errorf("Expected default maxTokens 2000, got %v", adapter.maxTokens)
+			}
+			if tt.temperature == 0 && adapter.temperature != 0.7 {
+				t.Errorf("Expected default temperature 0.7, got %v", adapter.temperature)
+			}
+		})
+	}
+}
+
+func TestOpenRouterAdapter_Call(t *testing.T) {
+	apiKey := os.Getenv("OPENROUTER_API_KEY")
+	if apiKey == "" {
+		t.Skip("OPENROUTER_API_KEY not set, skipping integration test")
+	}
+
+	adapter, err := NewOpenRouterAdapter(
+		apiKey,
+		"openai/gpt-3.5-turbo",
+		"https://openrouter.ai/api/v1",
+		150,
+		0.7,
+		"https://github.com/kunalkushwaha/agenticgokit",
+		"AgenticGoKit",
+	)
+	if err != nil {
+		t.Fatalf("Failed to create adapter: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	resp, err := adapter.Call(ctx, Prompt{
+		System: "You are a helpful assistant.",
+		User:   "Say 'Hello, World!' and nothing else.",
+	})
+
+	if err != nil {
+		t.Fatalf("Call failed: %v", err)
+	}
+
+	if resp.Content == "" {
+		t.Error("Expected non-empty response content")
+	}
+
+	if resp.Usage.TotalTokens == 0 {
+		t.Error("Expected non-zero token usage")
+	}
+
+	t.Logf("Response: %s", resp.Content)
+	t.Logf("Tokens: %d prompt, %d completion, %d total",
+		resp.Usage.PromptTokens,
+		resp.Usage.CompletionTokens,
+		resp.Usage.TotalTokens)
+}
+
+func TestOpenRouterAdapter_Call_WithParameters(t *testing.T) {
+	apiKey := os.Getenv("OPENROUTER_API_KEY")
+	if apiKey == "" {
+		t.Skip("OPENROUTER_API_KEY not set, skipping integration test")
+	}
+
+	adapter, err := NewOpenRouterAdapter(
+		apiKey,
+		"openai/gpt-3.5-turbo",
+		"https://openrouter.ai/api/v1",
+		150,
+		0.7,
+		"",
+		"",
+	)
+	if err != nil {
+		t.Fatalf("Failed to create adapter: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// Override parameters
+	maxTokens := int32(50)
+	temperature := float32(0.3)
+
+	resp, err := adapter.Call(ctx, Prompt{
+		User: "Count from 1 to 3.",
+		Parameters: ModelParameters{
+			MaxTokens:   &maxTokens,
+			Temperature: &temperature,
+		},
+	})
+
+	if err != nil {
+		t.Fatalf("Call with parameters failed: %v", err)
+	}
+
+	if resp.Content == "" {
+		t.Error("Expected non-empty response content")
+	}
+
+	t.Logf("Response with params: %s", resp.Content)
+}
+
+func TestOpenRouterAdapter_Stream(t *testing.T) {
+	apiKey := os.Getenv("OPENROUTER_API_KEY")
+	if apiKey == "" {
+		t.Skip("OPENROUTER_API_KEY not set, skipping integration test")
+	}
+
+	adapter, err := NewOpenRouterAdapter(
+		apiKey,
+		"openai/gpt-3.5-turbo",
+		"https://openrouter.ai/api/v1",
+		150,
+		0.7,
+		"",
+		"",
+	)
+	if err != nil {
+		t.Fatalf("Failed to create adapter: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	tokenChan, err := adapter.Stream(ctx, Prompt{
+		User: "Count from 1 to 5.",
+	})
+
+	if err != nil {
+		t.Fatalf("Stream failed: %v", err)
+	}
+
+	var tokens []string
+	for token := range tokenChan {
+		if token.Error != nil {
+			t.Fatalf("Stream error: %v", token.Error)
+		}
+		tokens = append(tokens, token.Content)
+	}
+
+	if len(tokens) == 0 {
+		t.Error("Expected at least one token")
+	}
+
+	fullResponse := strings.Join(tokens, "")
+	t.Logf("Streamed response (%d tokens): %s", len(tokens), fullResponse)
+}
+
+func TestOpenRouterAdapter_Stream_ContextCancellation(t *testing.T) {
+	apiKey := os.Getenv("OPENROUTER_API_KEY")
+	if apiKey == "" {
+		t.Skip("OPENROUTER_API_KEY not set, skipping integration test")
+	}
+
+	adapter, err := NewOpenRouterAdapter(
+		apiKey,
+		"openai/gpt-3.5-turbo",
+		"https://openrouter.ai/api/v1",
+		1000,
+		0.7,
+		"",
+		"",
+	)
+	if err != nil {
+		t.Fatalf("Failed to create adapter: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	tokenChan, err := adapter.Stream(ctx, Prompt{
+		User: "Write a long story about a robot.",
+	})
+
+	if err != nil {
+		t.Fatalf("Stream failed: %v", err)
+	}
+
+	// Cancel after receiving first few tokens
+	tokenCount := 0
+	for token := range tokenChan {
+		if token.Error != nil {
+			// Expected to get context cancellation error
+			if ctx.Err() != context.Canceled {
+				t.Errorf("Expected context.Canceled error, got: %v", token.Error)
+			}
+			return
+		}
+		tokenCount++
+		if tokenCount >= 3 {
+			cancel()
+		}
+	}
+
+	if tokenCount < 3 {
+		t.Logf("Received %d tokens before cancellation", tokenCount)
+	}
+}
+
+func TestOpenRouterAdapter_Embeddings(t *testing.T) {
+	apiKey := os.Getenv("OPENROUTER_API_KEY")
+	if apiKey == "" {
+		t.Skip("OPENROUTER_API_KEY not set, skipping integration test")
+	}
+
+	adapter, err := NewOpenRouterAdapter(
+		apiKey,
+		"openai/gpt-3.5-turbo",
+		"https://openrouter.ai/api/v1",
+		150,
+		0.7,
+		"",
+		"",
+	)
+	if err != nil {
+		t.Fatalf("Failed to create adapter: %v", err)
+	}
+
+	ctx := context.Background()
+
+	_, err = adapter.Embeddings(ctx, []string{"test"})
+
+	// Embeddings should return an error indicating not supported
+	if err == nil {
+		t.Error("Expected Embeddings to return error (not supported)")
+	}
+
+	if !strings.Contains(err.Error(), "not currently supported") {
+		t.Errorf("Expected 'not supported' error, got: %v", err)
+	}
+}
+
+func TestOpenRouterAdapter_CallWithEmptyPrompt(t *testing.T) {
+	adapter, err := NewOpenRouterAdapter(
+		"test-key",
+		"openai/gpt-3.5-turbo",
+		"https://openrouter.ai/api/v1",
+		150,
+		0.7,
+		"",
+		"",
+	)
+	if err != nil {
+		t.Fatalf("Failed to create adapter: %v", err)
+	}
+
+	ctx := context.Background()
+
+	_, err = adapter.Call(ctx, Prompt{
+		System: "You are helpful",
+		User:   "", // Empty user prompt
+	})
+
+	if err == nil {
+		t.Error("Expected error for empty user prompt")
+	}
+
+	if !strings.Contains(err.Error(), "cannot be empty") {
+		t.Errorf("Expected 'cannot be empty' error, got: %v", err)
+	}
+}
+
+func TestBuildOpenRouterMessages(t *testing.T) {
+	tests := []struct {
+		name      string
+		prompt    Prompt
+		wantLen   int
+		hasUser   bool
+		hasSystem bool
+	}{
+		{
+			name: "both system and user",
+			prompt: Prompt{
+				System: "You are helpful",
+				User:   "Hello",
+			},
+			wantLen:   2,
+			hasUser:   true,
+			hasSystem: true,
+		},
+		{
+			name: "user only",
+			prompt: Prompt{
+				User: "Hello",
+			},
+			wantLen:   1,
+			hasUser:   true,
+			hasSystem: false,
+		},
+		{
+			name: "system only",
+			prompt: Prompt{
+				System: "You are helpful",
+			},
+			wantLen:   1,
+			hasUser:   false,
+			hasSystem: true,
+		},
+		{
+			name:      "empty prompt",
+			prompt:    Prompt{},
+			wantLen:   0,
+			hasUser:   false,
+			hasSystem: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			messages := buildOpenRouterMessages(tt.prompt)
+
+			if len(messages) != tt.wantLen {
+				t.Errorf("Expected %d messages, got %d", tt.wantLen, len(messages))
+			}
+
+			hasSystem := false
+			hasUser := false
+			for _, msg := range messages {
+				if role, ok := msg["role"].(string); ok {
+					if role == "system" {
+						hasSystem = true
+					}
+					if role == "user" {
+						hasUser = true
+					}
+				}
+			}
+
+			if hasSystem != tt.hasSystem {
+				t.Errorf("Expected hasSystem=%v, got %v", tt.hasSystem, hasSystem)
+			}
+			if hasUser != tt.hasUser {
+				t.Errorf("Expected hasUser=%v, got %v", tt.hasUser, hasUser)
+			}
+		})
+	}
+}

--- a/internal/llm/wrappers.go
+++ b/internal/llm/wrappers.go
@@ -166,6 +166,10 @@ type PublicLLMProviderConfig struct {
 	// Ollama-specific fields
 	BaseURL string `json:"base_url,omitempty" toml:"base_url,omitempty"`
 
+	// OpenRouter-specific fields
+	SiteURL  string `json:"site_url,omitempty" toml:"site_url,omitempty"`
+	SiteName string `json:"site_name,omitempty" toml:"site_name,omitempty"`
+
 	// HTTP client configuration
 	HTTPTimeout time.Duration `json:"http_timeout,omitempty" toml:"http_timeout,omitempty"`
 }
@@ -210,6 +214,28 @@ func NewOllamaAdapterWrapped(baseURL, model string, maxTokens int, temperature f
 	return NewModelProviderWrapper(adapter), nil
 }
 
+func NewOpenRouterAdapterWrapped(
+	apiKey, model, baseURL string,
+	maxTokens int,
+	temperature float32,
+	siteURL, siteName string,
+) (PublicModelProvider, error) {
+	adapter, err := NewOpenRouterAdapter(
+		apiKey,
+		model,
+		baseURL,
+		maxTokens,
+		temperature,
+		siteURL,
+		siteName,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return NewModelProviderWrapper(adapter), nil
+}
+
 func NewModelProviderFromConfigWrapped(config PublicLLMProviderConfig) (PublicModelProvider, error) {
 	internalConfig := ProviderConfig{
 		Type:                ProviderType(config.Type),
@@ -221,6 +247,8 @@ func NewModelProviderFromConfigWrapped(config PublicLLMProviderConfig) (PublicMo
 		ChatDeployment:      config.ChatDeployment,
 		EmbeddingDeployment: config.EmbeddingDeployment,
 		BaseURL:             config.BaseURL,
+		SiteURL:             config.SiteURL,
+		SiteName:            config.SiteName,
 		HTTPTimeout:         config.HTTPTimeout,
 	}
 

--- a/plugins/llm/openrouter/README.md
+++ b/plugins/llm/openrouter/README.md
@@ -1,0 +1,300 @@
+# OpenRouter LLM Driver for AgenticGoKit
+
+This package provides OpenRouter integration for AgenticGoKit, enabling access to multiple AI models from various providers through a unified OpenAI-compatible API.
+
+## Features
+
+- **Multi-Provider Access**: Access models from OpenAI, Anthropic, Google, Meta, and many others
+- **OpenAI-Compatible API**: Easy migration from OpenAI-based implementations
+- **Streaming Support**: Full support for streaming responses (SSE)
+- **Site Tracking**: Optional headers for OpenRouter rankings and analytics
+- **Model Routing**: Automatic model selection and fallback support
+- **Cost Optimization**: Access to cost-efficient model alternatives
+
+## Installation
+
+```bash
+go get github.com/kunalkushwaha/agenticgokit
+```
+
+## Quick Start
+
+### Basic Usage
+
+```go
+package main
+
+import (
+    "context"
+    "fmt"
+    "log"
+
+    "github.com/kunalkushwaha/agenticgokit/core"
+    _ "github.com/kunalkushwaha/agenticgokit/plugins/llm/openrouter"
+)
+
+func main() {
+    config := core.LLMProviderConfig{
+        Type:        "openrouter",
+        APIKey:      "sk-or-v1-...",
+        Model:       "openai/gpt-3.5-turbo",
+        MaxTokens:   500,
+        Temperature: 0.7,
+    }
+
+    provider, err := core.NewModelProviderFromConfig(config)
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    ctx := context.Background()
+    response, err := provider.Call(ctx, core.Prompt{
+        System: "You are a helpful assistant.",
+        User:   "What is OpenRouter?",
+    })
+
+    if err != nil {
+        log.Fatal(err)
+    }
+
+    fmt.Println(response.Content)
+}
+```
+
+### Using Environment Variables
+
+Set the `OPENROUTER_API_KEY` environment variable:
+
+```bash
+export OPENROUTER_API_KEY=sk-or-v1-...
+```
+
+Then use `AgentLLMConfig`:
+
+```go
+config := core.AgentLLMConfig{
+    Provider:    "openrouter",
+    Model:       "anthropic/claude-3-sonnet",
+    MaxTokens:   2000,
+    Temperature: 0.7,
+}
+
+provider, err := core.NewLLMProvider(config)
+```
+
+### Streaming Responses
+
+```go
+tokenChan, err := provider.Stream(ctx, core.Prompt{
+    User: "Tell me a story.",
+})
+
+if err != nil {
+    log.Fatal(err)
+}
+
+for token := range tokenChan {
+    if token.Error != nil {
+        log.Fatal(token.Error)
+    }
+    fmt.Print(token.Content)
+}
+```
+
+## Configuration
+
+### Configuration Options
+
+| Field | Type | Description | Default |
+|-------|------|-------------|---------|
+| `Type` | string | Provider type (must be "openrouter") | Required |
+| `APIKey` | string | OpenRouter API key | Required (or env var) |
+| `Model` | string | Model identifier (e.g., "openai/gpt-4") | "openai/gpt-3.5-turbo" |
+| `MaxTokens` | int | Maximum tokens to generate | 2000 |
+| `Temperature` | float64 | Sampling temperature (0.0-2.0) | 0.7 |
+| `BaseURL` | string | API base URL | "https://openrouter.ai/api/v1" |
+| `SiteURL` | string | Your site URL (for rankings) | Optional |
+| `SiteName` | string | Your site name (for rankings) | Optional |
+
+### Environment Variables
+
+- `OPENROUTER_API_KEY` - Your OpenRouter API key
+- `OPENROUTER_BASE_URL` - Custom API base URL (optional)
+- `OPENROUTER_SITE_URL` - Site URL for tracking (optional)
+- `OPENROUTER_SITE_NAME` - Site name for tracking (optional)
+
+## Available Models
+
+OpenRouter provides access to numerous models across providers:
+
+### OpenAI Models
+- `openai/gpt-4`
+- `openai/gpt-4-turbo`
+- `openai/gpt-3.5-turbo`
+
+### Anthropic Models
+- `anthropic/claude-3-opus`
+- `anthropic/claude-3-sonnet`
+- `anthropic/claude-3-haiku`
+
+### Google Models
+- `google/gemini-pro`
+- `google/gemini-pro-vision`
+
+### Meta Models
+- `meta-llama/llama-3-70b-instruct`
+- `meta-llama/llama-3-8b-instruct`
+
+### And Many More!
+Visit [OpenRouter Models](https://openrouter.ai/models) for the full list.
+
+## Advanced Usage
+
+### Site Tracking
+
+Enable site tracking to appear on OpenRouter rankings:
+
+```go
+config := core.LLMProviderConfig{
+    Type:        "openrouter",
+    APIKey:      "sk-or-v1-...",
+    Model:       "anthropic/claude-3-sonnet",
+    SiteURL:     "https://myapp.com",
+    SiteName:    "My Awesome App",
+}
+```
+
+This sets the `HTTP-Referer` and `X-Title` headers for proper attribution.
+
+### Parameter Overrides
+
+Override default parameters per request:
+
+```go
+maxTokens := int32(100)
+temperature := float32(0.3)
+
+response, err := provider.Call(ctx, core.Prompt{
+    User: "Brief answer please.",
+    Parameters: core.ModelParameters{
+        MaxTokens:   &maxTokens,
+        Temperature: &temperature,
+    },
+})
+```
+
+### Multiple Models
+
+Easily switch between models:
+
+```go
+models := []string{
+    "openai/gpt-4",
+    "anthropic/claude-3-sonnet",
+    "google/gemini-pro",
+}
+
+for _, model := range models {
+    config.Model = model
+    provider, _ := core.NewModelProviderFromConfig(config)
+    response, _ := provider.Call(ctx, prompt)
+    fmt.Printf("%s: %s\n", model, response.Content)
+}
+```
+
+## Error Handling
+
+The adapter provides detailed error messages:
+
+```go
+response, err := provider.Call(ctx, prompt)
+if err != nil {
+    if strings.Contains(err.Error(), "API key") {
+        log.Fatal("Invalid API key")
+    } else if strings.Contains(err.Error(), "rate limit") {
+        log.Fatal("Rate limit exceeded")
+    } else {
+        log.Fatalf("API error: %v", err)
+    }
+}
+```
+
+## Testing
+
+Run unit tests:
+
+```bash
+go test ./internal/llm/openrouter_adapter_test.go
+```
+
+Run integration tests (requires API key):
+
+```bash
+export OPENROUTER_API_KEY=sk-or-v1-...
+go test ./plugins/llm/openrouter/...
+```
+
+## Limitations
+
+- **Embeddings**: Not currently supported by this adapter. Use a dedicated embedding provider.
+- **Function Calling**: Not yet implemented (planned for future release).
+- **Vision Models**: Supported by OpenRouter but requires additional image handling (coming soon).
+
+## Cost Management
+
+OpenRouter provides competitive pricing across models. Check the [OpenRouter Pricing](https://openrouter.ai/docs#models) page for current rates.
+
+Tips:
+- Use cheaper models for simple tasks (e.g., `openai/gpt-3.5-turbo`)
+- Use more powerful models for complex reasoning (e.g., `anthropic/claude-3-opus`)
+- Monitor usage through OpenRouter dashboard
+
+## Troubleshooting
+
+### Invalid API Key
+
+```
+Error: OpenRouter API error [invalid_api_key]: Invalid API key provided
+```
+
+**Solution**: Check your API key or set `OPENROUTER_API_KEY` environment variable.
+
+### Model Not Found
+
+```
+Error: OpenRouter API error [model_not_found]: Model not found
+```
+
+**Solution**: Verify model name at [OpenRouter Models](https://openrouter.ai/models).
+
+### Rate Limit Exceeded
+
+```
+Error: OpenRouter API error [rate_limit_exceeded]: Rate limit exceeded
+```
+
+**Solution**: Implement retry logic with exponential backoff or upgrade your plan.
+
+## Examples
+
+See the [examples/openrouter_usage](../../examples/openrouter_usage/) directory for complete examples.
+
+## Contributing
+
+Contributions are welcome! Please see the [Contributing Guide](../../../docs/contributors/ContributorGuide.md).
+
+## License
+
+This project is licensed under the same license as AgenticGoKit. See [LICENSE](../../../LICENSE) for details.
+
+## Resources
+
+- [OpenRouter Documentation](https://openrouter.ai/docs)
+- [OpenRouter Models](https://openrouter.ai/models)
+- [OpenRouter API](https://openrouter.ai/docs#api)
+- [AgenticGoKit Documentation](../../../docs/)
+
+## Support
+
+- GitHub Issues: [agenticgokit/agenticgokit](https://github.com/kunalkushwaha/agenticgokit/issues)
+- OpenRouter Discord: [Join Here](https://discord.gg/openrouter)

--- a/plugins/llm/openrouter/openrouter.go
+++ b/plugins/llm/openrouter/openrouter.go
@@ -1,0 +1,95 @@
+package openrouter
+
+import (
+	"context"
+
+	"github.com/kunalkushwaha/agenticgokit/core"
+	"github.com/kunalkushwaha/agenticgokit/internal/llm"
+)
+
+// providerAdapter adapts internal llm.PublicProviderAdapter to core.ModelProvider
+type providerAdapter struct {
+	adapter *llm.PublicProviderAdapter
+}
+
+func (a *providerAdapter) Call(ctx context.Context, prompt core.Prompt) (core.Response, error) {
+	internalPrompt := llm.PublicPrompt{
+		System: prompt.System,
+		User:   prompt.User,
+		Parameters: llm.PublicModelParameters{
+			Temperature: prompt.Parameters.Temperature,
+			MaxTokens:   prompt.Parameters.MaxTokens,
+		},
+	}
+
+	resp, err := a.adapter.Call(ctx, internalPrompt)
+	if err != nil {
+		return core.Response{}, err
+	}
+
+	return core.Response{
+		Content: resp.Content,
+		Usage: core.UsageStats{
+			PromptTokens:     resp.Usage.PromptTokens,
+			CompletionTokens: resp.Usage.CompletionTokens,
+			TotalTokens:      resp.Usage.TotalTokens,
+		},
+		FinishReason: resp.FinishReason,
+	}, nil
+}
+
+func (a *providerAdapter) Stream(ctx context.Context, prompt core.Prompt) (<-chan core.Token, error) {
+	internalPrompt := llm.PublicPrompt{
+		System: prompt.System,
+		User:   prompt.User,
+		Parameters: llm.PublicModelParameters{
+			Temperature: prompt.Parameters.Temperature,
+			MaxTokens:   prompt.Parameters.MaxTokens,
+		},
+	}
+
+	internalChan, err := a.adapter.Stream(ctx, internalPrompt)
+	if err != nil {
+		return nil, err
+	}
+
+	publicChan := make(chan core.Token)
+	go func() {
+		defer close(publicChan)
+		for token := range internalChan {
+			publicChan <- core.Token{Content: token.Content, Error: token.Error}
+		}
+	}()
+
+	return publicChan, nil
+}
+
+func (a *providerAdapter) Embeddings(ctx context.Context, texts []string) ([][]float64, error) {
+	return a.adapter.Embeddings(ctx, texts)
+}
+
+func factory(cfg core.LLMProviderConfig) (core.ModelProvider, error) {
+	baseURL := cfg.BaseURL
+	if baseURL == "" {
+		baseURL = "https://openrouter.ai/api/v1"
+	}
+
+	wrapper, err := llm.NewOpenRouterAdapterWrapped(
+		cfg.APIKey,
+		cfg.Model,
+		baseURL,
+		cfg.MaxTokens,
+		float32(cfg.Temperature),
+		cfg.SiteURL,
+		cfg.SiteName,
+	)
+	if err != nil {
+		return nil, err
+	}
+
+	return &providerAdapter{adapter: llm.NewPublicProviderAdapter(wrapper)}, nil
+}
+
+func init() {
+	core.RegisterModelProviderFactory("openrouter", factory)
+}

--- a/plugins/llm/openrouter/openrouter_test.go
+++ b/plugins/llm/openrouter/openrouter_test.go
@@ -1,0 +1,322 @@
+package openrouter
+
+import (
+	"context"
+	"os"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/kunalkushwaha/agenticgokit/core"
+)
+
+func TestPluginRegistration(t *testing.T) {
+	// Test that the plugin is registered correctly
+	config := core.LLMProviderConfig{
+		Type:   "openrouter",
+		APIKey: "test-key",
+		Model:  "openai/gpt-3.5-turbo",
+	}
+
+	provider, err := core.NewModelProviderFromConfig(config)
+
+	// Should not error about unregistered provider
+	// May error about invalid API key or network issues (expected in unit test)
+	if err != nil {
+		if strings.Contains(err.Error(), "not registered") {
+			t.Error("Plugin not registered correctly")
+		}
+		// Other errors are acceptable in unit tests without real API key
+		t.Logf("Expected error (no real API call): %v", err)
+	}
+
+	if provider != nil {
+		t.Log("Provider created successfully")
+	}
+}
+
+func TestFactoryWithConfig(t *testing.T) {
+	tests := []struct {
+		name    string
+		config  core.LLMProviderConfig
+		wantErr bool
+	}{
+		{
+			name: "valid config",
+			config: core.LLMProviderConfig{
+				Type:        "openrouter",
+				APIKey:      "test-key",
+				Model:       "anthropic/claude-3-sonnet",
+				MaxTokens:   2000,
+				Temperature: 0.7,
+			},
+			wantErr: false,
+		},
+		{
+			name: "with site tracking",
+			config: core.LLMProviderConfig{
+				Type:        "openrouter",
+				APIKey:      "test-key",
+				Model:       "openai/gpt-4",
+				SiteURL:     "https://myapp.com",
+				SiteName:    "My App",
+				MaxTokens:   1500,
+				Temperature: 0.5,
+			},
+			wantErr: false,
+		},
+		{
+			name: "default base url",
+			config: core.LLMProviderConfig{
+				Type:   "openrouter",
+				APIKey: "test-key",
+				Model:  "google/gemini-pro",
+			},
+			wantErr: false,
+		},
+		{
+			name: "custom base url",
+			config: core.LLMProviderConfig{
+				Type:    "openrouter",
+				APIKey:  "test-key",
+				Model:   "meta-llama/llama-3-70b-instruct",
+				BaseURL: "https://custom.openrouter.ai/api/v1",
+			},
+			wantErr: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			provider, err := core.NewModelProviderFromConfig(tt.config)
+
+			if tt.wantErr && err == nil {
+				t.Error("Expected error but got nil")
+			}
+
+			if !tt.wantErr && err != nil {
+				// Should not error during provider creation
+				// (actual API calls will fail without valid key)
+				t.Logf("Provider created, errors during use expected without valid API key: %v", err)
+			}
+
+			if provider != nil {
+				t.Log("Provider instance created")
+			}
+		})
+	}
+}
+
+func TestOpenRouterIntegration(t *testing.T) {
+	apiKey := os.Getenv("OPENROUTER_API_KEY")
+	if apiKey == "" {
+		t.Skip("OPENROUTER_API_KEY not set, skipping integration test")
+	}
+
+	config := core.LLMProviderConfig{
+		Type:        "openrouter",
+		APIKey:      apiKey,
+		Model:       "openai/gpt-3.5-turbo",
+		MaxTokens:   150,
+		Temperature: 0.7,
+		SiteURL:     "https://github.com/kunalkushwaha/agenticgokit",
+		SiteName:    "AgenticGoKit Tests",
+	}
+
+	provider, err := core.NewModelProviderFromConfig(config)
+	if err != nil {
+		t.Fatalf("Failed to create provider: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// Test Call
+	t.Run("Call", func(t *testing.T) {
+		response, err := provider.Call(ctx, core.Prompt{
+			System: "You are a helpful assistant.",
+			User:   "Say hello!",
+		})
+
+		if err != nil {
+			t.Fatalf("Call failed: %v", err)
+		}
+
+		if response.Content == "" {
+			t.Error("Expected non-empty response")
+		}
+
+		t.Logf("Response: %s", response.Content)
+		t.Logf("Tokens: %d prompt, %d completion, %d total",
+			response.Usage.PromptTokens,
+			response.Usage.CompletionTokens,
+			response.Usage.TotalTokens)
+	})
+
+	// Test Stream
+	t.Run("Stream", func(t *testing.T) {
+		tokenChan, err := provider.Stream(ctx, core.Prompt{
+			User: "Count from 1 to 3.",
+		})
+
+		if err != nil {
+			t.Fatalf("Stream failed: %v", err)
+		}
+
+		var tokens []string
+		for token := range tokenChan {
+			if token.Error != nil {
+				t.Fatalf("Stream error: %v", token.Error)
+			}
+			tokens = append(tokens, token.Content)
+		}
+
+		if len(tokens) == 0 {
+			t.Error("Expected at least one token")
+		}
+
+		fullResponse := strings.Join(tokens, "")
+		t.Logf("Streamed response: %s", fullResponse)
+	})
+}
+
+func TestProviderAdapter(t *testing.T) {
+	// Test the adapter type conversions work
+	// We can't create a full adapter without real dependencies,
+	// but we can verify the type implements the interface
+	var _ core.ModelProvider = (*providerAdapter)(nil)
+	t.Log("providerAdapter correctly implements core.ModelProvider interface")
+}
+
+func TestMultipleModels(t *testing.T) {
+	apiKey := os.Getenv("OPENROUTER_API_KEY")
+	if apiKey == "" {
+		t.Skip("OPENROUTER_API_KEY not set, skipping integration test")
+	}
+
+	models := []string{
+		"openai/gpt-3.5-turbo",
+		"anthropic/claude-3-haiku",
+		"google/gemini-pro",
+	}
+
+	for _, model := range models {
+		t.Run(model, func(t *testing.T) {
+			config := core.LLMProviderConfig{
+				Type:        "openrouter",
+				APIKey:      apiKey,
+				Model:       model,
+				MaxTokens:   50,
+				Temperature: 0.7,
+			}
+
+			provider, err := core.NewModelProviderFromConfig(config)
+			if err != nil {
+				t.Fatalf("Failed to create provider for %s: %v", model, err)
+			}
+
+			ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+			defer cancel()
+
+			response, err := provider.Call(ctx, core.Prompt{
+				User: "Say 'OK' and nothing else.",
+			})
+
+			if err != nil {
+				// Some models might not be available or might fail
+				t.Logf("Call to %s failed (may be unavailable): %v", model, err)
+				return
+			}
+
+			if response.Content == "" {
+				t.Errorf("Model %s returned empty response", model)
+			}
+
+			t.Logf("Model %s response: %s (tokens: %d)",
+				model, response.Content, response.Usage.TotalTokens)
+		})
+	}
+}
+
+func TestEnvironmentVariables(t *testing.T) {
+	// Test that environment variables are picked up correctly
+	apiKey := os.Getenv("OPENROUTER_API_KEY")
+	if apiKey == "" {
+		t.Skip("OPENROUTER_API_KEY not set, skipping test")
+	}
+
+	// Test with AgentLLMConfig which uses NewLLMProvider
+	config := core.AgentLLMConfig{
+		Provider:    "openrouter",
+		Model:       "openai/gpt-3.5-turbo",
+		MaxTokens:   100,
+		Temperature: 0.7,
+	}
+
+	provider, err := core.NewLLMProvider(config)
+	if err != nil {
+		t.Fatalf("Failed to create provider from env: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	response, err := provider.Call(ctx, core.Prompt{
+		User: "Say hello!",
+	})
+
+	if err != nil {
+		t.Fatalf("Call failed: %v", err)
+	}
+
+	if response.Content == "" {
+		t.Error("Expected non-empty response")
+	}
+
+	t.Logf("Response from env config: %s", response.Content)
+}
+
+func TestParameterOverrides(t *testing.T) {
+	apiKey := os.Getenv("OPENROUTER_API_KEY")
+	if apiKey == "" {
+		t.Skip("OPENROUTER_API_KEY not set, skipping integration test")
+	}
+
+	config := core.LLMProviderConfig{
+		Type:        "openrouter",
+		APIKey:      apiKey,
+		Model:       "openai/gpt-3.5-turbo",
+		MaxTokens:   500, // Default
+		Temperature: 0.7, // Default
+	}
+
+	provider, err := core.NewModelProviderFromConfig(config)
+	if err != nil {
+		t.Fatalf("Failed to create provider: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
+
+	// Override with prompt parameters
+	maxTokens := int32(50)
+	temperature := float32(0.3)
+
+	response, err := provider.Call(ctx, core.Prompt{
+		User: "Count from 1 to 5.",
+		Parameters: core.ModelParameters{
+			MaxTokens:   &maxTokens,
+			Temperature: &temperature,
+		},
+	})
+
+	if err != nil {
+		t.Fatalf("Call with overrides failed: %v", err)
+	}
+
+	if response.Content == "" {
+		t.Error("Expected non-empty response")
+	}
+
+	t.Logf("Response with parameter overrides: %s", response.Content)
+}


### PR DESCRIPTION
This commit implements complete OpenRouter support for AgenticGoKit, including core integration, plugin registration, comprehensive tests, and examples for both core and vNext APIs.

**Core Implementation:**
- Add OpenRouterAdapter in internal/llm/openrouter_adapter.go
  - Implements Call(), Stream(), and Embeddings() methods
  - Supports OpenAI-compatible API with custom headers
  - Site tracking via HTTP-Referer and X-Title headers
  - Configurable base URL, model, temperature, and token limits
- Add OpenRouter provider factory in internal/llm/factory.go
  - ProviderTypeOpenRouter constant and createOpenRouterProvider()
- Add OpenRouter wrapper in internal/llm/wrappers.go
  - NewOpenRouterAdapterWrapped() for internal integration
- Add plugin registration in plugins/llm/openrouter/openrouter.go
  - Auto-registers via init() with core.RegisterModelProviderFactory

**Core API Extensions:**
- Add SiteURL and SiteName fields to core.LLMProviderConfig
  - Enables OpenRouter site tracking for rankings and analytics
- Add environment variable support in core.NewLLMProvider()
  - Auto-reads OPENROUTER_API_KEY, OPENROUTER_BASE_URL
  - Auto-reads OPENROUTER_SITE_URL, OPENROUTER_SITE_NAME

**vNext API Extensions:**
- Add SiteURL and SiteName fields to vnext.LLMConfig
  - Consistent with core API for OpenRouter site tracking

**Testing:**
- Add comprehensive unit tests in internal/llm/openrouter_adapter_test.go
  - 14 passing unit tests for adapter functionality
  - 5 integration tests (require OPENROUTER_API_KEY)
  - Tests for message building, error handling, and streaming
- Add plugin tests in plugins/llm/openrouter/openrouter_test.go
  - Validates plugin registration and factory integration

**Examples:**
- Add core API example in examples/openrouter_usage/main.go
  - 6 examples: basic usage, multiple models, streaming, AgentLLMConfig, site tracking, parameter overrides
  - Environment variable configuration with proper error handling
  - Current model IDs: gpt-3.5-turbo, claude-3-haiku, gemini-2.0-flash-exp, llama-3.1-8b

- Add vNext API example in examples/vnext/openrouter-quickstart/main.go
  - 8 comprehensive examples demonstrating vNext patterns
  - Basic config, preset agents, streaming, multiple models, RunOptions, site tracking, custom handlers, presets
  - Complete README.md with setup instructions and best practices
  - IMPLEMENTATION_SUMMARY.md with technical details

**Documentation:**
- Add design document in docs/design/OpenRouterIntegration.md
  - Architecture analysis and implementation phases
  - Integration patterns and usage examples
- Add plugin README in plugins/llm/openrouter/README.md
  - Features, configuration, and usage instructions
- Add OPENROUTER_IMPLEMENTATION_SUMMARY.md
  - Complete implementation checklist and verification

**Key Features:**
- Full OpenAI-compatible API support via OpenRouter
- Access to 100+ models from multiple providers
- Streaming support with SSE
- Site tracking headers for OpenRouter rankings
- Environment variable configuration
- Comprehensive error handling and validation
- Works with both core and vNext APIs

**Models Tested:**
- OpenAI: gpt-3.5-turbo
- Anthropic: claude-3-haiku
- Google: gemini-2.0-flash-exp:free
- Meta: llama-3.1-8b-instruct

**Breaking Changes:** None
**Migration Required:** No - fully backward compatible

closes https://github.com/AgenticGoKit/AgenticGoKit/issues/43