### PR TITLE
auto-discover MCP tools during agent initialization

### DIFF
--- a/plugins/mcp/unified/unified.go
+++ b/plugins/mcp/unified/unified.go
@@ -3,6 +3,7 @@ package mcp_unified
 import (
 	"context"
 	"fmt"
+	"os"
 	"sync"
 	"time"
 
@@ -334,14 +335,24 @@ func (m *unifiedMCPManager) discoverToolsFromServer(ctx context.Context, serverN
 
 // createClientForServer creates appropriate client based on server type
 func (m *unifiedMCPManager) createClientForServer(server *core.MCPServerConfig) (*client.Client, error) {
-	builder := client.NewClientBuilder().
-		WithName("agentflow-mcp-client").
-		WithVersion("1.0.0").
-		WithTimeout(30 * time.Second)
+	newClient := func(tr transport.Transport) *client.Client {
+		cfg := client.ClientConfig{
+			Name:    "agentflow-mcp-client",
+			Version: "1.0.0",
+			Timeout: 30 * time.Second,
+		}
+
+		if v := os.Getenv("MCP_NAVIGATOR_DEBUG"); v != "" && v != "0" {
+			cfg.Debug = true
+		}
+
+		return client.NewClient(tr, cfg)
+	}
 
 	switch server.Type {
 	case "tcp":
-		return builder.WithTCPTransport(server.Host, server.Port).Build(), nil
+		tr := transport.NewTCPTransport(server.Host, server.Port)
+		return newClient(tr), nil
 
 	case "http_sse":
 		endpoint := server.Endpoint
@@ -352,9 +363,8 @@ func (m *unifiedMCPManager) createClientForServer(server *core.MCPServerConfig) 
 				return nil, fmt.Errorf("http_sse server %s requires either endpoint or host:port configuration", server.Name)
 			}
 		}
-		// Create SSE transport
 		sseTransport := transport.NewSSETransport(endpoint, "/sse")
-		return builder.WithTransport(sseTransport).Build(), nil
+		return newClient(sseTransport), nil
 
 	case "http_streaming":
 		endpoint := server.Endpoint
@@ -365,16 +375,17 @@ func (m *unifiedMCPManager) createClientForServer(server *core.MCPServerConfig) 
 				return nil, fmt.Errorf("http_streaming server %s requires either endpoint or host:port configuration", server.Name)
 			}
 		}
-		// Create Streaming HTTP transport
 		streamingTransport := transport.NewStreamingHTTPTransport(endpoint, "/stream")
-		return builder.WithTransport(streamingTransport).Build(), nil
+		return newClient(streamingTransport), nil
 
 	case "websocket":
 		url := fmt.Sprintf("ws://%s:%d", server.Host, server.Port)
-		return builder.WithWebSocketTransport(url).Build(), nil
+		tr := transport.NewWebSocketTransport(url)
+		return newClient(tr), nil
 
 	case "stdio":
-		return builder.WithSTDIOTransport(server.Command, []string{}).Build(), nil
+		tr := transport.NewStdioTransport(server.Command, []string{})
+		return newClient(tr), nil
 
 	default:
 		return nil, fmt.Errorf("unsupported transport type: %s", server.Type)
@@ -399,4 +410,3 @@ func init() {
 		return newUnifiedManager(cfg)
 	})
 }
-

--- a/v1beta/config.go
+++ b/v1beta/config.go
@@ -94,6 +94,7 @@ type ReasoningConfig struct {
 type MCPConfig struct {
 	Enabled           bool          `toml:"enabled"`
 	Discovery         bool          `toml:"discovery"`
+	AutoRefreshTools  bool          `toml:"auto_refresh_tools"` // Auto-refresh tools on initialization (default: true)
 	Servers           []MCPServer   `toml:"servers"`
 	Cache             *CacheConfig  `toml:"cache,omitempty"`
 	ConnectionTimeout time.Duration `toml:"connection_timeout"`

--- a/v1beta/provider_factory.go
+++ b/v1beta/provider_factory.go
@@ -169,7 +169,29 @@ func createTools(config *ToolsConfig) ([]Tool, error) {
 			// MCP initialization failure is not fatal - log and continue with internal tools
 			Logger().Warn().Err(err).Msg("Failed to initialize MCP, continuing without MCP tools")
 		} else {
-			Logger().Debug().Msg("MCP initialized successfully, discovering tools...")
+			Logger().Debug().Msg("MCP initialized successfully")
+
+			// Auto-refresh tools by default (batteries included)
+			// Set auto_refresh_tools=false in config to disable
+			autoRefresh := true // Default: batteries included
+			if config.MCP.AutoRefreshTools == false {
+				// Check if explicitly disabled in config
+				autoRefresh = false
+				Logger().Debug().Msg("AutoRefreshTools disabled in config")
+			}
+
+			if autoRefresh {
+				Logger().Debug().Msg("Auto-refreshing tools from MCP servers...")
+				if mgr := GetMCPManager(); mgr != nil {
+					ctx := context.Background()
+					if err := mgr.RefreshTools(ctx); err != nil {
+						Logger().Warn().Err(err).Msg("Auto-refresh failed, continuing with empty tools")
+					} else {
+						Logger().Debug().Msg("Auto-refresh completed successfully")
+					}
+				}
+			}
+
 			// Discover MCP tools
 			mcpTools, err := DiscoverMCPTools()
 			if err != nil {
@@ -178,7 +200,7 @@ func createTools(config *ToolsConfig) ([]Tool, error) {
 				allTools = append(allTools, mcpTools...)
 				Logger().Debug().Int("count", len(mcpTools)).Msg("Discovered MCP tools")
 			} else {
-				Logger().Warn().Msg("DiscoverMCPTools returned zero tools")
+				Logger().Warn().Msg("DiscoverMCPTools returned zero tools (check AutoRefreshTools config)")
 			}
 		}
 	}

--- a/v1beta/tools.go
+++ b/v1beta/tools.go
@@ -243,6 +243,7 @@ func DefaultMCPConfig() *MCPConfig {
 	return &MCPConfig{
 		Enabled:           true,
 		Discovery:         true,
+		AutoRefreshTools:  true, // Batteries included: auto-refresh by default
 		ConnectionTimeout: 30 * time.Second,
 		MaxRetries:        3,
 		RetryDelay:        1 * time.Second,


### PR DESCRIPTION
Implement AutoRefreshTools feature (default: true) to automatically discover and cache MCP tools when building agents. Eliminates need for manual RefreshTools() calls and improves developer experience.

- Add AutoRefreshTools config flag to MCPConfig
- Auto-refresh tools during agent.Build() when enabled
- Add MCP_NAVIGATOR_DEBUG env variable for optional logging
- Update DefaultMCPConfig() to enable auto-refresh by default

Fixes lazy loading confusion where tools weren't available until explicitly refreshed.