### PR TITLE
feat(v1beta): Add EvalServer and semantic evaluation support

### DIFF
--- a/core/llm.go
+++ b/core/llm.go
@@ -178,7 +178,7 @@ func NewOpenAIAdapter(apiKey, model string, maxTokens int, temperature float32) 
 
 // NewOllamaAdapter creates a new Ollama adapter
 func NewOllamaAdapter(baseURL, model string, maxTokens int, temperature float32) (ModelProvider, error) {
-	wrapper, err := llm.NewOllamaAdapterWrapped(baseURL, model, maxTokens, temperature)
+	wrapper, err := llm.NewOllamaAdapterWrapped(baseURL, model, maxTokens, temperature, 0) // 0 = use default timeout
 	if err != nil {
 		return nil, err
 	}

--- a/internal/llm/factory.go
+++ b/internal/llm/factory.go
@@ -224,7 +224,7 @@ func (f *ProviderFactory) createOllamaProvider(config ProviderConfig) (ModelProv
 		model = "llama3.2:latest" // Default model
 	}
 
-	return NewOllamaAdapter(baseURL, model, config.MaxTokens, config.Temperature)
+	return NewOllamaAdapter(baseURL, model, config.MaxTokens, config.Temperature, config.HTTPTimeout)
 }
 
 // createOpenRouterProvider creates an OpenRouter provider

--- a/internal/llm/ollama_adapter.go
+++ b/internal/llm/ollama_adapter.go
@@ -31,7 +31,7 @@ type OllamaAdapter struct {
 
 // NewOllamaAdapter creates a new OllamaAdapter instance.
 // baseURL should include scheme and host, e.g. http://localhost:11434
-func NewOllamaAdapter(baseURL, model string, maxTokens int, temperature float32) (*OllamaAdapter, error) {
+func NewOllamaAdapter(baseURL, model string, maxTokens int, temperature float32, httpTimeout time.Duration) (*OllamaAdapter, error) {
 	if baseURL == "" {
 		baseURL = "http://localhost:11434"
 	}
@@ -44,10 +44,13 @@ func NewOllamaAdapter(baseURL, model string, maxTokens int, temperature float32)
 	if temperature == 0 {
 		temperature = 0.7 // Default temperature
 	}
+	if httpTimeout == 0 {
+		httpTimeout = 120 * time.Second // Default timeout
+	}
 
 	// Reuse one HTTP client with keep-alive to avoid connection churn and model reload latency
 	// Use optimized transport configuration for best performance
-	client := NewOptimizedHTTPClient(120 * time.Second)
+	client := NewOptimizedHTTPClient(httpTimeout)
 
 	return &OllamaAdapter{
 		baseURL:        baseURL,

--- a/internal/llm/wrappers.go
+++ b/internal/llm/wrappers.go
@@ -251,8 +251,8 @@ func NewOpenAIAdapterWrapped(apiKey, model string, maxTokens int, temperature fl
 	return NewModelProviderWrapper(adapter), nil
 }
 
-func NewOllamaAdapterWrapped(baseURL, model string, maxTokens int, temperature float32) (PublicModelProvider, error) {
-	adapter, err := NewOllamaAdapter(baseURL, model, maxTokens, temperature)
+func NewOllamaAdapterWrapped(baseURL, model string, maxTokens int, temperature float32, httpTimeout time.Duration) (PublicModelProvider, error) {
+	adapter, err := NewOllamaAdapter(baseURL, model, maxTokens, temperature, httpTimeout)
 	if err != nil {
 		return nil, err
 	}

--- a/plugins/llm/ollama/ollama.go
+++ b/plugins/llm/ollama/ollama.go
@@ -65,7 +65,7 @@ func (a *providerAdapter) Embeddings(ctx context.Context, texts []string) ([][]f
 }
 
 func factory(cfg core.LLMProviderConfig) (core.ModelProvider, error) {
-	wrapper, err := llm.NewOllamaAdapterWrapped(cfg.BaseURL, cfg.Model, cfg.MaxTokens, float32(cfg.Temperature))
+	wrapper, err := llm.NewOllamaAdapterWrapped(cfg.BaseURL, cfg.Model, cfg.MaxTokens, float32(cfg.Temperature), cfg.HTTPTimeout)
 	if err != nil {
 		return nil, err
 	}

--- a/v1beta/config.go
+++ b/v1beta/config.go
@@ -37,14 +37,15 @@ type Config struct {
 
 // LLMConfig contains LLM provider configuration
 type LLMConfig struct {
-	Provider    string  `toml:"provider"`            // openai, ollama, azure, anthropic, openrouter
-	Model       string  `toml:"model"`               // Model name
-	Temperature float32 `toml:"temperature"`         // 0.0 to 2.0
-	MaxTokens   int     `toml:"max_tokens"`          // Maximum tokens to generate
-	BaseURL     string  `toml:"base_url,omitempty"`  // Custom base URL
-	APIKey      string  `toml:"api_key,omitempty"`   // API key (prefer env vars)
-	SiteURL     string  `toml:"site_url,omitempty"`  // OpenRouter: Site URL for rankings
-	SiteName    string  `toml:"site_name,omitempty"` // OpenRouter: Site name for analytics
+	Provider    string        `toml:"provider"`               // openai, ollama, azure, anthropic, openrouter
+	Model       string        `toml:"model"`                  // Model name
+	Temperature float32       `toml:"temperature"`            // 0.0 to 2.0
+	MaxTokens   int           `toml:"max_tokens"`             // Maximum tokens to generate
+	BaseURL     string        `toml:"base_url,omitempty"`     // Custom base URL
+	HTTPTimeout time.Duration `toml:"http_timeout,omitempty"` // HTTP client timeout for LLM requests
+	APIKey      string        `toml:"api_key,omitempty"`      // API key (prefer env vars)
+	SiteURL     string        `toml:"site_url,omitempty"`     // OpenRouter: Site URL for rankings
+	SiteName    string        `toml:"site_name,omitempty"`    // OpenRouter: Site name for analytics
 	// Azure specific fields
 	Endpoint            string `toml:"endpoint,omitempty"`
 	ChatDeployment      string `toml:"chat_deployment,omitempty"`
@@ -155,12 +156,31 @@ type LoopConditionFunc func(ctx context.Context, iteration int, lastResult *Work
 
 // WorkflowConfig contains workflow orchestration settings
 type WorkflowConfig struct {
-	Mode          WorkflowMode      `toml:"mode"`
-	Agents        []string          `toml:"agents"`
-	Timeout       time.Duration     `toml:"timeout"`
-	MaxIterations int               `toml:"max_iterations"`
-	Memory        *MemoryConfig     `toml:"memory,omitempty"`
-	LoopCondition LoopConditionFunc `toml:"-"` // Custom loop exit condition (not serializable)
+	Mode          WorkflowMode       `toml:"mode"`
+	Name          string             `toml:"name"`
+	Agents        []string           `toml:"agents"`
+	Timeout       time.Duration      `toml:"timeout"`
+	MaxIterations int                `toml:"max_iterations"`
+	Memory        *MemoryConfig      `toml:"memory,omitempty"`
+	LLM           *LLMConfig         `toml:"llm,omitempty"`        // Shared LLM config
+	AgentDefs     []WorkflowAgentDef `toml:"agent_defs,omitempty"` // Agent definitions
+	StepDefs      []WorkflowStepDef  `toml:"step_defs,omitempty"`  // Step definitions
+	LoopCondition LoopConditionFunc  `toml:"-"`                    // Custom loop exit condition (not serializable)
+}
+
+// WorkflowAgentDef defines an agent within a workflow
+type WorkflowAgentDef struct {
+	Name         string  `toml:"name"`
+	SystemPrompt string  `toml:"system_prompt"`
+	Temperature  float64 `toml:"temperature"`
+	MaxTokens    int     `toml:"max_tokens,omitempty"`
+}
+
+// WorkflowStepDef defines a step within a workflow
+type WorkflowStepDef struct {
+	Name      string   `toml:"name"`
+	Agent     string   `toml:"agent"`
+	DependsOn []string `toml:"depends_on,omitempty"`
 }
 
 // WorkflowMode defines workflow execution modes

--- a/v1beta/eval_handlers.go
+++ b/v1beta/eval_handlers.go
@@ -1,0 +1,391 @@
+package v1beta
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// =============================================================================
+// HTTP HANDLERS - Endpoints for EvalServer
+// =============================================================================
+
+// handleHealth returns server health status
+func (s *EvalServer) handleHealth(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"status":    "ok",
+		"agents":    s.agentNames(),
+		"workflows": s.workflowNames(),
+	})
+}
+
+// handleList returns the list of available agents and workflows
+func (s *EvalServer) handleList(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"agents":    s.agentNames(),
+		"workflows": s.workflowNames(),
+	})
+}
+
+// handleInvoke invokes the default agent or first registered agent
+func (s *EvalServer) handleInvoke(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	// Find default agent (first registered, or one named "main" or "default")
+	var agent Agent
+	var agentName string
+
+	if a, ok := s.agents["main"]; ok {
+		agent = a
+		agentName = "main"
+	} else if a, ok := s.agents["default"]; ok {
+		agent = a
+		agentName = "default"
+	} else if len(s.agents) == 1 {
+		for name, a := range s.agents {
+			agent = a
+			agentName = name
+			break
+		}
+	}
+
+	if agent == nil {
+		// Try workflows
+		var workflow Workflow
+		if wf, ok := s.workflows["main"]; ok {
+			workflow = wf
+			agentName = "main"
+		} else if wf, ok := s.workflows["default"]; ok {
+			workflow = wf
+			agentName = "default"
+		} else if len(s.workflows) == 1 {
+			for name, wf := range s.workflows {
+				workflow = wf
+				agentName = name
+				break
+			}
+		}
+
+		if workflow != nil {
+			s.invokeWorkflow(w, r, agentName, workflow)
+			return
+		}
+
+		http.Error(w, "No default agent or workflow found", http.StatusNotFound)
+		return
+	}
+
+	s.invokeAgent(w, r, agentName, agent)
+}
+
+// handleInvokeNamed invokes a specific named agent or workflow
+func (s *EvalServer) handleInvokeNamed(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	// Extract name from path: /invoke/{name}
+	name := strings.TrimPrefix(r.URL.Path, "/invoke/")
+	if name == "" {
+		http.Error(w, "Name required", http.StatusBadRequest)
+		return
+	}
+
+	// Try agent first
+	if agent, ok := s.agents[name]; ok {
+		s.invokeAgent(w, r, name, agent)
+		return
+	}
+
+	// Try workflow
+	if workflow, ok := s.workflows[name]; ok {
+		s.invokeWorkflow(w, r, name, workflow)
+		return
+	}
+
+	http.Error(w, fmt.Sprintf("Agent or workflow '%s' not found", name), http.StatusNotFound)
+}
+
+// invokeAgent executes an agent and returns the result
+func (s *EvalServer) invokeAgent(w http.ResponseWriter, r *http.Request, name string, agent Agent) {
+	// Parse request
+	var req InvokeRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, fmt.Sprintf("Invalid request: %v", err), http.StatusBadRequest)
+		return
+	}
+
+	// Get or create session
+	session := s.getOrCreateSession(req.SessionID)
+	session.AddMessage("user", req.Input)
+
+	// Generate trace ID
+	traceID := fmt.Sprintf("run-%s-%s", time.Now().Format("20060102-150405"), uuid.NewString()[:8])
+
+	// Create context with timeout
+	ctx := r.Context()
+	if timeout, ok := req.Options["timeout"].(float64); ok {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, time.Duration(timeout)*time.Second)
+		defer cancel()
+	}
+
+	// Execute agent with streaming to avoid timeout issues
+	startTime := time.Now()
+	stream, err := agent.RunStream(ctx, req.Input)
+	if err != nil {
+		resp := InvokeResponse{
+			TraceID:    traceID,
+			SessionID:  session.ID,
+			DurationMs: 0,
+			Success:    false,
+			Error:      err.Error(),
+		}
+		s.logger.Printf("Agent %s stream creation error: %v", name, err)
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+		return
+	}
+
+	// Collect all streamed chunks
+	var contentBuilder strings.Builder
+	for chunk := range stream.Chunks() {
+		if chunk.Type == "text" && chunk.Content != "" {
+			contentBuilder.WriteString(chunk.Content)
+		}
+	}
+
+	// Wait for final result
+	finalResult, streamErr := stream.Wait()
+	duration := time.Since(startTime)
+
+	// Build response
+	resp := InvokeResponse{
+		TraceID:    traceID,
+		SessionID:  session.ID,
+		DurationMs: duration.Milliseconds(),
+		Success:    streamErr == nil,
+	}
+
+	if streamErr != nil {
+		resp.Error = streamErr.Error()
+		s.logger.Printf("Agent %s error: %v", name, streamErr)
+	} else {
+		// Use accumulated content from all chunks
+		finalContent := contentBuilder.String()
+		if finalContent == "" && finalResult != nil {
+			finalContent = finalResult.Content
+		}
+		if finalResult != nil {
+			resp.Output = finalContent
+			resp.Success = finalResult.Success
+			if finalResult.ToolsCalled != nil {
+				resp.ToolsCalled = finalResult.ToolsCalled
+			}
+		} else {
+			resp.Output = finalContent
+		}
+		session.AddMessage("assistant", finalContent)
+	}
+
+	// Store trace
+	trace := &EvalTrace{
+		ID:        traceID,
+		StartTime: startTime,
+		EndTime:   time.Now(),
+		Duration:  duration.Milliseconds(),
+	}
+	s.storeTrace(trace)
+
+	// Send response
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(resp); err != nil {
+		s.logger.Printf("Failed to encode response: %v", err)
+	}
+}
+
+// invokeWorkflow executes a workflow and returns the result
+func (s *EvalServer) invokeWorkflow(w http.ResponseWriter, r *http.Request, name string, workflow Workflow) {
+	// Parse request
+	var req InvokeRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		http.Error(w, fmt.Sprintf("Invalid request: %v", err), http.StatusBadRequest)
+		return
+	}
+
+	// Get or create session
+	session := s.getOrCreateSession(req.SessionID)
+	session.AddMessage("user", req.Input)
+
+	// Generate trace ID
+	traceID := fmt.Sprintf("run-%s-%s", time.Now().Format("20060102-150405"), uuid.NewString()[:8])
+
+	// Create context with timeout
+	ctx := r.Context()
+	if timeout, ok := req.Options["timeout"].(float64); ok {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, time.Duration(timeout)*time.Second)
+		defer cancel()
+	}
+
+	// Execute workflow with streaming to avoid timeout issues
+	startTime := time.Now()
+	stream, err := workflow.RunStream(ctx, req.Input)
+	if err != nil {
+		resp := InvokeResponse{
+			TraceID:    traceID,
+			SessionID:  session.ID,
+			DurationMs: 0,
+			Success:    false,
+			Error:      err.Error(),
+		}
+		s.logger.Printf("Workflow %s stream creation error: %v", name, err)
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(resp)
+		return
+	}
+
+	// Collect all streamed chunks
+	var contentBuilder strings.Builder
+	for chunk := range stream.Chunks() {
+		if chunk.Type == "text" && chunk.Content != "" {
+			contentBuilder.WriteString(chunk.Content)
+		}
+	}
+
+	// Wait for final result (note: Stream.Wait() returns *Result, but we need WorkflowResult)
+	// For workflows, we'll use the accumulated content from chunks
+	_, streamErr := stream.Wait()
+	duration := time.Since(startTime)
+
+	// Build response
+	resp := InvokeResponse{
+		TraceID:    traceID,
+		SessionID:  session.ID,
+		DurationMs: duration.Milliseconds(),
+		Success:    streamErr == nil,
+	}
+
+	if streamErr != nil {
+		resp.Error = streamErr.Error()
+		s.logger.Printf("Workflow %s error: %v", name, streamErr)
+	} else {
+		finalContent := contentBuilder.String()
+		resp.Output = finalContent
+		resp.Success = true
+		session.AddMessage("assistant", finalContent)
+	}
+
+	// Store trace
+	trace := &EvalTrace{
+		ID:        traceID,
+		StartTime: startTime,
+		EndTime:   time.Now(),
+		Duration:  duration.Milliseconds(),
+	}
+	s.storeTrace(trace)
+
+	// Send response
+	w.Header().Set("Content-Type", "application/json")
+	if err := json.NewEncoder(w).Encode(resp); err != nil {
+		s.logger.Printf("Failed to encode response: %v", err)
+	}
+}
+
+// handleTraces retrieves trace data by ID
+func (s *EvalServer) handleTraces(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodGet {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	// Extract trace ID from path: /traces/{id}
+	traceID := strings.TrimPrefix(r.URL.Path, "/traces/")
+	if traceID == "" {
+		http.Error(w, "Trace ID required", http.StatusBadRequest)
+		return
+	}
+
+	trace, ok := s.getTrace(traceID)
+	if !ok {
+		http.Error(w, "Trace not found", http.StatusNotFound)
+		return
+	}
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(trace)
+}
+
+// handleSessionCreate creates a new session
+func (s *EvalServer) handleSessionCreate(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	session := s.getOrCreateSession("")
+
+	w.Header().Set("Content-Type", "application/json")
+	json.NewEncoder(w).Encode(map[string]interface{}{
+		"session_id": session.ID,
+		"created_at": session.CreatedAt,
+	})
+}
+
+// handleSession manages session operations
+func (s *EvalServer) handleSession(w http.ResponseWriter, r *http.Request) {
+	// Extract session ID from path: /session/{id}
+	sessionID := strings.TrimPrefix(r.URL.Path, "/session/")
+	if sessionID == "" {
+		http.Error(w, "Session ID required", http.StatusBadRequest)
+		return
+	}
+
+	switch r.Method {
+	case http.MethodGet:
+		// Get session history
+		s.sessionsMu.RLock()
+		session, ok := s.sessions[sessionID]
+		s.sessionsMu.RUnlock()
+
+		if !ok {
+			http.Error(w, "Session not found", http.StatusNotFound)
+			return
+		}
+
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(session)
+
+	case http.MethodDelete:
+		// Delete session
+		s.sessionsMu.Lock()
+		delete(s.sessions, sessionID)
+		s.sessionsMu.Unlock()
+
+		w.WriteHeader(http.StatusNoContent)
+
+	default:
+		http.Error(w, "Method not allowed", http.StatusMethodNotAllowed)
+	}
+}

--- a/v1beta/eval_server.go
+++ b/v1beta/eval_server.go
@@ -1,0 +1,198 @@
+package v1beta
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"net/http"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/google/uuid"
+)
+
+// =============================================================================
+// EVAL SERVER - HTTP Server for Testing Agents and Workflows
+// =============================================================================
+
+// EvalServer is an HTTP server that exposes agents and workflows for evaluation
+type EvalServer struct {
+	port     int
+	traceDir string
+	logger   *log.Logger
+
+	// Registered agents and workflows
+	agents    map[string]Agent
+	workflows map[string]Workflow
+
+	// Trace storage
+	traces   map[string]*EvalTrace
+	tracesMu sync.RWMutex
+
+	// Session storage
+	sessions   map[string]*EvalSession
+	sessionsMu sync.RWMutex
+
+	// HTTP server
+	server *http.Server
+	mux    *http.ServeMux
+}
+
+// EvalServerOption is a functional option for configuring EvalServer
+type EvalServerOption func(*EvalServer)
+
+// WithEvalAgent registers an agent with the eval server
+func WithEvalAgent(name string, agent Agent) EvalServerOption {
+	return func(s *EvalServer) {
+		s.agents[name] = agent
+	}
+}
+
+// WithEvalWorkflow registers a workflow with the eval server
+func WithEvalWorkflow(name string, workflow Workflow) EvalServerOption {
+	return func(s *EvalServer) {
+		s.workflows[name] = workflow
+	}
+}
+
+// WithEvalPort sets the port for the eval server
+func WithEvalPort(port int) EvalServerOption {
+	return func(s *EvalServer) {
+		s.port = port
+	}
+}
+
+// WithTraceDir sets the directory for persisting traces
+func WithTraceDir(dir string) EvalServerOption {
+	return func(s *EvalServer) {
+		s.traceDir = dir
+	}
+}
+
+// WithEvalLogger sets a custom logger for the eval server
+func WithEvalLogger(logger *log.Logger) EvalServerOption {
+	return func(s *EvalServer) {
+		s.logger = logger
+	}
+}
+
+// NewEvalServer creates a new EvalServer with the given options
+func NewEvalServer(opts ...EvalServerOption) *EvalServer {
+	s := &EvalServer{
+		port:      8787,
+		agents:    make(map[string]Agent),
+		workflows: make(map[string]Workflow),
+		traces:    make(map[string]*EvalTrace),
+		sessions:  make(map[string]*EvalSession),
+		logger:    log.New(os.Stdout, "[EvalServer] ", log.LstdFlags),
+		mux:       http.NewServeMux(),
+	}
+
+	for _, opt := range opts {
+		opt(s)
+	}
+
+	// Create trace directory if specified
+	if s.traceDir != "" {
+		if err := os.MkdirAll(s.traceDir, 0755); err != nil {
+			s.logger.Printf("Warning: failed to create trace dir: %v", err)
+		}
+	}
+
+	// Register routes
+	s.registerRoutes()
+
+	return s
+}
+
+// registerRoutes sets up the HTTP routes
+func (s *EvalServer) registerRoutes() {
+	s.mux.HandleFunc("/health", s.handleHealth)
+	s.mux.HandleFunc("/invoke", s.handleInvoke)
+	s.mux.HandleFunc("/invoke/", s.handleInvokeNamed)
+	s.mux.HandleFunc("/traces/", s.handleTraces)
+	s.mux.HandleFunc("/session", s.handleSessionCreate)
+	s.mux.HandleFunc("/session/", s.handleSession)
+	s.mux.HandleFunc("/list", s.handleList)
+}
+
+// ListenAndServe starts the HTTP server
+func (s *EvalServer) ListenAndServe() error {
+	addr := fmt.Sprintf(":%d", s.port)
+	s.server = &http.Server{
+		Addr:    addr,
+		Handler: s.mux,
+	}
+
+	s.logger.Printf("Starting eval server on %s", addr)
+	s.logger.Printf("Registered agents: %v", s.agentNames())
+	s.logger.Printf("Registered workflows: %v", s.workflowNames())
+
+	return s.server.ListenAndServe()
+}
+
+// Shutdown gracefully shuts down the server
+func (s *EvalServer) Shutdown(ctx context.Context) error {
+	if s.server != nil {
+		return s.server.Shutdown(ctx)
+	}
+	return nil
+}
+
+// agentNames returns the names of registered agents
+func (s *EvalServer) agentNames() []string {
+	names := make([]string, 0, len(s.agents))
+	for name := range s.agents {
+		names = append(names, name)
+	}
+	return names
+}
+
+// workflowNames returns the names of registered workflows
+func (s *EvalServer) workflowNames() []string {
+	names := make([]string, 0, len(s.workflows))
+	for name := range s.workflows {
+		names = append(names, name)
+	}
+	return names
+}
+
+// getOrCreateSession gets an existing session or creates a new one
+func (s *EvalServer) getOrCreateSession(sessionID string) *EvalSession {
+	s.sessionsMu.Lock()
+	defer s.sessionsMu.Unlock()
+
+	if sessionID != "" {
+		if session, ok := s.sessions[sessionID]; ok {
+			session.UpdateLastUsed()
+			return session
+		}
+	}
+
+	// Create new session
+	newID := uuid.NewString()
+	session := &EvalSession{
+		ID:        newID,
+		CreatedAt: time.Now(),
+		LastUsed:  time.Now(),
+		History:   make([]SessionMessage, 0),
+	}
+	s.sessions[newID] = session
+	return session
+}
+
+// storeTrace stores a trace in memory and optionally to disk
+func (s *EvalServer) storeTrace(trace *EvalTrace) {
+	s.tracesMu.Lock()
+	defer s.tracesMu.Unlock()
+	s.traces[trace.ID] = trace
+}
+
+// getTrace retrieves a trace by ID
+func (s *EvalServer) getTrace(id string) (*EvalTrace, bool) {
+	s.tracesMu.RLock()
+	defer s.tracesMu.RUnlock()
+	trace, ok := s.traces[id]
+	return trace, ok
+}

--- a/v1beta/eval_types.go
+++ b/v1beta/eval_types.go
@@ -1,0 +1,90 @@
+package v1beta
+
+import (
+	"sync"
+	"time"
+)
+
+// =============================================================================
+// EVAL TYPES - Request/Response and Trace Storage
+// =============================================================================
+
+// InvokeRequest is the request body for /invoke endpoints
+type InvokeRequest struct {
+	Input     string                 `json:"input"`
+	SessionID string                 `json:"session_id,omitempty"`
+	Options   map[string]interface{} `json:"options,omitempty"`
+}
+
+// InvokeResponse is the response body for /invoke endpoints
+type InvokeResponse struct {
+	Output      string   `json:"output"`
+	TraceID     string   `json:"trace_id"`
+	SessionID   string   `json:"session_id"`
+	DurationMs  int64    `json:"duration_ms"`
+	Success     bool     `json:"success"`
+	ToolsCalled []string `json:"tools_called,omitempty"`
+	Error       string   `json:"error,omitempty"`
+}
+
+// EvalTrace represents collected trace data for a single invocation
+type EvalTrace struct {
+	ID        string       `json:"id"`
+	StartTime time.Time    `json:"start_time"`
+	EndTime   time.Time    `json:"end_time"`
+	Duration  int64        `json:"duration_ms"`
+	Spans     []*EvalSpan  `json:"spans,omitempty"`
+	Events    []*EvalEvent `json:"events,omitempty"`
+}
+
+// EvalSpan represents a span within a trace (e.g., agent execution, tool call)
+type EvalSpan struct {
+	Name       string                 `json:"name"`
+	StartTime  time.Time              `json:"start_time"`
+	EndTime    time.Time              `json:"end_time"`
+	Duration   int64                  `json:"duration_ms"`
+	Attributes map[string]interface{} `json:"attributes,omitempty"`
+	Events     []*EvalEvent           `json:"events,omitempty"`
+}
+
+// EvalEvent represents an event within a span or trace
+type EvalEvent struct {
+	Name       string                 `json:"name"`
+	Time       time.Time              `json:"time"`
+	Attributes map[string]interface{} `json:"attributes,omitempty"`
+}
+
+// EvalSession represents a conversation session with memory
+type EvalSession struct {
+	ID        string           `json:"id"`
+	CreatedAt time.Time        `json:"created_at"`
+	LastUsed  time.Time        `json:"last_used"`
+	Memory    Memory           `json:"-"`
+	History   []SessionMessage `json:"history"`
+	mu        sync.Mutex       `json:"-"`
+}
+
+// SessionMessage represents a message in the session history
+type SessionMessage struct {
+	Role      string    `json:"role"` // "user" or "assistant"
+	Content   string    `json:"content"`
+	Timestamp time.Time `json:"timestamp"`
+}
+
+// UpdateLastUsed updates the last used timestamp
+func (s *EvalSession) UpdateLastUsed() {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.LastUsed = time.Now()
+}
+
+// AddMessage adds a message to the session history
+func (s *EvalSession) AddMessage(role, content string) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.History = append(s.History, SessionMessage{
+		Role:      role,
+		Content:   content,
+		Timestamp: time.Now(),
+	})
+}

--- a/v1beta/provider_factory.go
+++ b/v1beta/provider_factory.go
@@ -35,6 +35,7 @@ func createLLMProvider(config LLMConfig) (llm.ModelProvider, error) {
 		MaxTokens:           config.MaxTokens,
 		Temperature:         config.Temperature,
 		BaseURL:             config.BaseURL,
+		HTTPTimeout:         config.HTTPTimeout,         // HTTP client timeout
 		Endpoint:            config.Endpoint,            // For Azure
 		ChatDeployment:      config.ChatDeployment,      // For Azure
 		EmbeddingDeployment: config.EmbeddingDeployment, // For Azure

--- a/v1beta/workflow.go
+++ b/v1beta/workflow.go
@@ -11,6 +11,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/BurntSushi/toml"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
@@ -2165,3 +2166,104 @@ Accessing workflow results:
 			stepResult.Tokens)
 	}
 */
+
+// =============================================================================
+// TOML CONFIG LOADER
+// =============================================================================
+
+// LoadWorkflowFromTOML loads a workflow from a TOML configuration file
+// This provides a convenient way to initialize workflows from config files
+func LoadWorkflowFromTOML(configPath string) (Workflow, error) {
+	// Check if file exists
+	if _, err := os.Stat(configPath); os.IsNotExist(err) {
+		return nil, fmt.Errorf("configuration file not found: %s", configPath)
+	}
+
+	// Read the file
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read configuration file %s: %w", configPath, err)
+	}
+
+	// Parse TOML into ProjectConfig which has workflow support
+	var projectConfig ProjectConfig
+	if err := toml.Unmarshal(data, &projectConfig); err != nil {
+		return nil, fmt.Errorf("failed to parse TOML configuration: %w", err)
+	}
+
+	// Check if workflow config exists (mode should be set)
+	if projectConfig.Workflow.Mode == "" {
+		return nil, fmt.Errorf("no workflow configuration found in %s (workflow.mode must be set)", configPath)
+	}
+
+	// Create the workflow
+	workflow, err := NewWorkflow(&projectConfig.Workflow)
+	if err != nil {
+		return nil, fmt.Errorf("failed to create workflow: %w", err)
+	}
+
+	// Build agents from agent_defs
+	agentMap := make(map[string]Agent)
+	for _, agentDef := range projectConfig.Workflow.AgentDefs {
+		// Build agent using the builder API with options
+		var opts []Option
+
+		// Set system prompt
+		if agentDef.SystemPrompt != "" {
+			opts = append(opts, WithSystemPrompt(agentDef.SystemPrompt))
+		}
+
+		// Set LLM config if available
+		if projectConfig.Workflow.LLM != nil {
+			llmConfig := projectConfig.Workflow.LLM
+			temperature := agentDef.Temperature
+			if temperature == 0 {
+				temperature = float64(llmConfig.Temperature)
+			}
+			maxTokens := agentDef.MaxTokens
+			if maxTokens == 0 {
+				maxTokens = llmConfig.MaxTokens
+			}
+
+			// Use a custom option to set the full LLM config including timeout and base URL
+			opts = append(opts, func(c *Config) {
+				c.LLM.Provider = llmConfig.Provider
+				c.LLM.Model = llmConfig.Model
+				c.LLM.Temperature = float32(temperature)
+				c.LLM.MaxTokens = maxTokens
+				c.LLM.BaseURL = llmConfig.BaseURL
+				c.LLM.HTTPTimeout = llmConfig.HTTPTimeout
+			})
+		}
+
+		// Create the agent using builder
+		agent, err := NewChatAgent(agentDef.Name, opts...)
+		if err != nil {
+			return nil, fmt.Errorf("failed to create agent %s: %w", agentDef.Name, err)
+		}
+
+		agentMap[agentDef.Name] = agent
+	}
+
+	// Build steps from step_defs
+	for _, stepDef := range projectConfig.Workflow.StepDefs {
+		agent, ok := agentMap[stepDef.Agent]
+		if !ok {
+			return nil, fmt.Errorf("step %s references undefined agent %s", stepDef.Name, stepDef.Agent)
+		}
+
+		// Create workflow step
+		step := WorkflowStep{
+			Name:         stepDef.Name,
+			Agent:        agent,
+			Dependencies: stepDef.DependsOn,
+		}
+
+		// Add the step to the workflow
+		if err := workflow.AddStep(step); err != nil {
+			return nil, fmt.Errorf("failed to add step %s: %w", stepDef.Name, err)
+		}
+	}
+
+	return workflow, nil
+}


### PR DESCRIPTION
Add EvalServer with HTTP endpoints (`/invoke`, `/health`, `/traces`) for automated workflow testing. Implement streaming fixes to properly read both Delta and Content fields in chunk processing. Add `LoadWorkflowFromTOML` helper for declarative workflow configuration.

Update API compatibility: Result.Content (was Output), agent.Cleanup() (was Shutdown), stream.Wait() for proper error handling. Support `AGK_EVAL_MODE` environment variable for toggling between normal and eval server modes.

Enables semantic matching evaluation framework in AGK CLI.