### PR TITLE
fix: add detailed tracing to all LLM adapter Call and Stream methods

### DIFF
--- a/internal/llm/anthropic_adapter.go
+++ b/internal/llm/anthropic_adapter.go
@@ -375,7 +375,13 @@ func (a *AnthropicAdapter) Call(ctx context.Context, prompt Prompt) (Response, e
 		attribute.Int64("llm.latency_ms", latencyMs),
 		attribute.String("llm.finish_reason", response.StopReason),
 	)
-
+	if observability.IsDetailedTracing() {
+		span.SetAttributes(
+			attribute.String(observability.AttrPromptSystem, observability.TruncateForTrace(prompt.System, observability.MaxContentLength)),
+			attribute.String(observability.AttrPromptUser, observability.TruncateForTrace(prompt.User, observability.MaxContentLength)),
+			attribute.String(observability.AttrLLMResponse, observability.TruncateForTrace(contentBuilder.String(), observability.MaxContentLength)),
+		)
+	}
 	span.SetStatus(codes.Ok, "LLM call successful")
 
 	return Response{
@@ -524,6 +530,7 @@ func (a *AnthropicAdapter) Stream(ctx context.Context, prompt Prompt) (<-chan To
 
 		chunkCount := 0
 		totalBytes := 0
+		var fullResponseBuilder strings.Builder
 
 		scanner := bufio.NewScanner(resp.Body)
 		for scanner.Scan() {
@@ -557,6 +564,13 @@ func (a *AnthropicAdapter) Stream(ctx context.Context, prompt Prompt) (<-chan To
 						attribute.Int("llm.stream.total_bytes", totalBytes),
 						attribute.Int64("llm.latency_ms", latencyMs),
 					)
+					if observability.IsDetailedTracing() {
+						span.SetAttributes(
+							attribute.String(observability.AttrPromptSystem, observability.TruncateForTrace(prompt.System, observability.MaxContentLength)),
+							attribute.String(observability.AttrPromptUser, observability.TruncateForTrace(prompt.User, observability.MaxContentLength)),
+							attribute.String(observability.AttrLLMResponse, observability.TruncateForTrace(fullResponseBuilder.String(), observability.MaxContentLength)),
+						)
+					}
 					span.SetStatus(codes.Ok, "stream completed successfully")
 					return
 				}
@@ -574,6 +588,7 @@ func (a *AnthropicAdapter) Stream(ctx context.Context, prompt Prompt) (<-chan To
 					if event.Delta != nil && event.Delta.Type == "text_delta" && event.Delta.Text != "" {
 						chunkCount++
 						totalBytes += len(event.Delta.Text)
+						fullResponseBuilder.WriteString(event.Delta.Text)
 						select {
 						case tokenChan <- Token{Content: event.Delta.Text}:
 						case <-ctx.Done():
@@ -590,6 +605,13 @@ func (a *AnthropicAdapter) Stream(ctx context.Context, prompt Prompt) (<-chan To
 						attribute.Int("llm.stream.total_bytes", totalBytes),
 						attribute.Int64("llm.latency_ms", latencyMs),
 					)
+					if observability.IsDetailedTracing() {
+						span.SetAttributes(
+							attribute.String(observability.AttrPromptSystem, observability.TruncateForTrace(prompt.System, observability.MaxContentLength)),
+							attribute.String(observability.AttrPromptUser, observability.TruncateForTrace(prompt.User, observability.MaxContentLength)),
+							attribute.String(observability.AttrLLMResponse, observability.TruncateForTrace(fullResponseBuilder.String(), observability.MaxContentLength)),
+						)
+					}
 					span.SetStatus(codes.Ok, "stream completed successfully")
 					return
 				case "error":

--- a/internal/llm/azure_adapter.go
+++ b/internal/llm/azure_adapter.go
@@ -332,6 +332,13 @@ func (a *AzureOpenAIAdapter) Call(ctx context.Context, prompt Prompt) (Response,
 		return Response{}, err
 	}
 
+	if observability.IsDetailedTracing() {
+		span.SetAttributes(
+			attribute.String(observability.AttrPromptSystem, observability.TruncateForTrace(prompt.System, observability.MaxContentLength)),
+			attribute.String(observability.AttrPromptUser, observability.TruncateForTrace(prompt.User, observability.MaxContentLength)),
+			attribute.String(observability.AttrLLMResponse, observability.TruncateForTrace(llmResp.Content, observability.MaxContentLength)),
+		)
+	}
 	span.SetStatus(codes.Ok, "LLM call successful")
 	return llmResp, nil
 }
@@ -398,6 +405,7 @@ func (a *AzureOpenAIAdapter) Stream(ctx context.Context, prompt Prompt) (<-chan 
 		// Track chunks and total bytes
 		chunkCount := 0
 		totalBytes := 0
+		var fullResponseBuilder strings.Builder
 
 		scanner := bufio.NewScanner(httpResp.Body)
 		for scanner.Scan() {
@@ -427,6 +435,13 @@ func (a *AzureOpenAIAdapter) Stream(ctx context.Context, prompt Prompt) (<-chan 
 						attribute.Int("llm.stream.total_bytes", totalBytes),
 						attribute.Int64("llm.latency_ms", latencyMs),
 					)
+					if observability.IsDetailedTracing() {
+						span.SetAttributes(
+							attribute.String(observability.AttrPromptSystem, observability.TruncateForTrace(prompt.System, observability.MaxContentLength)),
+							attribute.String(observability.AttrPromptUser, observability.TruncateForTrace(prompt.User, observability.MaxContentLength)),
+							attribute.String(observability.AttrLLMResponse, observability.TruncateForTrace(fullResponseBuilder.String(), observability.MaxContentLength)),
+						)
+					}
 					span.SetStatus(codes.Ok, "stream completed successfully")
 					return // Stream finished successfully
 				}
@@ -446,6 +461,7 @@ func (a *AzureOpenAIAdapter) Stream(ctx context.Context, prompt Prompt) (<-chan 
 					if contentDelta != "" {
 						chunkCount++
 						totalBytes += len(contentDelta)
+						fullResponseBuilder.WriteString(contentDelta)
 						select {
 						case tokenChan <- Token{Content: contentDelta}:
 						case <-ctx.Done():

--- a/internal/llm/huggingface_adapter.go
+++ b/internal/llm/huggingface_adapter.go
@@ -405,7 +405,13 @@ func (h *HuggingFaceAdapter) Call(ctx context.Context, prompt Prompt) (Response,
 		attribute.Int64("llm.latency_ms", latencyMs),
 		attribute.String("llm.finish_reason", result.FinishReason),
 	)
-
+	if observability.IsDetailedTracing() {
+		span.SetAttributes(
+			attribute.String(observability.AttrPromptSystem, observability.TruncateForTrace(prompt.System, observability.MaxContentLength)),
+			attribute.String(observability.AttrPromptUser, observability.TruncateForTrace(prompt.User, observability.MaxContentLength)),
+			attribute.String(observability.AttrLLMResponse, observability.TruncateForTrace(result.Content, observability.MaxContentLength)),
+		)
+	}
 	span.SetStatus(codes.Ok, "LLM call successful")
 
 	return result, nil
@@ -532,6 +538,7 @@ func (h *HuggingFaceAdapter) Stream(ctx context.Context, prompt Prompt) (<-chan 
 
 		var chunkCount int
 		var totalBytes int64
+		var fullResponseBuilder strings.Builder
 
 		scanner := bufio.NewScanner(resp.Body)
 		for scanner.Scan() {
@@ -561,6 +568,13 @@ func (h *HuggingFaceAdapter) Stream(ctx context.Context, prompt Prompt) (<-chan 
 						attribute.Int64("llm.total_bytes", totalBytes),
 						attribute.Int64("llm.latency_ms", latencyMs),
 					)
+					if observability.IsDetailedTracing() {
+						span.SetAttributes(
+							attribute.String(observability.AttrPromptSystem, observability.TruncateForTrace(prompt.System, observability.MaxContentLength)),
+							attribute.String(observability.AttrPromptUser, observability.TruncateForTrace(prompt.User, observability.MaxContentLength)),
+							attribute.String(observability.AttrLLMResponse, observability.TruncateForTrace(fullResponseBuilder.String(), observability.MaxContentLength)),
+						)
+					}
 					span.SetStatus(codes.Ok, "stream completed")
 					return // Stream finished
 				}
@@ -587,6 +601,7 @@ func (h *HuggingFaceAdapter) Stream(ctx context.Context, prompt Prompt) (<-chan 
 				if content != "" {
 					chunkCount++
 					totalBytes += int64(len(content))
+					fullResponseBuilder.WriteString(content)
 
 					select {
 					case tokenChan <- Token{Content: content}:

--- a/internal/llm/ollama_adapter.go
+++ b/internal/llm/ollama_adapter.go
@@ -298,6 +298,15 @@ func (o *OllamaAdapter) Call(ctx context.Context, prompt Prompt) (Response, erro
 		}
 	}
 
+	// Capture full prompt and response at detailed trace level
+	if observability.IsDetailedTracing() {
+		span.SetAttributes(
+			attribute.String(observability.AttrPromptSystem, observability.TruncateForTrace(prompt.System, observability.MaxContentLength)),
+			attribute.String(observability.AttrPromptUser, observability.TruncateForTrace(prompt.User, observability.MaxContentLength)),
+			attribute.String(observability.AttrLLMResponse, observability.TruncateForTrace(response.Content, observability.MaxContentLength)),
+		)
+	}
+
 	span.SetStatus(codes.Ok, "LLM call successful")
 	return response, nil
 }
@@ -447,6 +456,7 @@ func (o *OllamaAdapter) Stream(ctx context.Context, prompt Prompt) (<-chan Token
 		promptTokens := 0
 		completionTokens := 0
 		serverDurationNs := int64(0)
+		var fullResponseBuilder strings.Builder
 
 		decoder := json.NewDecoder(resp.Body)
 
@@ -478,6 +488,13 @@ func (o *OllamaAdapter) Stream(ctx context.Context, prompt Prompt) (<-chan Token
 						attribute.Int("llm.stream.total_bytes", totalBytes),
 						attribute.Int64("llm.latency_ms", latencyMs),
 					)
+					if observability.IsDetailedTracing() {
+						span.SetAttributes(
+							attribute.String(observability.AttrPromptSystem, observability.TruncateForTrace(prompt.System, observability.MaxContentLength)),
+							attribute.String(observability.AttrPromptUser, observability.TruncateForTrace(prompt.User, observability.MaxContentLength)),
+							attribute.String(observability.AttrLLMResponse, observability.TruncateForTrace(fullResponseBuilder.String(), observability.MaxContentLength)),
+						)
+					}
 					span.SetStatus(codes.Ok, "stream completed successfully")
 					return // End of stream
 				}
@@ -498,6 +515,7 @@ func (o *OllamaAdapter) Stream(ctx context.Context, prompt Prompt) (<-chan Token
 			if response.Response != "" {
 				chunkCount++
 				totalBytes += len(response.Response)
+				fullResponseBuilder.WriteString(response.Response)
 				tokenChan <- Token{Content: response.Response}
 			}
 
@@ -540,6 +558,13 @@ func (o *OllamaAdapter) Stream(ctx context.Context, prompt Prompt) (<-chan Token
 					attrs = append(attrs, attribute.Int(observability.AttrLLMTotalTokens, total))
 				}
 				span.SetAttributes(attrs...)
+				if observability.IsDetailedTracing() {
+					span.SetAttributes(
+						attribute.String(observability.AttrPromptSystem, observability.TruncateForTrace(prompt.System, observability.MaxContentLength)),
+						attribute.String(observability.AttrPromptUser, observability.TruncateForTrace(prompt.User, observability.MaxContentLength)),
+						attribute.String(observability.AttrLLMResponse, observability.TruncateForTrace(fullResponseBuilder.String(), observability.MaxContentLength)),
+					)
+				}
 				span.SetStatus(codes.Ok, "stream completed successfully")
 				return // Stream complete
 			}

--- a/internal/llm/openai_adapter.go
+++ b/internal/llm/openai_adapter.go
@@ -319,6 +319,15 @@ func (o *OpenAIAdapter) Call(ctx context.Context, prompt Prompt) (Response, erro
 		attribute.String("llm.finish_reason", response.Choices[0].FinishReason),
 	)
 
+	// Capture full prompt and response at detailed trace level
+	if observability.IsDetailedTracing() {
+		span.SetAttributes(
+			attribute.String(observability.AttrPromptSystem, observability.TruncateForTrace(prompt.System, observability.MaxContentLength)),
+			attribute.String(observability.AttrPromptUser, observability.TruncateForTrace(prompt.User, observability.MaxContentLength)),
+			attribute.String(observability.AttrLLMResponse, observability.TruncateForTrace(response.Choices[0].Message.Content, observability.MaxContentLength)),
+		)
+	}
+
 	span.SetStatus(codes.Ok, "LLM call successful")
 
 	return Response{
@@ -474,6 +483,7 @@ func (o *OpenAIAdapter) Stream(ctx context.Context, prompt Prompt) (<-chan Token
 		// Track chunks and total bytes
 		chunkCount := 0
 		totalBytes := 0
+		var fullResponseBuilder strings.Builder
 
 		scanner := bufio.NewScanner(resp.Body)
 		for scanner.Scan() {
@@ -503,6 +513,13 @@ func (o *OpenAIAdapter) Stream(ctx context.Context, prompt Prompt) (<-chan Token
 						attribute.Int("llm.stream.total_bytes", totalBytes),
 						attribute.Int64("llm.latency_ms", latencyMs),
 					)
+					if observability.IsDetailedTracing() {
+						span.SetAttributes(
+							attribute.String(observability.AttrPromptSystem, observability.TruncateForTrace(prompt.System, observability.MaxContentLength)),
+							attribute.String(observability.AttrPromptUser, observability.TruncateForTrace(prompt.User, observability.MaxContentLength)),
+							attribute.String(observability.AttrLLMResponse, observability.TruncateForTrace(fullResponseBuilder.String(), observability.MaxContentLength)),
+						)
+					}
 					span.SetStatus(codes.Ok, "stream completed successfully")
 					return // Stream finished successfully
 				}
@@ -530,6 +547,7 @@ func (o *OpenAIAdapter) Stream(ctx context.Context, prompt Prompt) (<-chan Token
 					if content != "" {
 						chunkCount++
 						totalBytes += len(content)
+						fullResponseBuilder.WriteString(content)
 						select {
 						case tokenChan <- Token{Content: content}:
 						case <-ctx.Done():

--- a/internal/llm/openrouter_adapter.go
+++ b/internal/llm/openrouter_adapter.go
@@ -248,6 +248,15 @@ func (o *OpenRouterAdapter) Call(ctx context.Context, prompt Prompt) (Response, 
 		attribute.String("llm.finish_reason", response.Choices[0].FinishReason),
 	)
 
+	// Capture full prompt and response at detailed trace level
+	if observability.IsDetailedTracing() {
+		span.SetAttributes(
+			attribute.String(observability.AttrPromptSystem, observability.TruncateForTrace(prompt.System, observability.MaxContentLength)),
+			attribute.String(observability.AttrPromptUser, observability.TruncateForTrace(prompt.User, observability.MaxContentLength)),
+			attribute.String(observability.AttrLLMResponse, observability.TruncateForTrace(response.Choices[0].Message.Content, observability.MaxContentLength)),
+		)
+	}
+
 	span.SetStatus(codes.Ok, "LLM call successful")
 
 	return Response{
@@ -393,6 +402,7 @@ func (o *OpenRouterAdapter) Stream(ctx context.Context, prompt Prompt) (<-chan T
 
 		var chunkCount int
 		var totalBytes int64
+		var fullResponseBuilder strings.Builder
 
 		scanner := bufio.NewScanner(resp.Body)
 		for scanner.Scan() {
@@ -422,6 +432,13 @@ func (o *OpenRouterAdapter) Stream(ctx context.Context, prompt Prompt) (<-chan T
 						attribute.Int64("llm.total_bytes", totalBytes),
 						attribute.Int64("llm.latency_ms", latencyMs),
 					)
+					if observability.IsDetailedTracing() {
+						span.SetAttributes(
+							attribute.String(observability.AttrPromptSystem, observability.TruncateForTrace(prompt.System, observability.MaxContentLength)),
+							attribute.String(observability.AttrPromptUser, observability.TruncateForTrace(prompt.User, observability.MaxContentLength)),
+							attribute.String(observability.AttrLLMResponse, observability.TruncateForTrace(fullResponseBuilder.String(), observability.MaxContentLength)),
+						)
+					}
 					span.SetStatus(codes.Ok, "stream completed")
 					return // Stream finished successfully
 				}
@@ -449,6 +466,7 @@ func (o *OpenRouterAdapter) Stream(ctx context.Context, prompt Prompt) (<-chan T
 					if content != "" {
 						chunkCount++
 						totalBytes += int64(len(content))
+						fullResponseBuilder.WriteString(content)
 
 						select {
 						case tokenChan <- Token{Content: content}:


### PR DESCRIPTION
Add IsDetailedTracing() blocks to Ollama, OpenAI, OpenRouter, Anthropic, Azure, and HuggingFace adapters — both Call() and Stream() methods now capture agk.prompt.system, agk.prompt.user, and agk.llm.response span attributes when AGK_TRACE_LEVEL=detailed is set.