### PR TITLE
remove broken links from contributor guide

### DIFF
--- a/docs/contributors/ContributorGuide.md
+++ b/docs/contributors/ContributorGuide.md
@@ -523,7 +523,5 @@ Follow existing patterns in the codebase. When in doubt:
 
 ## Next Steps
 
-- **[Architecture Deep Dive](Architecture.md)** - Understand the internal structure
 - **[Testing Strategy](Testing.md)** - Learn our testing approaches
 - **[Adding Features](AddingFeatures.md)** - Detailed guide for extending AgenticGoKit
-- **[Release Process](ReleaseProcess.md)** - How we manage releases


### PR DESCRIPTION
Removed links in the "Next Steps" section that were pointing to missing pages Architecture and Release Process

Kept the links that are still working Testing Strategy and Adding Features

Missing docs can be added separately if needed

Closes #118