### PR TITLE
docs: fix v1beta.NewBuilder examples in DEPRECATION.md

### DIFF
--- a/DEPRECATION.md
+++ b/DEPRECATION.md
@@ -32,8 +32,7 @@ agent, err := vnext.NewBuilder("assistant").
 ```go
 import "github.com/agenticgokit/agenticgokit/v1beta"
 
-agent, err := v1beta.NewBuilder().
-    WithName("assistant").
+agent, err := v1beta.NewBuilder("assistant").
     WithLLM("ollama", "gemma3:1b").
     Build()
 ```
@@ -54,8 +53,7 @@ agent, err := v1beta.NewBuilder().
 ```diff
 - agent, err := vnext.NewBuilder("myagent").
 -     WithConfig(&vnext.Config{...}).
-+ agent, err := v1beta.NewBuilder().
-+     WithName("myagent").
++ agent, err := v1beta.NewBuilder("myagent").
 +     WithLLM("openai", "gpt-4").
       Build()
 ```
@@ -63,7 +61,7 @@ agent, err := v1beta.NewBuilder().
 **core → v1beta:**
 ```diff
 - agent, err := core.NewAgent(config)
-+ agent, err := v1beta.NewBuilder().
++ agent, err := v1beta.NewBuilder("myagent").
 +     WithLLM("openai", "gpt-4").
 +     Build()
 ```
@@ -79,8 +77,7 @@ agent, err := v1beta.NewBuilder().
 -         Model: "gpt-4",
 -     },
 - }
-+ agent, err := v1beta.NewBuilder().
-+     WithName("assistant").
++ agent, err := v1beta.NewBuilder("assistant").
 +     WithLLM("openai", "gpt-4").
 +     WithAPIKey(os.Getenv("OPENAI_API_KEY")).
 +     Build()
@@ -141,7 +138,7 @@ The v1beta API provides the same functionality as vnext:
 
 - [ ] Identify all uses of `core` or `core/vnext` imports
 - [ ] Update imports to `v1beta`
-- [ ] Update agent creation to use `v1beta.NewBuilder()`
+- [ ] Update agent creation to use `v1beta.NewBuilder(name)`
 - [ ] Update config structs to v1beta types
 - [ ] Update streaming code (minimal changes needed)
 - [ ] Update workflow code (minimal changes needed)
@@ -160,7 +157,7 @@ The v1beta API provides the same functionality as vnext:
 | Feature | core/vnext | v1beta | Notes |
 |---------|-----------|--------|-------|
 | Package | `core/vnext` | `v1beta` | Import path change |
-| Agent Creation | `NewBuilder(name)` | `NewBuilder().WithName(name)` | Builder pattern |
+| Agent Creation | `NewBuilder(name)` | `NewBuilder(name)` | Builder pattern |
 | Config | `WithConfig(&Config{...})` | Fluent methods | More ergonomic |
 | Streaming | `RunStream()` | `RunStream()` | Same API |
 | Workflows | `NewSequentialWorkflow()` | `NewSequentialWorkflow()` | Same API |


### PR DESCRIPTION
## Summary
Fix `v1beta.NewBuilder()` examples in `DEPRECATION.md` to match the actual v1beta API signature `NewBuilder(name string) Builder`. The old examples showed a non-existent `WithName()` method on the Builder interface.

## Why this matters
Issue #126 reported that `DEPRECATION.md` shows migration examples like:

```go
v1beta.NewBuilder().
    WithName("myagent").
    WithLLM(...).
    Build()
```

but `v1beta/builder.go:355` declares `func NewBuilder(name string) Builder` and there is no `WithName()` method on the Builder interface. Anyone following the migration guide would hit a compile error on `WithName`.

`README.md:69` and `docs/API_VERSIONING.md:373,381` already use the correct form `v1beta.NewBuilder("Agent")`, so `DEPRECATION.md` was the outlier.

## Changes
- `DEPRECATION.md`: every `v1beta.NewBuilder().WithName(x)` example rewritten as `v1beta.NewBuilder(x)`. Applies to the initial `New Code (v1beta)` example, both diff blocks under `vnext -> v1beta` and `core -> v1beta`, the config-struct diff, the migration checklist bullet, and the API Comparison Table row.

## Testing
Documentation-only change. Verified:
- `grep "WithName" DEPRECATION.md` returns no matches after the change
- `grep "v1beta.NewBuilder(" v1beta/builder.go` confirms `NewBuilder(name string)` at line 355
- README.md and docs/API_VERSIONING.md already match the corrected form

Fixes #126

This contribution was developed with AI assistance (Claude Code).
