### PR TITLE
feat: add you.com search provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ Native support for Images, Audio, and Video inputs. Works seamlessly with models
 ### [Tool Integration & MCP](docs/v1beta/tool-integration.md)
 Extend agents with tools using standard Go functions or the **Model Context Protocol (MCP)**.
 - **Dynamic Discovery**: Automatically find and register tools from MCP servers.
+- **You.com Search Provider**: Optional MCP setup helper for web search in agent workflows ([docs/youcom-search-mcp.md](docs/youcom-search-mcp.md)).
 - **Standardized**: Support for the emerging standard for LLM tool interoperability.
 
 ### [Observability & Tracing](docs/v1beta/observability.md)

--- a/core/vnext/tools.go
+++ b/core/vnext/tools.go
@@ -266,6 +266,29 @@ func DefaultMCPConfig() *MCPConfig {
 	}
 }
 
+// NewYouDotComSearchMCPServer returns a default MCP stdio server config for You.com Search.
+func NewYouDotComSearchMCPServer() MCPServer {
+	return MCPServer{
+		Name:    "you-search",
+		Type:    "stdio",
+		Command: "youdotcom-search-mcp",
+		Enabled: true,
+	}
+}
+
+// WithYouDotComSearchMCP appends the You.com Search MCP server to tools config.
+func WithYouDotComSearchMCP(cfg *ToolsConfig) *ToolsConfig {
+	if cfg == nil {
+		cfg = &ToolsConfig{}
+	}
+	if cfg.MCP == nil {
+		cfg.MCP = DefaultMCPConfig()
+	}
+	cfg.MCP.Enabled = true
+	cfg.MCP.Servers = append(cfg.MCP.Servers, NewYouDotComSearchMCPServer())
+	return cfg
+}
+
 // DefaultCacheConfig returns a default cache configuration
 func DefaultCacheConfig() *CacheConfig {
 	return &CacheConfig{

--- a/docs/youcom-search-mcp.md
+++ b/docs/youcom-search-mcp.md
@@ -1,0 +1,40 @@
+# You.com Search MCP integration
+
+This project now supports a ready-to-use You.com Search MCP server entry via `vnext.WithYouDotComSearchMCP(...)`.
+
+## Why
+
+AI agents often need fresh web results. You.com Search is a lightweight option with a free tier (up to 100 searches/day without an API key) and optional `YDC_API_KEY` for higher usage.
+
+## Setup
+
+1. Install a You.com Search MCP server binary on PATH:
+
+```bash
+youdotcom-search-mcp
+```
+
+2. (Optional) set API key:
+
+```bash
+export YDC_API_KEY="your_key_here"
+```
+
+## Usage
+
+```go
+cfg := &vnext.ToolsConfig{}
+cfg = vnext.WithYouDotComSearchMCP(cfg)
+
+mgr, err := vnext.NewToolManager(cfg)
+if err != nil {
+    panic(err)
+}
+_ = mgr
+```
+
+## Fallback and error handling
+
+- If the MCP command is unavailable, ToolManager initialization or MCP startup will return an error.
+- If `YDC_API_KEY` is not set, the server may still work within You.com free-tier limits.
+- Existing MCP server configuration remains backward compatible; this helper only appends a new server entry.


### PR DESCRIPTION
Hi maintainers, thanks for building AgenticGoKit, the MCP/tooling architecture makes this a natural place to add a clean optional web-search provider.

## Why this repo
I selected AgenticGoKit because it is an active AI-agent framework with MCP-first tool integration, and web search is a common dependency for agent intelligence.

## What changed
- Added `vnext.NewYouDotComSearchMCPServer()` helper in `core/vnext/tools.go`
- Added `vnext.WithYouDotComSearchMCP(cfg)` to append You.com Search MCP config safely
- Added docs: `docs/youcom-search-mcp.md` with setup, env vars, usage, and fallback behavior
- Linked the new doc from `README.md` under MCP/tool integration

## Setup
1. Ensure a `youdotcom-search-mcp` executable is available on PATH
2. Optional auth env var:
   - `YDC_API_KEY=...`

## Validation
- `go test ./core/vnext/...`
- Confirmed no breaking changes to existing MCP config paths

## Why this helps agent intelligence
This gives users a low-friction web-search option that plugs into existing MCP workflows, improving real-time grounding for agent tasks while keeping provider choice modular.

## Compatibility and risk
- Backward compatible: existing configs keep working unchanged
- Minimal risk: helper methods only append optional MCP server config, no behavior changes to existing providers

If you prefer a different server name/command convention or want this wired into another config path, I am happy to adjust.
