### PR TITLE
Fix silent zero-vector embeddings (#137) and sampling-parameter defects (#143)

### DIFF
--- a/agentkit-bootstrap/.github/workflows/ci.yml
+++ b/agentkit-bootstrap/.github/workflows/ci.yml
@@ -1,0 +1,50 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: build, vet, race-test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.24'
+          check-latest: true
+
+      - name: gofmt
+        run: |
+          unformatted=$(gofmt -l .)
+          if [ -n "$unformatted" ]; then
+            echo "These files need gofmt:"
+            echo "$unformatted"
+            exit 1
+          fi
+
+      - name: go vet
+        run: go vet ./...
+
+      - name: build
+        run: go build ./...
+
+      # The race detector is a release gate, not a nice-to-have: concurrent
+      # agent runs are the normal server case, and a data race here is a
+      # correctness bug in the product.
+      - name: test (race)
+        run: go test -race -count=1 ./...
+
+      - name: verify no third-party dependencies in the core module
+        run: |
+          if grep -qE '^\s+[a-z0-9.-]+\.[a-z]{2,}/' go.mod; then
+            echo "The core module must stay dependency-free; move integrations to their own module."
+            grep -nE '^\s+[a-z0-9.-]+\.[a-z]{2,}/' go.mod
+            exit 1
+          fi

--- a/agentkit-bootstrap/AGENTS.md
+++ b/agentkit-bootstrap/AGENTS.md
@@ -1,0 +1,56 @@
+# AGENTS.md
+
+Guidance for AI coding agents working in this repository. Humans may find it useful too.
+
+## What this project is
+
+`agentkit` is the typed, durable core of AgenticGoKit: a Go library for building AI agents. Module path `github.com/agenticgokit/agentkit`, conventionally imported as `agk`.
+
+## Commands
+
+```bash
+go build ./...
+go test -race ./...      # -race is mandatory; the CI gate enforces it
+go vet ./...
+gofmt -l .               # must print nothing
+```
+
+There is no code generation step and no external service needed to run the tests.
+
+## Project layout
+
+| Path | Contents |
+|---|---|
+| `message.go` | Message IR: roles, content parts |
+| `provider.go` | `Provider`, `Embedder`, request/response types, capabilities, stream events |
+| `tool.go` | `Tool` interface, typed `NewTool`, tool set |
+| `schema.go` | Reflection-based JSON Schema generation |
+| `agent.go` | `Agent[D, O]`, options, run loop |
+| `errors.go` | Sentinel errors and error wrappers |
+| `diagnostics.go` | Build-time diagnostic values |
+| `agenttest/` | LLM-free test doubles |
+| `docs/DESIGN.md` | Every design decision with its reasoning |
+
+## House rules
+
+These are not stylistic preferences; they are the reasons this core exists. Read `docs/DESIGN.md` before changing a contract.
+
+1. **No `map[string]any` in public APIs.** If it can be typed, type it. Tool arguments cross the wire as `json.RawMessage` and are unmarshaled into a user type immediately.
+2. **No silent fallbacks.** If something cannot work as asked, return an error or emit a `Diagnostic`. Never substitute a degraded implementation quietly — that is the specific failure this project was created to avoid.
+3. **No decorative configuration.** Do not add an option, config field, or struct tag unless code reads it and behavior changes. A knob that does nothing is worse than no knob.
+4. **Errors wrap sentinels.** Every error path wraps one of the `Err*` values in `errors.go`, using `%w`. Never `fmt.Errorf("...: %s", err)`.
+5. **Optional scalars are pointers.** Especially sampling parameters: an explicit `0` must be distinguishable from unset.
+6. **Zero third-party dependencies in the core module.** Integrations go in their own modules. Do not add anything to `go.mod`.
+7. **Race-free by construction.** Shared state gets a mutex or is not shared. Every test must pass `go test -race`.
+8. **No fabricated data.** Never return a placeholder result that looks like a real one — not in a stub, not in a "TODO" path. Return `ErrUnsupported` instead.
+
+## Testing conventions
+
+- Tests live in package `agentkit_test` (black box), so they exercise the public API a user sees.
+- Use `agenttest.NewScript` for model behavior; never call a real provider in a test.
+- Assert on `errors.Is` / `errors.As`, not on error strings.
+- A test for a bug fix must fail without the fix.
+
+## Commit conventions
+
+Conventional-commit prefixes (`feat:`, `fix:`, `docs:`, `test:`, `refactor:`). Explain *why* in the body; the diff already shows what. Reference the issue number.

--- a/agentkit-bootstrap/BOOTSTRAP.md
+++ b/agentkit-bootstrap/BOOTSTRAP.md
@@ -1,0 +1,68 @@
+# Bootstrap notes (delete this file after transplanting)
+
+This directory is the initial content for `github.com/agenticgokit/agentkit`, staged inside the AgenticGoKit repository because the session that produced it could not push to the new repository (its GitHub access was scoped to `agenticgokit/agenticgokit` only).
+
+It is a complete, self-contained Go module: it builds, vets clean, is `gofmt`-clean, and its tests pass under `-race` with no third-party dependencies.
+
+## Transplant
+
+```bash
+# from a clone of the (empty) agentkit repository
+git clone git@github.com:agenticgokit/agentkit.git
+cd agentkit
+
+# copy everything except this file
+rsync -a --exclude BOOTSTRAP.md /path/to/AgenticGoKit/agentkit-bootstrap/ .
+
+go test -race ./...     # expect: ok github.com/agenticgokit/agentkit
+
+git add -A
+git commit -m "feat: initial core — message IR, provider contract, typed tools and agents
+
+Establishes the contracts documented in docs/DESIGN.md: a multi-turn
+message IR, a four-method Provider interface with capability discovery,
+an Embedder kept separate from Provider, typed tools whose JSON schemas
+are derived from Go types, and a generic Agent[D, O] with a tool loop,
+structured output, and self-correcting retries.
+
+Includes agenttest for LLM-free testing, sentinel errors throughout, and
+build-time diagnostics as values rather than log lines."
+git push -u origin main
+```
+
+Then remove the staging copy from the AgenticGoKit repository:
+
+```bash
+cd /path/to/AgenticGoKit
+git rm -r agentkit-bootstrap
+git commit -m "chore: remove agentkit bootstrap staging directory (transplanted)"
+```
+
+## File the issues
+
+`ISSUES.md` holds 37 ready-to-file issues with front matter (title, type, milestone, labels). Either:
+
+```bash
+# with the gh CLI, from the agentkit repo root
+./scripts/file-issues.sh
+```
+
+or grant a Claude Code session access to `agenticgokit/agentkit` and ask it to file them from `ISSUES.md` — it will create the milestones and issues, and link the epics to their children.
+
+Create these milestones first (the script does it for you):
+
+| Milestone | Theme |
+|---|---|
+| v0.1 Core contracts | Real providers, streaming, conformance |
+| v0.2 Durable | Journal, interrupt/resume, fork |
+| v0.3 Workflows | Typed steps, fan-out, per-step policies |
+| v0.4 Multi-agent | Agents-as-tools, handoffs, guardrails, sessions |
+| v0.5 Dev loop | Registry, wire format, evals, MCP, prompts |
+
+## Repository settings worth setting on day one
+
+- Default branch `main`; require the CI check before merge.
+- Enable Issues and Discussions; disable Wiki and Projects until needed.
+- Description: *The typed, durable core of AgenticGoKit — build AI agents in Go.*
+- Topics: `go`, `golang`, `ai-agents`, `llm`, `agentic-ai`, `agents`, `mcp`.
+- Add a link from the AgenticGoKit README so the existing audience finds this repo.

--- a/agentkit-bootstrap/ISSUES.md
+++ b/agentkit-bootstrap/ISSUES.md
@@ -1,0 +1,637 @@
+# agentkit — issue backlog (ready to file)
+
+Each issue below is delimited by a line of `===`, with YAML front matter carrying the fields the GitHub API needs (`title`, `type`, `milestone`, `labels`) followed by the markdown body. This file is the source of record until the issues are filed; `scripts/file-issues` (or a single API pass) can consume it verbatim.
+
+Ordering reflects the intended milestone sequence. Design references point at `docs/DESIGN.md` in this repo and the analysis set in [AgenticGoKit](https://github.com/AgenticGoKit/AgenticGoKit) (`docs/CONSOLIDATED_REPORT.md`, `docs/DEVELOPER_FIRST_ROADMAP.md`).
+
+===
+---
+title: "Epic: v0.1 — lock the core contracts"
+type: Task
+milestone: "v0.1 Core contracts"
+labels: [epic]
+---
+Umbrella for the work that makes agentkit usable end to end against real models, and freezes the contracts everything else builds on.
+
+The contracts in `docs/DESIGN.md` (D1–D12) are deliberate and evidence-backed; they should not change casually after v0.1 because adapters, workflows, and durability all encode them.
+
+**In scope**
+- [ ] Streaming agent runs (`Agent.Stream`)
+- [ ] Reference provider adapter: OpenAI (proves the contract end to end)
+- [ ] Anthropic, Ollama, Gemini adapters
+- [ ] Generic `openai-compatible` adapter
+- [ ] Provider conformance test suite
+- [ ] Structured output: native and prompted modes
+- [ ] Parallel tool execution
+- [ ] Provider middleware (retry / rate limit / usage accounting)
+- [ ] OTel GenAI instrumentation
+
+**Definition of done**
+`go test -race ./...` green across core and every adapter module; a documented quickstart that runs against OpenAI, Anthropic, and Ollama unchanged except for two strings; zero third-party dependencies in the core module.
+
+===
+---
+title: "Streaming agent runs: Agent.Stream with agent-level events"
+type: Feature
+milestone: "v0.1 Core contracts"
+labels: [core, streaming]
+---
+`Provider.Stream` and the `Stream` cursor exist; the agent has no streaming entry point yet.
+
+**Scope**
+- `func (a *Agent[D, O]) Stream(ctx, input string, deps D) (RunStream, error)`.
+- Agent-level events, not raw provider passthrough: `StepStart`, `TextDelta`, `ReasoningDelta`, `ToolCallStart/Delta/Done`, `ToolResult`, `StepEnd`, `Done{Output O, Usage}`.
+- The tool loop runs inside the stream: tool calls execute and their results are emitted, then generation continues.
+- Terminal `Done` carries the typed output for structured runs.
+
+**Requirements that are non-negotiable** (each corresponds to a shipped bug in the previous generation, see `DEVELOPER_FIRST_ROADMAP.md` §1.2):
+- Cancelling the returned stream must cancel the in-flight provider request. A cancel that keeps generating tokens costs real money.
+- Every producer failure must be observable through `Err()`. A failed stream must never be indistinguishable from a successful one.
+- Terminal usage must be populated, so a streaming run reports the same accounting as a non-streaming one.
+- No protocol text leaks: if a fallback strategy encodes tool calls in text, that text must not reach the caller as content.
+
+**Acceptance**
+Tests using `agenttest` covering: mid-stream cancellation stops the provider; a provider error surfaces from `Err()` and not as a silent end; usage is present on `Done`; a tool call executes and its result appears before subsequent text.
+
+===
+---
+title: "Provider conformance test suite"
+type: Feature
+milestone: "v0.1 Core contracts"
+labels: [core, testing]
+---
+Small interfaces attract third-party implementations only when there is an objective definition of "correct". Ship one.
+
+**Scope**
+- New package `providertest` exporting `providertest.Run(t *testing.T, newProvider func() agentkit.Provider, opts ...)`.
+- Verifies: multi-turn message round-tripping; system message handling; tool definitions reaching the model and tool results being accepted back; explicit temperature 0 is honored; usage is populated on both paths; streaming emits deltas then exactly one terminal event; errors wrap `ErrProvider`; `Capabilities` is self-consistent (claims native tools ⇒ tool calls actually return `ToolCall` parts).
+- Opt-out flags for genuinely unsupported features, so an adapter declares gaps instead of failing.
+- Runs against `agenttest` in CI and against live providers behind a build tag.
+
+**Why**
+LangGraph's checkpointer ecosystem exists because the contract was tiny *and* conformance-tested. The same lever applies here.
+
+===
+---
+title: "OpenAI provider adapter (reference implementation)"
+type: Feature
+milestone: "v0.1 Core contracts"
+labels: [provider]
+---
+First real adapter; doubles as the worked example for every other one.
+
+**Scope**
+- Separate module `github.com/agenticgokit/agentkit/providers/openai` (core stays dependency-free, D12).
+- Full message IR translation including images, tool calls, and tool results.
+- Native tool calling and parallel tool calls.
+- Native structured output (`response_format` with JSON schema) wired to `OutputNative`.
+- Streaming with tool-call argument deltas and `stream_options.include_usage` so terminal usage is real.
+- `Capabilities` per model, including context window.
+- Prompt-caching token reporting mapped onto `Usage.CachedInputTokens`.
+- Passes `providertest`.
+
+**Notes**
+Base URL must be configurable — this adapter is also the substrate for the `openai-compatible` provider.
+
+===
+---
+title: "Anthropic provider adapter"
+type: Feature
+milestone: "v0.1 Core contracts"
+labels: [provider]
+---
+**Scope**
+- Module `providers/anthropic`.
+- System prompt as a top-level parameter, not a message.
+- `tool_use` / `tool_result` block translation, including the requirement that assistant tool-use blocks are echoed back verbatim on subsequent turns.
+- Extended thinking mapped to `Reasoning` parts, preserving `Signature` for turns that require it.
+- Prompt caching (`cache_control`) surfaced through `Usage.CachedInputTokens`.
+- No `Embedder` implementation — Anthropic has no embeddings API, and per D3 that is expressed by *not implementing the interface* rather than by a stub.
+- Passes `providertest`.
+
+===
+---
+title: "Ollama provider adapter"
+type: Feature
+milestone: "v0.1 Core contracts"
+labels: [provider]
+---
+**Scope**
+- Module `providers/ollama`.
+- Chat API with native tool calling; streaming tool calls where the server supports them.
+- `format` field wired to `OutputNative` for JSON-schema-constrained output.
+- Implements `Embedder` (`/api/embed`) with dimensions derived from the model.
+- Actionable errors: a missing model must tell the user to `ollama pull <model>`; an unreachable host must name the URL that was tried and suggest `ollama serve`.
+- Passes `providertest`.
+
+**Why the error requirement is in scope**
+Local-first is the first-five-minutes experience for most Go developers; a cryptic connection error there is a lost adopter.
+
+===
+---
+title: "Google Gemini provider adapter"
+type: Feature
+milestone: "v0.1 Core contracts"
+labels: [provider]
+---
+**Scope**
+- Module `providers/gemini`, speaking the native API (not an OpenAI compatibility shim).
+- `contents`/`parts` translation, function calling, `responseSchema` for structured output, multimodal input, and `Embedder` via the embedding models.
+- Long-context reporting in `Capabilities.ContextWindow`.
+- Passes `providertest`.
+
+**Why**
+Gemini is the largest provider with no adapter in the ecosystem today, and its multimodal and context-window strengths are exactly what an agent framework should be able to reach without a proxy.
+
+===
+---
+title: "Generic openai-compatible provider"
+type: Feature
+milestone: "v0.1 Core contracts"
+labels: [provider]
+---
+A first-class `openai-compatible` provider that takes a required base URL and speaks the OpenAI wire format.
+
+**Why this is the highest-leverage adapter**
+Most serving stacks and aggregators (vLLM, Together, Groq, Mistral, OpenRouter, LM Studio, llama.cpp, BentoML, MLflow gateways) expose OpenAI-compatible endpoints. One adapter covers all of them with zero new code per vendor, and it means a new vendor never blocks a user waiting for framework support.
+
+**Scope**
+- Explicit capability declaration, since compatibility varies: the caller states whether the endpoint supports tools/JSON mode, with conservative defaults and a `Diagnostic` when a requested feature is not declared.
+- Documented presets for common backends.
+- Clear naming: `openai` means api.openai.com semantics; `openai-compatible` means bring-your-own endpoint.
+
+===
+---
+title: "Structured output: native and prompted modes"
+type: Feature
+milestone: "v0.1 Core contracts"
+labels: [core]
+---
+`OutputTool` is implemented. `OutputNative` and `OutputPrompted` are declared but not honored end to end.
+
+**Scope**
+- `OutputNative`: pass the schema through `Request.Output` and parse the model's JSON response directly.
+- `OutputPrompted`: inject the schema into instructions, extract JSON from the reply defensively (fenced blocks, leading prose), and validate.
+- Validation failures feed the existing self-correction loop (D8) with a bounded budget rather than failing the run.
+- `WithOutputRetries(n)` to bound correction attempts.
+
+**Acceptance**
+Each mode covered by `agenttest` scripts, including a malformed-response path that recovers and one that exhausts the budget and returns `ErrNoOutput`.
+
+===
+---
+title: "Parallel tool execution with bounded concurrency"
+type: Feature
+milestone: "v0.1 Core contracts"
+labels: [core, performance]
+---
+When a model requests several independent tool calls in one turn, run them concurrently.
+
+**Scope**
+- `errgroup` fan-out bounded by a configurable limit (`WithMaxParallelTools(n)`, default e.g. 5).
+- Results appended in the model's original call order regardless of completion order, so transcripts stay deterministic.
+- First non-retryable tool error cancels siblings and aborts; retryable errors are collected per call.
+- Respect `Capabilities.ParallelTools`: when the provider cannot express parallel calls, this is simply never exercised.
+
+**Why**
+Three independent fetches currently serialize, tripling latency. This is precisely where Go should beat Python frameworks, and it is ~30 lines behind a clean tool interface.
+
+===
+---
+title: "Provider middleware: retry, rate limit, timeout, usage accounting"
+type: Feature
+milestone: "v0.1 Core contracts"
+labels: [core, reliability]
+---
+Cross-cutting reliability written once as `Provider` decorators, never re-implemented per adapter.
+
+**Scope**
+- `middleware.Retry(policy)` — exponential backoff with jitter, honoring `Retry-After`, retrying only classified-retryable errors.
+- `middleware.RateLimit(limiter)` — request and token budgets.
+- `middleware.Timeout(d)` — per-call deadline.
+- `middleware.Usage(recorder)` — per provider/model token and cost rollup, with user-supplied pricing (never hardcoded).
+- `middleware.Chain(base, ...)`.
+- Error classification (`rate_limited`, `overloaded`, `invalid_request`, `auth`, `timeout`) normalized across adapters, so retry policy is principled rather than string-matched.
+
+**Why in the core milestone**
+The previous generation shipped retry/rate-limit/circuit-breaker *configuration* that no code read. Building it as middleware from the start means the knobs exist only where behavior exists.
+
+===
+---
+title: "Provider fallback chain"
+type: Feature
+milestone: "v0.1 Core contracts"
+labels: [provider, reliability]
+---
+`fallback.New(primary, secondary, ...)` implementing `Provider`, trying each in order.
+
+**Scope**
+- Trigger on classified API errors by default; `FallbackOn(func(err error, resp *Response) bool)` to also trigger on response content (e.g. `StopFiltered`, `StopMaxTokens`).
+- Per-provider model and params preserved.
+- All failures joined with `errors.Join` so nothing is swallowed.
+- A `Diagnostic` when a fallback is used, so silent degradation to a weaker model is visible.
+
+**Effort/value**
+Pure decorator over an existing interface; makes provider resilience a one-liner.
+
+===
+---
+title: "OpenTelemetry instrumentation using GenAI semantic conventions"
+type: Feature
+milestone: "v0.1 Core contracts"
+labels: [core, observability]
+---
+Instrument runs with OTel spans following the **GenAI semantic conventions** (`gen_ai.*`), in a separate module so the core stays dependency-free.
+
+**Scope**
+- One CLIENT span per model call (`gen_ai.operation.name`, `gen_ai.system`, `gen_ai.request.model`, `gen_ai.usage.input_tokens`, `gen_ai.usage.output_tokens`, `gen_ai.response.finish_reasons`), one span per tool call, one parent span per run.
+- Opt-in content capture (prompts/responses) with a redaction hook.
+- Standard `OTEL_*` environment variables honored; endpoint configured with `WithEndpointURL` (a scheme-carrying URL passed to `WithEndpoint` silently produces a malformed target — the exact bug in the previous generation).
+- Header support so hosted backends are reachable.
+
+**Why the convention matters**
+Bespoke attribute names are invisible to every LLM observability backend. Speaking `gen_ai.*` means Langfuse, Braintrust, Datadog, Grafana, and Jaeger LLM views work with no adapter.
+
+===
+---
+title: "Embedder implementations and a store-facing contract"
+type: Feature
+milestone: "v0.1 Core contracts"
+labels: [provider, memory]
+---
+`Embedder` is defined (D3) but has no implementations.
+
+**Scope**
+- Implementations alongside their providers: OpenAI, Gemini, Ollama, plus a deterministic `agenttest` fake.
+- Every implementation reports true `Dimensions()`.
+- A helper that fails loudly when a configured store dimension disagrees with the embedder's — a mismatch silently corrupts a vector index, and detecting it at construction is cheap.
+- Explicitly no dummy/zero-vector implementation outside `agenttest`.
+
+===
+---
+title: "Epic: v0.2 — durable execution"
+type: Task
+milestone: "v0.2 Durable"
+labels: [epic, durability]
+---
+The strategic differentiator: nothing in the Go agent ecosystem offers durable agent runs, and Go is the language of durable execution (Temporal, DBOS, Restate, River all ship first-class Go SDKs).
+
+**Architecture decision to confirm first (see `docs/DESIGN.md` open question 1):** journal-skip, not event-history replay. On recovery the function is re-invoked from the top and completed steps return their journaled results. This imposes *no* determinism constraints on user code — plain goroutines, `time.Now`, and map iteration stay legal outside steps — which is why Temporal's model is explicitly not being copied.
+
+**In scope**
+- [ ] Journal + `Checkpointer` contract, SQLite-backed
+- [ ] LLM and tool calls auto-wrapped as steps
+- [ ] `Interrupt`/`Resume` for human-in-the-loop
+- [ ] Durable sleep and idempotency keys
+- [ ] Fork-from-step
+
+===
+---
+title: "Journal-skip durable execution engine over an embedded SQL journal"
+type: Feature
+milestone: "v0.2 Durable"
+labels: [durability]
+---
+**Scope**
+- Two tables — run status and step journal — on SQLite by default (a separate module; core stays dependency-free), Postgres as an alternative backend.
+- `Step[T](ctx, name string, fn func(context.Context) (T, error)) (T, error)`: the closure is where non-determinism lives; the result is journaled by `(runID, stepSeq)` and replayed on recovery. Three independent Go SDKs converged on this signature, which is strong evidence it is the right idiom.
+- `Checkpointer` interface kept deliberately small (put / put-writes / get / list / delete-thread), addressed by `(threadID, namespace, checkpointID)`, with pending-writes so successful parallel siblings are not re-executed after a partial failure.
+- Per-run durability mode: `Exit` (checkpoint at end), `Async` (background writer, default), `Sync` (write before proceeding).
+- Recovery scans for orphaned runs and resumes them.
+
+**Why a library, not a server**
+DBOS demonstrated a complete durable-execution engine as a plain library over SQL. Zero-infrastructure durability is a headline differentiator; requiring an orchestrator server would forfeit it.
+
+===
+---
+title: "Auto-wrap model and tool calls as durable steps"
+type: Feature
+milestone: "v0.2 Durable"
+labels: [durability]
+---
+Durability must be a builder option, not a different agent type.
+
+**Scope**
+- `agentkit.WithDurability(store)` — every model call, tool call, and (later) MCP round-trip becomes a journaled step keyed by agent name and call sequence.
+- The agent API is otherwise unchanged; the same code runs durably and non-durably.
+- Only serializable values cross a step boundary; a clear error names the offending value rather than failing at deserialize time.
+
+**Reference**
+PydanticAI's Temporal integration proved the ergonomic: users wrap nothing by hand.
+
+===
+---
+title: "Interrupt and Resume: durable human-in-the-loop"
+type: Feature
+milestone: "v0.2 Durable"
+labels: [durability, hitl]
+---
+Approval gates are the most-requested production agent feature and cannot be bolted on after the fact.
+
+**Scope**
+- `Interrupt[T](ctx, payload any) (T, error)` — suspends the run durably; the payload surfaces to the caller; `Resume(ctx, runID, value)` re-invokes the run, and the interrupt returns the recorded value.
+- Node re-execution semantics (the code before the interrupt runs again on resume) so no stack serialization is required — this is what makes the pattern implementable in Go at all.
+- A tool-level convenience: `WithToolApproval(func(ctx, ToolCall) (Decision, error))` gating on `ToolAnnotations.Destructive`.
+- Emit approval requests as ordinary events so any frontend can render them without framework-specific glue.
+
+===
+---
+title: "Durable timers, idempotency keys, and honest exactly-once semantics"
+type: Feature
+milestone: "v0.2 Durable"
+labels: [durability]
+---
+**Scope**
+- `Sleep(ctx, d)` that journals a wake deadline and survives restarts; cron scheduling for long-horizon agents.
+- A deterministic idempotency key per step attempt `(runID, stepSeq)`, surfaced to tools via context so they can pass it to APIs that deduplicate.
+- Documentation stating the guarantee precisely: step *results* are recorded exactly once, but a crash mid-step re-executes the body, so external side effects are at-least-once unless the callee deduplicates.
+- For database side effects, a transactional path where the write and the journal entry commit together.
+
+**Why the honesty matters**
+Every engine has this property; frameworks that imply otherwise cause data corruption in production. State it in the API docs, not a footnote.
+
+===
+---
+title: "Fork-from-step and run inspection"
+type: Feature
+milestone: "v0.2 Durable"
+labels: [durability, devex]
+---
+The journal is a debugger, not only a recovery mechanism.
+
+**Scope**
+- `ForkRun(ctx, runID string, fromStep int)` — start a copy of a run reusing journaled results before the fork point.
+- `ListRuns` / `GetRunSteps` for inspection.
+- Documented state/topology migration rules for runs that outlive a deploy, plus a boolean `Patch(ctx, "change-id")` for versioning in-flight runs (DBOS's distillation of Temporal's `GetVersion`, which is famously confusing).
+
+**Why it is disproportionately valuable here**
+Agent steps cost real money. "The agent derailed at tool call 7 — fork from 6 with a corrected prompt" avoids re-paying for steps 1–6, which no print-statement workflow can offer.
+
+===
+---
+title: "Epic: v0.3 — typed workflows"
+type: Task
+milestone: "v0.3 Workflows"
+labels: [epic, workflow]
+---
+Multi-step orchestration where step boundaries are type-checked at build time.
+
+**In scope**
+- [ ] `Step[In, Out]` with chainable composition
+- [ ] Dynamic fan-out (map-reduce over runtime collections)
+- [ ] Per-step policies: retry, timeout, cache, fallback
+- [ ] Graph validation and export before execution
+
+**Design constraint from prior art**
+Eino proves build-time type alignment works in Go; its own documentation concedes the concept load (four streaming paradigms, boxing rules) is a cost. Keep the public surface to `Invoke` and `Stream`, and let composition be chainable rather than error-returning at every `AddNode`.
+
+===
+---
+title: "Typed workflow steps with compile-time composition"
+type: Feature
+milestone: "v0.3 Workflows"
+labels: [workflow]
+---
+**Scope**
+- `Step[In, Out]` where an agent, a function, or a nested workflow can all be steps.
+- Chainable builder: `.Then`, `.Parallel`, `.Branch`, `.Loop`, `.Map`, terminating in a compile step that surfaces topology errors as values.
+- The output type of step N is checked against the input type of step N+1.
+- No stringly-typed data flow: fan-in produces a typed struct with named fields per dependency, so a step always knows which upstream produced what — the concatenate-with-newlines approach loses that information irrecoverably.
+- `Validate()` (cycles, unknown dependencies) and `Mermaid()`/`DOT()` export before any token is spent.
+- Identical semantics between the streaming and non-streaming entry points, enforced by a shared executor and tests that assert equivalence.
+
+===
+---
+title: "Dynamic fan-out: map-reduce over runtime collections"
+type: Feature
+milestone: "v0.3 Workflows"
+labels: [workflow]
+---
+The orchestrator-worker pattern — step A produces N items, each processed in parallel, results reduced — is currently impossible with a statically declared step list.
+
+**Scope**
+- A `Send`-style primitive: a router returns `[]Send[W]`, each invoking the target step with its own typed state; a reducer merges results on fan-in.
+- Bounded concurrency and per-branch error policy.
+- Streaming passthrough with branch attribution on every event.
+
+**Why Go wins here**
+This is `errgroup` plus a semaphore behind a typed API — a marquee demonstration that Go's concurrency is a real advantage over Python frameworks emulating it.
+
+===
+---
+title: "Per-step policies: retry, timeout, cache, fallback"
+type: Feature
+milestone: "v0.3 Workflows"
+labels: [workflow, reliability]
+---
+**Scope**
+- `Retry(policy)`, `Timeout(d)`, `OnError(Skip|Fail|Fallback(step))`, `Cache(ttl, keyFn)` attached per step.
+- Parallel branches: fail-fast cancellation of siblings, and `errors.Join` so *every* failure is reported rather than the first one.
+- Cached step results marked in metadata so a run is never mistaken for fresh.
+
+**Why cache is in scope early**
+The inner development loop is where a framework is judged: not re-paying for an expensive step while iterating on the one after it is a small feature with outsized delight.
+
+===
+---
+title: "Epic: v0.4 — multi-agent primitives"
+type: Task
+milestone: "v0.4 Multi-agent"
+labels: [epic, multi-agent]
+---
+The primitives the ecosystem has converged on, implemented once and composably.
+
+**In scope**
+- [ ] Agents as tools (primary composition currency)
+- [ ] Handoffs with typed payloads (when control must transfer)
+- [ ] Guardrails with tripwires, run concurrently
+- [ ] Sessions and scoped shared state
+
+===
+---
+title: "Agents as tools"
+type: Feature
+milestone: "v0.4 Multi-agent"
+labels: [multi-agent]
+---
+**Scope**
+- `func (a *Agent[D, O]) AsTool(name, description string, opts ...ToolOption) Tool` — the sub-agent's typed output becomes the tool result; its input schema is derived.
+- Optional output extractor for post-processing.
+- Sub-agent events pass through to the parent's stream with attribution.
+- Usage from sub-runs rolls up into the parent's accounting.
+
+**Why this over handoffs as the default**
+Eino converged on agent-as-tool and explicitly deprecated transfer-style handoffs; the parent keeps control and the composition currency stays uniform.
+
+===
+---
+title: "Handoffs with typed payloads and history filters"
+type: Feature
+milestone: "v0.4 Multi-agent"
+labels: [multi-agent]
+---
+For the triage/specialist pattern where control genuinely transfers.
+
+**Scope**
+- `Handoff(target, opts...)` producing an auto-generated `transfer_to_<name>` tool the model can call, carrying a schema-validated typed payload.
+- History filter controlling what the receiving agent sees.
+- A `Command{Update, Goto}` return shape so state update and routing are one primitive rather than two mechanisms.
+- Loop protection: a bounded transfer depth with a clear error.
+
+===
+---
+title: "Guardrails with tripwires, executed concurrently"
+type: Feature
+milestone: "v0.4 Multi-agent"
+labels: [multi-agent, safety]
+---
+**Scope**
+- Input, output, and tool-level guardrails: functions (often a small fast model) returning `(info, tripwire bool)`.
+- Input guardrails run **concurrently with** the main agent; a tripwire cancels the expensive run through context.
+- Tripwires produce a typed error identifying which guardrail fired.
+
+**Why Go's version is better than the original**
+The Python implementation of "run the cheap screen alongside the expensive call, cancel on trip" is awkward; in Go it is `errgroup` plus context cancellation, and cancellation actually propagates to the HTTP request.
+
+===
+---
+title: "Sessions and scoped shared state"
+type: Feature
+milestone: "v0.4 Multi-agent"
+labels: [multi-agent, memory]
+---
+**Scope**
+- A deliberately tiny `Session` interface — `Items(ctx, limit)`, `Append(ctx, items)`, `Pop(ctx)`, `Clear(ctx)` — so backends (SQLite, Postgres, Redis) are community-implementable. `Pop` exists to support undo/regenerate flows.
+- The runner prepends stored history and persists new turns, removing the manual message-threading boilerplate.
+- Scoped state with prefix semantics (`app:`, `user:`, session, `temp:`) so app config, user profile, and scratch space are one mechanism.
+- Instruction templating that reads from state.
+
+**Depends on** the message IR (D1); this is the feature that makes multi-turn worth having.
+
+===
+---
+title: "Epic: v0.5 — dev loop and ecosystem"
+type: Task
+milestone: "v0.5 Dev loop"
+labels: [epic, devex]
+---
+Adoption is won in the first hour. This milestone is about what a developer sees, runs, and debugs.
+
+**In scope**
+- [ ] Action registry (introspection substrate)
+- [ ] AI SDK v5 SSE wire format
+- [ ] Evals under `go test`
+- [ ] MCP client on the official Go SDK
+- [ ] Agent → MCP server export
+- [ ] `.prompt` files
+- [ ] `agk dev` playground integration
+
+===
+---
+title: "Action registry: one introspectable unit for agents, tools, workflows, prompts"
+type: Feature
+milestone: "v0.5 Dev loop"
+labels: [devex]
+---
+**Scope**
+- A small `Action` abstraction — name, kind, input schema, output schema, run function with an optional stream callback — that agents, tools, workflows, prompts, and evaluators all register as.
+- Registry lookup by `kind/name`.
+
+**Why this first in the milestone**
+Genkit's dev UI, HTTP serving, and eval runner are all cheap *because* everything is an Action: the UI is list-actions plus run-action. Building the registry before the playground makes the playground small; building it after makes it bespoke.
+
+===
+---
+title: "uistream: serve agent runs over the AI SDK v5 SSE protocol"
+type: Feature
+milestone: "v0.5 Dev loop"
+labels: [devex, streaming]
+---
+**Scope**
+- A `uistream` module: an `http.Handler` that serves any agent or workflow stream as AI SDK v5 typed SSE parts (`text-start`/`text-delta`/`text-end`, reasoning, `tool-input-start`/`-delta`/`-available`, `tool-output-available`, `start-step`/`finish-step`, `error`, `finish`, plus `data-*`).
+- Resumability: a pluggable `EventStore` with `Last-Event-ID` replay.
+- Heartbeats and correct flushing.
+
+**Why this format**
+It is the de facto frontend contract — any React/Svelte `useChat` frontend works against any backend that emits it, and other frameworks already ship v5-compatible emitters. Shipping it means a Go backend gets a modern chat UI for free, and it retires the hand-rolled WebSocket servers that examples currently duplicate.
+
+===
+---
+title: "Evals that run under go test"
+type: Feature
+milestone: "v0.5 Dev loop"
+labels: [devex, eval]
+---
+**Scope**
+- `agenteval` module: `Case[In, Out]`, `Dataset`, and `Run(t, dataset, task, scorers...)` executing as an ordinary Go test.
+- Scorers: exact/contains, embedding similarity, LLM judge, and custom `Scorer[In, Out]` returning 0..1 with a reason.
+- Trials (run each case N times, aggregate) and CI thresholds that fail the build.
+- Span-based assertions: "was tool X called before tool Y" against the run transcript, not only the final answer.
+- The same scorers usable against sampled production runs, not only offline datasets.
+
+**Positioning**
+Evals in the native test runner is the idiomatic Go differentiator — no separate harness, no YAML dialect to learn, `go test ./...` covers correctness *and* quality.
+
+===
+---
+title: "MCP client on the official modelcontextprotocol/go-sdk"
+type: Feature
+milestone: "v0.5 Dev loop"
+labels: [mcp, ecosystem]
+---
+**Scope**
+- Module `mcpclient` wrapping the official SDK (stable v1.0 with a compatibility guarantee): stdio and streamable HTTP, OAuth, elicitation, sampling, roots, resumable event stores.
+- MCP tools exposed as ordinary `Tool` values, so the agent loop is unaware of their origin.
+- Per-server configuration including command **args**, env, cwd, and credentials — `npx -y @modelcontextprotocol/server-filesystem /path` must be expressible.
+- Namespaced tool names (`server:tool`) with an explicit collision policy; never route an unknown tool to an arbitrary server.
+- Persistent sessions per server, not connect-per-call.
+- MCP tool annotations mapped onto `ToolAnnotations` so approval gating works on MCP tools.
+
+**Why adopt rather than maintain**
+Protocol churn is constant; the official SDK absorbs it, and vendoring a personal fork is a supply-chain and feature-lag risk.
+
+===
+---
+title: "Export an agent as an MCP server"
+type: Feature
+milestone: "v0.5 Dev loop"
+labels: [mcp, ecosystem]
+---
+**Scope**
+- `agent.AsMCPServer()` returning a server (stdio and streamable HTTP) that exposes the agent — and optionally its tools — to any MCP client.
+- Generate `server.json` for the official MCP registry.
+
+**Why**
+This is the distribution play: write a Go agent, one command makes it installable in Claude, VS Code, Cursor, and every other MCP-aware client. Combined with the client work, agentkit sits on both sides of the ecosystem's settled interop standard.
+
+===
+---
+title: "Prompts as versioned artifacts (.prompt files)"
+type: Feature
+milestone: "v0.5 Dev loop"
+labels: [devex]
+---
+**Scope**
+- `.prompt` files: YAML front matter (model, params, typed input/output schema) plus a template body.
+- Loaded from a directory or an `embed.FS` so single-binary deploys keep working.
+- Variants (`name.variant.prompt`) for A/B testing.
+- Typed access: `LookupPrompt[In, Out](name)` returning something executable with compile-time types.
+
+**Why**
+It answers "where do prompts live" with a versioned, reviewable artifact instead of string literals scattered through Go files — and community templates already keep prompts in separate files, so the convention is emerging organically.
+
+===
+---
+title: "Migration guide and compatibility story for AgenticGoKit v1beta users"
+type: Task
+milestone: "v0.1 Core contracts"
+labels: [docs, ecosystem]
+---
+**Scope**
+- A concept-mapping table (v1beta `Builder`/`Config`/`Agent` → agentkit `New[D, O]`/options; `Tool` map-args → typed `NewTool`; `Prompt{System,User}` → `[]Message`).
+- Honest statement of what agentkit does **not** yet cover, so nobody migrates into a gap.
+- A support policy for AgenticGoKit `v1beta` during the transition.
+- Cross-links in both repositories so the existing audience finds this one.
+
+**Why it belongs in the first milestone**
+A clean-slate core starts with zero users unless the existing ones are given a path. Writing the guide early also pressure-tests whether the new API genuinely covers the old use cases.

--- a/agentkit-bootstrap/LICENSE
+++ b/agentkit-bootstrap/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [2025] [Kunal Kushwaha]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/agentkit-bootstrap/README.md
+++ b/agentkit-bootstrap/README.md
@@ -1,0 +1,102 @@
+# agentkit
+
+**The typed, durable core of AgenticGoKit.**
+
+```go
+import agk "github.com/agenticgokit/agentkit"
+```
+
+agentkit is a ground-up core for building AI agents in Go: typed at compile time, honest at runtime, and durable by design. It is the foundation the [AgenticGoKit](https://github.com/AgenticGoKit/AgenticGoKit) ecosystem is converging on, and the module the [`agk`](https://github.com/AgenticGoKit/agk) CLI and [templates](https://github.com/agk-templates) will target.
+
+> **Status: pre-alpha.** The contracts in this repository (message IR, `Provider`, `Tool`, `Agent[D, O]`) are being locked deliberately, because everything else builds on them. Expect breaking changes until v0.1; expect no silent breakage after it.
+
+---
+
+## Why another core
+
+Go deserves an agent framework that plays to Go's strengths rather than transcribing a Python one. Four design commitments:
+
+**1. Typed end to end.** Agents are generic over their dependencies and output; tools are plain typed Go functions whose JSON schemas are *derived* from their signatures, so a schema can never drift from the code that runs.
+
+```go
+type SearchArgs struct {
+    Query string `json:"query" jsonschema:"description=Search terms"`
+    Limit int    `json:"limit,omitempty"`
+}
+
+search := agk.NewTool("search", "Search the web",
+    func(ctx context.Context, in SearchArgs) ([]Hit, error) {
+        db, _ := agk.DepsFrom[Deps](ctx)   // deps, not globals
+        return db.Search(ctx, in.Query, in.Limit)
+    }, agk.ReadOnly())
+
+agent, err := agk.New[Deps, Verdict](provider, "gpt-4o",
+    agk.WithSystem("You review pull requests."),
+    agk.WithTools(search),
+    agk.WithUsageLimits(agk.UsageLimits{MaxTotalTokens: 50_000}),
+)
+
+res, err := agent.Run(ctx, "Review PR 42", deps)
+fmt.Println(res.Output.Score)   // Verdict — no casting, no map[string]any
+```
+
+**2. Multi-turn from the first commit.** Conversations are `[]Message` with typed content parts (text, image, audio, reasoning, tool calls, tool results). Nothing is flattened into a string, so provider-native conversation handling, prompt caching, and correct tool-call protocols all remain available.
+
+**3. Fail loudly, in values.** Every error wraps a sentinel you can `errors.Is`. Non-fatal findings are `Diagnostic` values delivered to your code — not log lines you might never wire up. Nothing silently degrades: if a model can't call tools natively, you get a diagnostic, not a mystery.
+
+```go
+if errors.Is(err, agk.ErrMaxSteps) { ... }
+
+for _, d := range agent.Diagnostics() {
+    if d.Code == agk.DiagNoNativeTools { /* fail the deploy */ }
+}
+```
+
+**4. Testable without a network.** `agenttest` ships scripted providers so agents, tools, and loops are exercised in ordinary `go test` runs — no keys, no cost, no flakes.
+
+```go
+p := agenttest.NewScript(
+    agenttest.Calls(agenttest.Call("c1", "search", SearchArgs{Query: "go generics"})),
+    agenttest.Text("Here's what I found."),
+)
+agent, _ := agk.New[Deps, string](p, "test-model", agk.WithTools(search))
+res, _ := agent.Run(ctx, "search for me", deps)
+```
+
+---
+
+## What's here today
+
+| Component | State |
+|---|---|
+| Message IR (roles, typed content parts) | ✅ |
+| `Provider` interface + `Capabilities` discovery | ✅ contract |
+| `Embedder` (separate from `Provider` by design) | ✅ contract |
+| Typed tools + reflection-derived JSON Schema | ✅ |
+| `Agent[D, O]` with tool loop, structured output, self-correcting retries | ✅ |
+| Usage limits, step budgets | ✅ |
+| Sentinel errors, `StepError`/`ToolError` unwrapping | ✅ |
+| Build-time diagnostics | ✅ |
+| `agenttest` scripted provider | ✅ |
+| Provider adapters (OpenAI, Anthropic, Gemini, Ollama, Bedrock, …) | 🚧 |
+| Streaming agent runs | 🚧 contract defined |
+| Durable execution (journal, interrupt/resume, fork) | 🚧 |
+| Typed workflows | 🚧 |
+| Sessions, memory | 🚧 |
+
+See [`docs/DESIGN.md`](docs/DESIGN.md) for the decisions behind each contract, and the issue tracker for the sequenced plan.
+
+## Non-goals
+
+- **No `map[string]any` APIs.** If it can be typed, it is typed.
+- **No decorative configuration.** Every option this library accepts changes behavior, or it doesn't ship.
+- **No silent fallbacks.** Degradation is reported as a `Diagnostic` or an error, never absorbed.
+- **No fat dependency graph.** The core is standard library only; every integration is a separate module.
+
+## Relationship to AgenticGoKit
+
+[AgenticGoKit](https://github.com/AgenticGoKit/AgenticGoKit) is the current framework (`v1beta`); it remains supported while agentkit matures. agentkit is the clean-slate core its roadmap describes — same ecosystem, same CLI, no legacy surface. Migration guidance will land before v0.1.
+
+## License
+
+Apache 2.0

--- a/agentkit-bootstrap/agent.go
+++ b/agentkit-bootstrap/agent.go
@@ -1,0 +1,333 @@
+package agentkit
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+)
+
+// outputToolName is the synthetic tool through which structured output is
+// requested when the model has no native JSON mode.
+const outputToolName = "final_output"
+
+// Agent is a typed agent. D is the dependency type threaded through a run and
+// available to tools; O is the output type. Both are checked at compile time,
+// so a refactor of either surfaces as a build error rather than a runtime
+// surprise.
+//
+//	agent, err := agentkit.New[Deps, Verdict](provider, "gpt-4o",
+//	    agentkit.WithSystem("You review code."),
+//	    agentkit.WithTools(searchTool),
+//	)
+//	res, err := agent.Run(ctx, "Review PR 42", deps)
+//	fmt.Println(res.Output.Score) // Verdict, no casting
+type Agent[D any, O any] struct {
+	provider Provider
+	model    string
+
+	system   string
+	tools    *toolSet
+	params   Params
+	maxSteps int
+	limits   UsageLimits
+
+	structured   bool
+	outputFormat OutputFormat
+	outputSchema *Schema
+
+	diagnostics []Diagnostic
+}
+
+// Result is the outcome of a run.
+type Result[O any] struct {
+	// Output is the typed result of the run.
+	Output O
+	// Messages is the full transcript, including tool calls and results.
+	Messages []Message
+	// Usage is the accumulated token usage across every model call.
+	Usage Usage
+	// Steps is the number of model calls made.
+	Steps int
+}
+
+// UsageLimits bounds a run so a misbehaving loop cannot spend without limit.
+type UsageLimits struct {
+	MaxTotalTokens  int
+	MaxOutputTokens int
+}
+
+type options struct {
+	system   string
+	tools    []Tool
+	params   Params
+	maxSteps int
+	limits   UsageLimits
+	format   OutputFormat
+	onDiag   DiagnosticHandler
+}
+
+// Option configures an agent.
+type Option func(*options)
+
+// WithSystem sets the system instruction.
+func WithSystem(s string) Option { return func(o *options) { o.system = s } }
+
+// WithTools registers tools available to the model.
+func WithTools(ts ...Tool) Option {
+	return func(o *options) { o.tools = append(o.tools, ts...) }
+}
+
+// WithParams sets sampling parameters. Unset fields use the provider default;
+// an explicit zero is honored.
+func WithParams(p Params) Option { return func(o *options) { o.params = p } }
+
+// WithMaxSteps bounds how many model calls one run may make. Default is 10.
+func WithMaxSteps(n int) Option { return func(o *options) { o.maxSteps = n } }
+
+// WithUsageLimits bounds token spend for a run.
+func WithUsageLimits(l UsageLimits) Option { return func(o *options) { o.limits = l } }
+
+// WithOutputFormat selects how structured output is obtained. Default is
+// OutputTool, which works on nearly every tool-capable model.
+func WithOutputFormat(f OutputFormat) Option { return func(o *options) { o.format = f } }
+
+// WithDiagnosticHandler receives non-fatal findings produced while building
+// the agent. Diagnostics are also readable afterwards via Diagnostics.
+func WithDiagnosticHandler(h DiagnosticHandler) Option {
+	return func(o *options) { o.onDiag = h }
+}
+
+// New builds a typed agent.
+func New[D any, O any](p Provider, model string, opts ...Option) (*Agent[D, O], error) {
+	if p == nil {
+		return nil, fmt.Errorf("%w: provider is nil", ErrInvalidConfig)
+	}
+	if model == "" {
+		return nil, fmt.Errorf("%w: model is empty", ErrInvalidConfig)
+	}
+
+	o := options{maxSteps: 10, format: OutputTool}
+	for _, opt := range opts {
+		opt(&o)
+	}
+	if o.maxSteps <= 0 {
+		return nil, fmt.Errorf("%w: max steps must be positive, got %d", ErrInvalidConfig, o.maxSteps)
+	}
+
+	a := &Agent[D, O]{
+		provider:     p,
+		model:        model,
+		system:       o.system,
+		tools:        newToolSet(),
+		params:       o.params,
+		maxSteps:     o.maxSteps,
+		limits:       o.limits,
+		structured:   !isStringOutput[O](),
+		outputFormat: o.format,
+	}
+	for _, t := range o.tools {
+		if err := a.tools.add(t); err != nil {
+			return nil, err
+		}
+	}
+	if a.structured {
+		a.outputSchema = SchemaOf[O]()
+	}
+
+	a.checkCapabilities(o.onDiag)
+	return a, nil
+}
+
+// checkCapabilities compares what the agent needs against what the model
+// supports, reporting degraded modes instead of discovering them at runtime.
+func (a *Agent[D, O]) checkCapabilities(onDiag DiagnosticHandler) {
+	caps := a.provider.Capabilities(a.model)
+
+	if len(a.tools.order) > 0 && !caps.NativeTools {
+		a.report(onDiag, Diagnostic{
+			Severity: SevWarning,
+			Code:     DiagNoNativeTools,
+			Message: "model does not support native tool calling; tool results depend on the provider adapter's fallback strategy. " +
+				"Choose a tool-capable model, or remove the tools.",
+			Details: map[string]string{"provider": a.provider.Name(), "model": a.model},
+		})
+	}
+
+	if a.structured && a.outputFormat == OutputNative && !caps.NativeJSON {
+		a.outputFormat = OutputTool
+		a.report(onDiag, Diagnostic{
+			Severity: SevInfo,
+			Code:     DiagNoNativeJSON,
+			Message:  "model has no native JSON mode; falling back to tool-based structured output.",
+			Details:  map[string]string{"provider": a.provider.Name(), "model": a.model},
+		})
+	}
+}
+
+func (a *Agent[D, O]) report(onDiag DiagnosticHandler, d Diagnostic) {
+	a.diagnostics = append(a.diagnostics, d)
+	if onDiag != nil {
+		onDiag(d)
+	}
+}
+
+// Diagnostics returns non-fatal findings collected while building this agent.
+func (a *Agent[D, O]) Diagnostics() []Diagnostic { return a.diagnostics }
+
+// Run executes the agent against input, with deps available to tools via
+// DepsFrom.
+func (a *Agent[D, O]) Run(ctx context.Context, input string, deps D) (*Result[O], error) {
+	ctx = withDeps(ctx, deps)
+
+	msgs := make([]Message, 0, 4)
+	if a.system != "" {
+		msgs = append(msgs, System(a.system))
+	}
+	msgs = append(msgs, User(input))
+
+	var usage Usage
+
+	for step := 1; step <= a.maxSteps; step++ {
+		if err := ctx.Err(); err != nil {
+			return nil, &StepError{Step: step, Phase: "generate", Err: err}
+		}
+
+		resp, err := a.provider.Generate(ctx, a.request(msgs))
+		if err != nil {
+			return nil, &StepError{Step: step, Phase: "generate", Err: fmt.Errorf("%w: %v", ErrProvider, err)}
+		}
+		usage.Add(resp.Usage)
+		if err := a.limits.check(usage); err != nil {
+			return nil, &StepError{Step: step, Phase: "limits", Err: err}
+		}
+		msgs = append(msgs, resp.Message)
+
+		calls := resp.Message.ToolCalls()
+		if len(calls) == 0 {
+			if !a.structured {
+				return &Result[O]{
+					Output:   stringOutput[O](resp.Message.Text()),
+					Messages: msgs,
+					Usage:    usage,
+					Steps:    step,
+				}, nil
+			}
+			// Structured output was requested but the model answered in prose.
+			// Ask once more, explicitly, rather than failing the run.
+			msgs = append(msgs, User(fmt.Sprintf(
+				"Respond by calling the %q tool with the required fields.", outputToolName)))
+			continue
+		}
+
+		for _, c := range calls {
+			if a.structured && c.Name == outputToolName {
+				var out O
+				if err := json.Unmarshal(c.Input, &out); err != nil {
+					msgs = append(msgs, ToolResult(c.ID, c.Name,
+						fmt.Sprintf("output did not match the schema: %v", err), true))
+					continue
+				}
+				return &Result[O]{Output: out, Messages: msgs, Usage: usage, Steps: step}, nil
+			}
+
+			tool, ok := a.tools.get(c.Name)
+			if !ok {
+				// A hallucinated tool name is the model's mistake to correct,
+				// not a reason to abort the run.
+				msgs = append(msgs, ToolResult(c.ID, c.Name,
+					fmt.Sprintf("%v: %q", ErrToolNotFound, c.Name), true))
+				continue
+			}
+
+			out, err := tool.Invoke(ctx, c.Input)
+			if err != nil {
+				var retry *RetryError
+				if errors.As(err, &retry) {
+					msgs = append(msgs, ToolResult(c.ID, c.Name, retry.Message, true))
+					continue
+				}
+				return nil, &StepError{Step: step, Phase: "tool", Err: &ToolError{Tool: c.Name, Err: err}}
+			}
+			msgs = append(msgs, ToolResult(c.ID, c.Name, string(out), false))
+		}
+	}
+
+	return nil, fmt.Errorf("%w: %d steps without a final answer", ErrMaxSteps, a.maxSteps)
+}
+
+func (a *Agent[D, O]) request(msgs []Message) Request {
+	req := Request{
+		Model:    a.model,
+		Messages: msgs,
+		Tools:    a.tools.defs(),
+		Params:   a.params,
+	}
+	if a.structured {
+		switch a.outputFormat {
+		case OutputNative:
+			req.Output = &OutputSpec{
+				Format: OutputNative,
+				Name:   outputToolName,
+				Schema: mustJSON(a.outputSchema),
+			}
+		default:
+			req.Tools = append(req.Tools, ToolDef{
+				Name:        outputToolName,
+				Description: "Return the final answer in the required structure. Call this when you are done.",
+				InputSchema: a.outputSchema,
+			})
+		}
+	}
+	return req
+}
+
+func (l UsageLimits) check(u Usage) error {
+	if l.MaxTotalTokens > 0 && u.Total() > l.MaxTotalTokens {
+		return fmt.Errorf("%w: %d total tokens exceeds limit %d", ErrUsageLimit, u.Total(), l.MaxTotalTokens)
+	}
+	if l.MaxOutputTokens > 0 && u.OutputTokens > l.MaxOutputTokens {
+		return fmt.Errorf("%w: %d output tokens exceeds limit %d", ErrUsageLimit, u.OutputTokens, l.MaxOutputTokens)
+	}
+	return nil
+}
+
+// depsKey is unexported so only this package can put deps in a context.
+type depsKey struct{}
+
+func withDeps[D any](ctx context.Context, deps D) context.Context {
+	return context.WithValue(ctx, depsKey{}, deps)
+}
+
+// DepsFrom retrieves the dependencies for the current run. Tools use it to
+// reach the database handles, clients, and configuration a run was given,
+// without globals.
+func DepsFrom[D any](ctx context.Context) (D, bool) {
+	d, ok := ctx.Value(depsKey{}).(D)
+	return d, ok
+}
+
+// isStringOutput reports whether O is string, in which case the model's text
+// is the answer and no output schema is needed.
+func isStringOutput[O any]() bool {
+	var zero O
+	_, ok := any(zero).(string)
+	return ok
+}
+
+// stringOutput converts text to O when O is string; otherwise the zero value.
+func stringOutput[O any](text string) O {
+	var out O
+	if p, ok := any(&out).(*string); ok {
+		*p = text
+	}
+	return out
+}
+
+func mustJSON(v any) []byte {
+	b, err := json.Marshal(v)
+	if err != nil {
+		panic("agentkit: marshal failed: " + err.Error())
+	}
+	return b
+}

--- a/agentkit-bootstrap/agent_test.go
+++ b/agentkit-bootstrap/agent_test.go
@@ -1,0 +1,374 @@
+package agentkit_test
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/agenticgokit/agentkit"
+	"github.com/agenticgokit/agentkit/agenttest"
+)
+
+type deps struct {
+	Caller string
+}
+
+type searchArgs struct {
+	Query string `json:"query" jsonschema:"description=Search terms"`
+	Limit int    `json:"limit,omitempty"`
+}
+
+type hit struct {
+	Title string `json:"title"`
+}
+
+type verdict struct {
+	Score  int    `json:"score" jsonschema:"description=0 to 100"`
+	Reason string `json:"reason"`
+}
+
+func TestRunTextOutput(t *testing.T) {
+	p := agenttest.NewScript(agenttest.Text("hello there"))
+
+	agent, err := agentkit.New[deps, string](p, "test-model",
+		agentkit.WithSystem("be brief"))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	res, err := agent.Run(context.Background(), "hi", deps{Caller: "alice"})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.Output != "hello there" {
+		t.Errorf("Output = %q, want %q", res.Output, "hello there")
+	}
+	if res.Steps != 1 {
+		t.Errorf("Steps = %d, want 1", res.Steps)
+	}
+	if res.Usage.Total() == 0 {
+		t.Error("Usage not accumulated")
+	}
+
+	req, _ := p.LastRequest()
+	if len(req.Messages) != 2 || req.Messages[0].Role != agentkit.RoleSystem {
+		t.Errorf("expected system+user messages, got %d", len(req.Messages))
+	}
+}
+
+func TestRunExecutesToolAndFeedsResultBack(t *testing.T) {
+	var gotArgs searchArgs
+	var gotCaller string
+
+	tool := agentkit.NewTool("search", "Search the web",
+		func(ctx context.Context, in searchArgs) ([]hit, error) {
+			gotArgs = in
+			if d, ok := agentkit.DepsFrom[deps](ctx); ok {
+				gotCaller = d.Caller
+			}
+			return []hit{{Title: "result one"}}, nil
+		}, agentkit.ReadOnly())
+
+	p := agenttest.NewScript(
+		agenttest.Calls(agenttest.Call("c1", "search", searchArgs{Query: "go generics", Limit: 5})),
+		agenttest.Text("found it"),
+	)
+
+	agent, err := agentkit.New[deps, string](p, "test-model", agentkit.WithTools(tool))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	res, err := agent.Run(context.Background(), "search for me", deps{Caller: "alice"})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+
+	if gotArgs.Query != "go generics" || gotArgs.Limit != 5 {
+		t.Errorf("tool received %+v, want query/limit from the call", gotArgs)
+	}
+	// Deps must reach tools without globals.
+	if gotCaller != "alice" {
+		t.Errorf("DepsFrom in tool = %q, want %q", gotCaller, "alice")
+	}
+	if res.Output != "found it" {
+		t.Errorf("Output = %q", res.Output)
+	}
+	if res.Steps != 2 {
+		t.Errorf("Steps = %d, want 2", res.Steps)
+	}
+
+	// The second request must carry the tool result back to the model.
+	reqs := p.Requests()
+	if len(reqs) != 2 {
+		t.Fatalf("expected 2 model calls, got %d", len(reqs))
+	}
+	var sawToolResult bool
+	for _, m := range reqs[1].Messages {
+		if m.Role == agentkit.RoleTool {
+			sawToolResult = true
+		}
+	}
+	if !sawToolResult {
+		t.Error("second request did not include the tool result")
+	}
+}
+
+func TestStructuredOutput(t *testing.T) {
+	p := agenttest.NewScript(
+		agenttest.Calls(agenttest.Call("c1", "final_output", verdict{Score: 87, Reason: "solid"})),
+	)
+
+	agent, err := agentkit.New[deps, verdict](p, "test-model")
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	res, err := agent.Run(context.Background(), "review this", deps{})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.Output.Score != 87 || res.Output.Reason != "solid" {
+		t.Errorf("Output = %+v, want the scripted verdict", res.Output)
+	}
+
+	// The output schema must be advertised to the model.
+	req, _ := p.LastRequest()
+	var found bool
+	for _, d := range req.Tools {
+		if d.Name == "final_output" {
+			found = true
+			if d.InputSchema == nil || d.InputSchema.Properties["score"] == nil {
+				t.Error("final_output schema missing derived properties")
+			}
+		}
+	}
+	if !found {
+		t.Error("final_output tool was not offered to the model")
+	}
+}
+
+func TestInvalidToolArgsAreReturnedToModelForCorrection(t *testing.T) {
+	calls := 0
+	tool := agentkit.NewTool("search", "Search",
+		func(ctx context.Context, in searchArgs) ([]hit, error) {
+			calls++
+			return nil, nil
+		})
+
+	// First call sends a string where an object is required.
+	bad := agentkit.ToolCall{ID: "c1", Name: "search", Input: json.RawMessage(`"not an object"`)}
+	p := agenttest.NewScript(
+		agenttest.Calls(bad),
+		agenttest.Text("recovered"),
+	)
+
+	agent, _ := agentkit.New[deps, string](p, "test-model", agentkit.WithTools(tool))
+	res, err := agent.Run(context.Background(), "go", deps{})
+	if err != nil {
+		t.Fatalf("Run should recover from bad args, got: %v", err)
+	}
+	if calls != 0 {
+		t.Errorf("tool body ran %d times with invalid args, want 0", calls)
+	}
+	if res.Output != "recovered" {
+		t.Errorf("Output = %q", res.Output)
+	}
+
+	// The correction must have been sent back as an error tool result.
+	reqs := p.Requests()
+	var sawError bool
+	for _, m := range reqs[len(reqs)-1].Messages {
+		for _, part := range m.Parts {
+			if to, ok := part.(agentkit.ToolOutput); ok && to.IsError {
+				sawError = true
+			}
+		}
+	}
+	if !sawError {
+		t.Error("validation failure was not returned to the model")
+	}
+}
+
+func TestRetryErrorFromToolIsSelfCorrecting(t *testing.T) {
+	tool := agentkit.NewTool("lookup", "Look up a person",
+		func(ctx context.Context, in searchArgs) (string, error) {
+			if in.Query == "bob" {
+				return "", agentkit.Retry("use a full name, not %q", in.Query)
+			}
+			return "Bob Smith, engineer", nil
+		})
+
+	p := agenttest.NewScript(
+		agenttest.Calls(agenttest.Call("c1", "lookup", searchArgs{Query: "bob"})),
+		agenttest.Calls(agenttest.Call("c2", "lookup", searchArgs{Query: "bob smith"})),
+		agenttest.Text("done"),
+	)
+
+	agent, _ := agentkit.New[deps, string](p, "test-model", agentkit.WithTools(tool))
+	res, err := agent.Run(context.Background(), "look up bob", deps{})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.Steps != 3 {
+		t.Errorf("Steps = %d, want 3 (retry loop)", res.Steps)
+	}
+}
+
+func TestUnknownToolDoesNotAbortRun(t *testing.T) {
+	p := agenttest.NewScript(
+		agenttest.Calls(agenttest.Call("c1", "nonexistent", map[string]string{})),
+		agenttest.Text("ok"),
+	)
+	agent, _ := agentkit.New[deps, string](p, "test-model")
+
+	res, err := agent.Run(context.Background(), "go", deps{})
+	if err != nil {
+		t.Fatalf("hallucinated tool name should be correctable, got: %v", err)
+	}
+	if res.Output != "ok" {
+		t.Errorf("Output = %q", res.Output)
+	}
+}
+
+func TestMaxStepsIsEnforced(t *testing.T) {
+	tool := agentkit.NewTool("loop", "Loops forever",
+		func(ctx context.Context, in searchArgs) (string, error) { return "again", nil })
+
+	steps := make([]agentkit.Response, 10)
+	for i := range steps {
+		steps[i] = agenttest.Calls(agenttest.Call("c", "loop", searchArgs{Query: "x"}))
+	}
+	p := agenttest.NewScript(steps...)
+
+	agent, _ := agentkit.New[deps, string](p, "test-model",
+		agentkit.WithTools(tool), agentkit.WithMaxSteps(3))
+
+	_, err := agent.Run(context.Background(), "go", deps{})
+	if !errors.Is(err, agentkit.ErrMaxSteps) {
+		t.Errorf("err = %v, want ErrMaxSteps", err)
+	}
+}
+
+func TestUsageLimitStopsRun(t *testing.T) {
+	p := agenttest.NewScript(agenttest.Text("hi"))
+	agent, _ := agentkit.New[deps, string](p, "test-model",
+		agentkit.WithUsageLimits(agentkit.UsageLimits{MaxTotalTokens: 1}))
+
+	_, err := agent.Run(context.Background(), "go", deps{})
+	if !errors.Is(err, agentkit.ErrUsageLimit) {
+		t.Errorf("err = %v, want ErrUsageLimit", err)
+	}
+}
+
+func TestProviderErrorsWrapSentinelAndStep(t *testing.T) {
+	p := agenttest.NewScript() // exhausted immediately
+	agent, _ := agentkit.New[deps, string](p, "test-model")
+
+	_, err := agent.Run(context.Background(), "go", deps{})
+	if !errors.Is(err, agentkit.ErrProvider) {
+		t.Errorf("err = %v, want it to wrap ErrProvider", err)
+	}
+	var se *agentkit.StepError
+	if !errors.As(err, &se) {
+		t.Errorf("err = %v, want a *StepError identifying the failing step", err)
+	}
+}
+
+func TestParamsCarryExplicitZeroTemperature(t *testing.T) {
+	p := agenttest.NewScript(agenttest.Text("ok"))
+	zero := float32(0)
+	agent, _ := agentkit.New[deps, string](p, "test-model",
+		agentkit.WithParams(agentkit.Params{Temperature: &zero}))
+
+	if _, err := agent.Run(context.Background(), "go", deps{}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	req, _ := p.LastRequest()
+	if req.Params.Temperature == nil {
+		t.Fatal("Temperature was dropped; explicit 0 must reach the provider")
+	}
+	if *req.Params.Temperature != 0 {
+		t.Errorf("Temperature = %v, want explicit 0", *req.Params.Temperature)
+	}
+}
+
+func TestCapabilityGapProducesDiagnostic(t *testing.T) {
+	p := agenttest.NewScript(agenttest.Text("ok"))
+	p.Caps = &agentkit.Capabilities{NativeTools: false, Streaming: true}
+
+	tool := agentkit.NewTool("search", "Search",
+		func(ctx context.Context, in searchArgs) (string, error) { return "", nil })
+
+	var handled []agentkit.Diagnostic
+	agent, err := agentkit.New[deps, string](p, "weak-model",
+		agentkit.WithTools(tool),
+		agentkit.WithDiagnosticHandler(func(d agentkit.Diagnostic) { handled = append(handled, d) }))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	if len(agent.Diagnostics()) == 0 {
+		t.Fatal("tools on a non-tool-calling model produced no diagnostic")
+	}
+	if len(handled) == 0 {
+		t.Error("diagnostic handler was not called")
+	}
+	if agent.Diagnostics()[0].Code != agentkit.DiagNoNativeTools {
+		t.Errorf("code = %s, want %s", agent.Diagnostics()[0].Code, agentkit.DiagNoNativeTools)
+	}
+}
+
+func TestCleanConfigProducesNoDiagnostics(t *testing.T) {
+	p := agenttest.NewScript(agenttest.Text("ok"))
+	agent, _ := agentkit.New[deps, string](p, "good-model")
+	if d := agent.Diagnostics(); len(d) != 0 {
+		t.Errorf("clean config produced diagnostics: %+v", d)
+	}
+}
+
+func TestDuplicateToolIsRejectedAtBuild(t *testing.T) {
+	mk := func() agentkit.Tool {
+		return agentkit.NewTool("search", "Search",
+			func(ctx context.Context, in searchArgs) (string, error) { return "", nil })
+	}
+	p := agenttest.NewScript()
+	_, err := agentkit.New[deps, string](p, "m", agentkit.WithTools(mk(), mk()))
+	if !errors.Is(err, agentkit.ErrInvalidConfig) {
+		t.Errorf("err = %v, want ErrInvalidConfig for a duplicate tool name", err)
+	}
+	if err != nil && !strings.Contains(err.Error(), "search") {
+		t.Errorf("error should name the duplicated tool, got: %v", err)
+	}
+}
+
+func TestStreamReplaysEvents(t *testing.T) {
+	p := agenttest.NewScript(agenttest.Text("streamed"))
+	s, err := p.Stream(context.Background(), agentkit.Request{Model: "m"})
+	if err != nil {
+		t.Fatalf("Stream: %v", err)
+	}
+	defer s.Close()
+
+	var text strings.Builder
+	var done bool
+	for s.Next() {
+		switch e := s.Event().(type) {
+		case agentkit.TextDelta:
+			text.WriteString(e.Text)
+		case agentkit.Done:
+			done = true
+		}
+	}
+	if err := s.Err(); err != nil {
+		t.Fatalf("stream error: %v", err)
+	}
+	if text.String() != "streamed" {
+		t.Errorf("streamed text = %q", text.String())
+	}
+	if !done {
+		t.Error("stream ended without a Done event")
+	}
+}

--- a/agentkit-bootstrap/agenttest/agenttest.go
+++ b/agentkit-bootstrap/agenttest/agenttest.go
@@ -1,0 +1,162 @@
+// Package agenttest provides LLM-free test doubles so agents, tools, and
+// workflows can be tested in ordinary `go test` runs with no network, no API
+// keys, and no cost.
+package agenttest
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"sync"
+
+	"github.com/agenticgokit/agentkit"
+)
+
+// Script is a Provider that replays a fixed sequence of responses and records
+// every request it received, so tests can assert on what the agent actually
+// sent to the model.
+type Script struct {
+	mu    sync.Mutex
+	steps []agentkit.Response
+	next  int
+	reqs  []agentkit.Request
+
+	// Caps is returned by Capabilities. The zero value reports a fully
+	// capable model; set fields to exercise degraded paths.
+	Caps *agentkit.Capabilities
+}
+
+// NewScript returns a provider that returns the given responses in order.
+func NewScript(steps ...agentkit.Response) *Script {
+	return &Script{steps: steps}
+}
+
+// Text is a response containing only assistant text.
+func Text(s string) agentkit.Response {
+	return agentkit.Response{
+		Message:    agentkit.Assistant(s),
+		StopReason: agentkit.StopEndTurn,
+		Usage:      agentkit.Usage{InputTokens: 10, OutputTokens: 5},
+	}
+}
+
+// Calls is a response in which the model requests one or more tool calls.
+func Calls(calls ...agentkit.ToolCall) agentkit.Response {
+	parts := make([]agentkit.Part, 0, len(calls))
+	for _, c := range calls {
+		parts = append(parts, c)
+	}
+	return agentkit.Response{
+		Message:    agentkit.Message{Role: agentkit.RoleAssistant, Parts: parts},
+		StopReason: agentkit.StopToolUse,
+		Usage:      agentkit.Usage{InputTokens: 10, OutputTokens: 5},
+	}
+}
+
+// Call builds a tool call whose arguments are the JSON encoding of args.
+func Call(id, name string, args any) agentkit.ToolCall {
+	raw, err := json.Marshal(args)
+	if err != nil {
+		panic("agenttest: cannot marshal tool args: " + err.Error())
+	}
+	return agentkit.ToolCall{ID: id, Name: name, Input: raw}
+}
+
+// Name implements agentkit.Provider.
+func (s *Script) Name() string { return "agenttest.Script" }
+
+// Generate returns the next scripted response.
+func (s *Script) Generate(ctx context.Context, req agentkit.Request) (*agentkit.Response, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	s.reqs = append(s.reqs, req)
+	if s.next >= len(s.steps) {
+		return nil, fmt.Errorf("agenttest: script exhausted after %d responses; the agent made more model calls than the test scripted", len(s.steps))
+	}
+	resp := s.steps[s.next]
+	s.next++
+	return &resp, nil
+}
+
+// Stream replays the next scripted response as a stream of events.
+func (s *Script) Stream(ctx context.Context, req agentkit.Request) (agentkit.Stream, error) {
+	resp, err := s.Generate(ctx, req)
+	if err != nil {
+		return nil, err
+	}
+
+	var events []agentkit.Event
+	for _, p := range resp.Message.Parts {
+		switch v := p.(type) {
+		case agentkit.Text:
+			events = append(events, agentkit.TextDelta{Text: v.Text})
+		case agentkit.Reasoning:
+			events = append(events, agentkit.ReasoningDelta{Text: v.Text})
+		case agentkit.ToolCall:
+			events = append(events,
+				agentkit.ToolCallStart{ID: v.ID, Name: v.Name},
+				agentkit.ToolCallDelta{ID: v.ID, InputJSON: string(v.Input)},
+				agentkit.ToolCallDone{ID: v.ID, Input: v.Input},
+			)
+		}
+	}
+	events = append(events, agentkit.Done{StopReason: resp.StopReason, Usage: resp.Usage})
+	return &sliceStream{events: events}, nil
+}
+
+// Capabilities reports a fully capable model unless Caps is set.
+func (s *Script) Capabilities(model string) agentkit.Capabilities {
+	if s.Caps != nil {
+		return *s.Caps
+	}
+	return agentkit.Capabilities{
+		NativeTools:     true,
+		ParallelTools:   true,
+		NativeJSON:      true,
+		Streaming:       true,
+		Input:           []agentkit.Modality{agentkit.ModalityText},
+		ContextWindow:   128000,
+		MaxOutputTokens: 4096,
+	}
+}
+
+// Requests returns every request the agent sent, in order.
+func (s *Script) Requests() []agentkit.Request {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	out := make([]agentkit.Request, len(s.reqs))
+	copy(out, s.reqs)
+	return out
+}
+
+// LastRequest returns the most recent request, or false if none was made.
+func (s *Script) LastRequest() (agentkit.Request, bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if len(s.reqs) == 0 {
+		return agentkit.Request{}, false
+	}
+	return s.reqs[len(s.reqs)-1], true
+}
+
+// sliceStream replays a fixed event slice.
+type sliceStream struct {
+	events []agentkit.Event
+	i      int
+	cur    agentkit.Event
+	closed bool
+}
+
+func (s *sliceStream) Next() bool {
+	if s.closed || s.i >= len(s.events) {
+		return false
+	}
+	s.cur = s.events[s.i]
+	s.i++
+	return true
+}
+
+func (s *sliceStream) Event() agentkit.Event { return s.cur }
+func (s *sliceStream) Err() error            { return nil }
+func (s *sliceStream) Close() error          { s.closed = true; return nil }

--- a/agentkit-bootstrap/diagnostics.go
+++ b/agentkit-bootstrap/diagnostics.go
@@ -1,0 +1,48 @@
+package agentkit
+
+// Build-time diagnostics.
+//
+// Non-fatal findings are values, not log lines. A framework that only logs a
+// problem is invisible to any consumer that wires its own logger, so anything
+// worth telling a developer is returned where code can act on it.
+
+// Severity classifies a diagnostic.
+type Severity string
+
+const (
+	// SevInfo is expected behavior worth knowing about.
+	SevInfo Severity = "info"
+	// SevWarning is probably-unintended configuration that still works.
+	SevWarning Severity = "warning"
+	// SevError is a degraded mode: the agent runs, but a feature will not
+	// behave as advertised until it is fixed.
+	SevError Severity = "error"
+)
+
+// DiagnosticCode identifies a finding for programmatic handling.
+type DiagnosticCode string
+
+const (
+	// DiagNoNativeTools: tools are registered but the model cannot call them
+	// natively, so a fallback strategy is in use.
+	DiagNoNativeTools DiagnosticCode = "NO_NATIVE_TOOLS"
+
+	// DiagNoNativeJSON: structured output was requested but the model has no
+	// native JSON mode, so a tool or prompted strategy is in use.
+	DiagNoNativeJSON DiagnosticCode = "NO_NATIVE_JSON"
+
+	// DiagModalityUnsupported: the request carries content the model cannot
+	// accept.
+	DiagModalityUnsupported DiagnosticCode = "MODALITY_UNSUPPORTED"
+)
+
+// Diagnostic is a non-fatal finding produced while building an agent.
+type Diagnostic struct {
+	Severity Severity          `json:"severity"`
+	Code     DiagnosticCode    `json:"code"`
+	Message  string            `json:"message"`
+	Details  map[string]string `json:"details,omitempty"`
+}
+
+// DiagnosticHandler receives diagnostics as they are produced.
+type DiagnosticHandler func(Diagnostic)

--- a/agentkit-bootstrap/docs/DESIGN.md
+++ b/agentkit-bootstrap/docs/DESIGN.md
@@ -1,0 +1,100 @@
+# agentkit design decisions
+
+Every entry records a decision, the reasoning, and the alternative rejected. These are the contracts everything else builds on, so they are worth arguing about now and not later.
+
+Evidence for the "learned from" notes lives in the AgenticGoKit analysis set: `docs/CONSOLIDATED_REPORT.md`, `docs/AGNOSTIC_FRAMEWORK_ANALYSIS.md`, and `docs/DEVELOPER_FIRST_ROADMAP.md` in that repository.
+
+---
+
+## D1. Messages, not a system/user pair
+
+**Decision.** A call takes `[]Message`, each with a `Role` and typed `[]Part` (text, image, audio, reasoning, tool call, tool result).
+
+**Why.** Anything less makes multi-turn a lie. The previous generation modeled a call as `Prompt{System, User string}` and simulated conversation by concatenating prior output and tool results into the next user string. That defeats provider-side conversation handling and prompt caching, degrades long-run quality, and makes correct native tool loops impossible — providers require the assistant's `tool_use` and the matching `tool_result` echoed back in structure, not prose.
+
+**Rejected.** "Add a `History []string` field later." Retrofitting message structure through a stringly-typed core touches every adapter anyway; the cost is the same now and the damage is smaller.
+
+## D2. Provider is small; capabilities are discoverable
+
+**Decision.** `Provider` has four methods: `Name`, `Generate`, `Stream`, `Capabilities`. `Capabilities(model)` reports native tools, native JSON, streaming, modalities, context window.
+
+**Why.** A small interface is implementable by third parties without depending on internals, and lets cross-cutting concerns (retry, rate limit, fallback, cost accounting, caching) be written *once* as decorators rather than N times inside adapters. Capability discovery exists so the runtime branches deliberately: when tools are registered on a model that can't call them, the developer gets a `Diagnostic`, not a mysteriously toolless agent.
+
+**Rejected.** Capability flags inferred from model-name string matching. Model names change faster than any table can track, and the failure mode is silent.
+
+## D3. Embedder is not Provider
+
+**Decision.** Embeddings live behind a separate `Embedder` interface with an explicit `Dimensions()`.
+
+**Why.** Learned the hard way: when `Embeddings()` was part of the model interface, providers without an embeddings API (Anthropic) had to stub it, and one stub returned zero vectors — semantic search silently returned meaningless results with no error. Separating the interfaces makes "this provider cannot embed" a compile-time fact instead of a runtime lie. `Dimensions()` exists so a store/model mismatch is caught before the first write, not after a corrupted index.
+
+## D4. Sampling parameters are pointers
+
+**Decision.** `Params` fields are `*float32` / `*int`.
+
+**Why.** Temperature 0 is a legitimate, common setting (determinism, evals). With value types, "unset" and "zero" are the same bit pattern, so every layer guesses — and the previous generation guessed wrong in three separate places, silently rewriting explicit zeros and defaulting `MaxTokens` to 150. Pointers make intent unambiguous end to end.
+
+## D5. Tools are typed functions; schemas are derived
+
+**Decision.** `NewTool[In, Out](name, desc, fn)` derives both input and output JSON Schema from the Go types via reflection.
+
+**Why.** A hand-written schema beside a Go function is drift waiting to happen, and the fallback for tools without schemas — a single string field named `input` — actively teaches models to double-wrap their arguments (the previous generation shipped a normalization hack to undo its own fallback). Deriving from the signature makes the two impossible to disagree. Output schemas are derived too, so contract drift is catchable at the boundary.
+
+**Rejected.** Requiring an external schema library in the core. Reflection over `json` + `jsonschema` tags covers the common cases with zero dependencies; a richer generator can be layered in a separate module.
+
+## D6. Dependencies travel in context, tools stay non-generic
+
+**Decision.** `Run(ctx, input, deps D)` stores deps in the context; tools retrieve them with `DepsFrom[D](ctx)`.
+
+**Why.** Typed dependency injection without globals, and without forcing every tool constructor and option to carry `[D]` type parameters — which would make every call site verbose (`WithTool[Deps, Out](...)`). The trade-off is that deps retrieval is checked at runtime, not compile time; it is contained to one call, returns `(D, bool)`, and keeps the common path clean.
+
+## D7. Structured output is declared once, obtained three ways
+
+**Decision.** `Agent[D, O]` where `O` is non-string implies structured output. *How* it's obtained is separate: `OutputTool` (schema as a tool call — the default, works nearly everywhere), `OutputNative` (provider JSON schema), `OutputPrompted` (schema in the prompt).
+
+**Why.** What you want and what the model can do are independent concerns. Coupling them makes switching providers a rewrite. When native mode is requested on a model that lacks it, the agent falls back to tool mode *and says so* with a diagnostic.
+
+## D8. Model mistakes are correctable; system faults are not
+
+**Decision.** Invalid tool arguments, unknown tool names, and `Retry(...)` errors from tools are returned to the model as error tool-results so it can self-correct. Genuine failures (provider errors, tool panics, context cancellation) abort with a wrapped error.
+
+**Why.** Validation-driven self-correction measurably improves structured-output reliability, and a hallucinated tool name is not a reason to discard a run. But the distinction has to be explicit: absorbing real failures into the loop is how a framework ends up reporting success for a broken run.
+
+## D9. Streams are cursors, and errors cannot be lost
+
+**Decision.** `Stream` is `Next() bool / Event() Event / Err() error / Close() error`.
+
+**Why.** The single most damaging streaming bug in the previous generation was that producer errors never reached the terminal check: failed streams looked successful, and downstream workflow steps consumed empty output as if it were an answer. A cursor makes `Err()` the one place a caller must look, and `Next()` returning false is deliberately ambiguous between "done" and "failed" so that consulting `Err()` is mandatory. `Close()` cancels the underlying request — cancellation that doesn't stop token generation is cancellation that costs money.
+
+**Rejected.** A bare `<-chan Event`. Channels have no error channel by construction, which is exactly how errors got dropped before.
+
+## D10. Non-fatal findings are values
+
+**Decision.** Degraded configurations produce `Diagnostic` values, available from `agent.Diagnostics()` and pushed to `WithDiagnosticHandler`.
+
+**Why.** A framework that only logs is invisible to any consumer that wires its own logger — and the consumers most likely to have their own logger are exactly the production users who most need the warning. Diagnostics carry a stable `Code` so callers branch programmatically ("fail the deploy if embeddings are degraded") instead of matching message text. They are also logged; ignoring the API costs nothing.
+
+## D11. Errors wrap sentinels
+
+**Decision.** Every returned error wraps one of `ErrInvalidConfig`, `ErrMaxSteps`, `ErrUsageLimit`, `ErrToolNotFound`, `ErrNoOutput`, `ErrUnsupported`, `ErrProvider`; `StepError` and `ToolError` add location while preserving the chain via `Unwrap`.
+
+**Why.** `errors.Is/As` is the Go contract for programmatic error handling. The previous generation flattened step errors to strings with `%s`, which destroyed the chain and made its *own* typed-error package unusable against its own engine.
+
+## D12. Standard library only in the core
+
+**Decision.** The core module has zero third-party dependencies. Adapters, stores, and telemetry integrations are separate modules.
+
+**Why.** A single fat `go.mod` forced every consumer to pull Postgres drivers, a vector database, a metrics client, and a cloud SDK — one of which was used only by a test. Anyone deploying a small agent paid for all of it. Keeping the core dependency-free makes the cost of each integration explicit and opt-in.
+
+---
+
+## Decisions still open
+
+These are deliberately unresolved and tracked as issues. They are the ones worth settling before v0.1, because they shape public API.
+
+1. **Durable execution shape.** Journal-skip (re-invoke and replay completed steps from a journal) versus event-history replay. Leaning journal-skip: it imposes no determinism constraints on user code, so plain goroutines and `time.Now` stay legal outside steps.
+2. **Checkpoint store contract.** Target a five-method interface addressable by `(threadID, namespace, checkpointID)`, with pending-writes so successful parallel siblings aren't re-executed on resume. Small contracts attract community backends; large ones don't.
+3. **Interrupt/resume ergonomics.** `Interrupt[T](ctx, payload)` that suspends durably and returns the recorded value on resume, with the node re-executing to that point — no stack serialization required.
+4. **Typed workflow steps.** How far to push compile-time checking between step boundaries without making construction verbose.
+5. **Streaming agent runs.** `Agent.Stream` returning agent-level events (step start, tool call, text delta) versus provider events passed through.
+6. **Session/state contract.** Interface shape and scope prefixes for cross-run state.

--- a/agentkit-bootstrap/errors.go
+++ b/agentkit-bootstrap/errors.go
@@ -1,0 +1,72 @@
+package agentkit
+
+import (
+	"errors"
+	"fmt"
+)
+
+// Sentinel errors. Every error this package returns wraps one of these, so
+// callers branch with errors.Is rather than matching message text.
+var (
+	// ErrInvalidConfig means the agent could not be constructed as described.
+	ErrInvalidConfig = errors.New("invalid configuration")
+
+	// ErrMaxSteps means the run hit its step budget without producing a final
+	// answer — usually a tool loop that never converges.
+	ErrMaxSteps = errors.New("max steps exceeded")
+
+	// ErrUsageLimit means the run hit a token or call budget.
+	ErrUsageLimit = errors.New("usage limit exceeded")
+
+	// ErrToolNotFound means the model called a tool that is not registered.
+	ErrToolNotFound = errors.New("tool not found")
+
+	// ErrNoOutput means the model finished without producing output matching
+	// the requested type.
+	ErrNoOutput = errors.New("no structured output produced")
+
+	// ErrUnsupported means the provider or model lacks a required capability.
+	// Callers should consult Provider.Capabilities to branch before calling.
+	ErrUnsupported = errors.New("unsupported capability")
+
+	// ErrProvider means the model backend failed. Inspect the wrapped error
+	// for provider-specific detail.
+	ErrProvider = errors.New("provider error")
+)
+
+// RetryError is returned by a tool or output validator to send a corrective
+// message back to the model instead of failing the run. It turns validation
+// into an autonomous self-correction loop.
+type RetryError struct {
+	Message string
+}
+
+func (e *RetryError) Error() string { return e.Message }
+
+// Retry returns an error that asks the model to try again with the given
+// guidance.
+func Retry(format string, args ...any) error {
+	return &RetryError{Message: fmt.Sprintf(format, args...)}
+}
+
+// ToolError identifies which tool failed while preserving the cause for
+// errors.Is and errors.As.
+type ToolError struct {
+	Tool string
+	Err  error
+}
+
+func (e *ToolError) Error() string { return fmt.Sprintf("tool %s: %v", e.Tool, e.Err) }
+func (e *ToolError) Unwrap() error { return e.Err }
+
+// StepError identifies which step of a run failed while preserving the cause.
+type StepError struct {
+	Step  int
+	Phase string
+	Err   error
+}
+
+func (e *StepError) Error() string {
+	return fmt.Sprintf("step %d (%s): %v", e.Step, e.Phase, e.Err)
+}
+func (e *StepError) Unwrap() error { return e.Err }

--- a/agentkit-bootstrap/go.mod
+++ b/agentkit-bootstrap/go.mod
@@ -1,0 +1,3 @@
+module github.com/agenticgokit/agentkit
+
+go 1.24.1

--- a/agentkit-bootstrap/message.go
+++ b/agentkit-bootstrap/message.go
@@ -1,0 +1,134 @@
+package agentkit
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+// Role identifies who produced a message.
+type Role string
+
+const (
+	RoleSystem    Role = "system"
+	RoleUser      Role = "user"
+	RoleAssistant Role = "assistant"
+	RoleTool      Role = "tool"
+)
+
+// Part is one piece of message content. The closed set of implementations is
+// the provider-neutral intermediate representation every adapter translates
+// to and from; adapters must never require callers to speak a provider's
+// wire format.
+type Part interface{ isPart() }
+
+// Text is plain text content.
+type Text struct {
+	Text string
+}
+
+// Image is image content, referenced by URL or carried inline.
+type Image struct {
+	URL  string
+	Data []byte
+	MIME string
+}
+
+// Audio is audio content, referenced by URL or carried inline.
+type Audio struct {
+	URL  string
+	Data []byte
+	MIME string
+}
+
+// Reasoning is a reasoning/thinking block from a reasoning model. Signature
+// carries provider-specific verification data that must be echoed back on
+// subsequent turns when the provider requires it.
+type Reasoning struct {
+	Text      string
+	Redacted  bool
+	Signature string
+}
+
+// ToolCall is a request from the model to invoke a tool. Input is the raw
+// JSON arguments so no fidelity is lost before validation.
+type ToolCall struct {
+	ID    string
+	Name  string
+	Input json.RawMessage
+}
+
+// ToolOutput is the result of a tool invocation, correlated to a ToolCall by
+// CallID. IsError distinguishes a tool that failed from one that returned a
+// negative result — providers render the two differently.
+type ToolOutput struct {
+	CallID  string
+	Name    string
+	Content []Part
+	IsError bool
+}
+
+func (Text) isPart()       {}
+func (Image) isPart()      {}
+func (Audio) isPart()      {}
+func (Reasoning) isPart()  {}
+func (ToolCall) isPart()   {}
+func (ToolOutput) isPart() {}
+
+// Message is one turn in a conversation.
+type Message struct {
+	Role  Role
+	Parts []Part
+}
+
+// System returns a system message carrying text.
+func System(text string) Message {
+	return Message{Role: RoleSystem, Parts: []Part{Text{Text: text}}}
+}
+
+// User returns a user message carrying text.
+func User(text string) Message {
+	return Message{Role: RoleUser, Parts: []Part{Text{Text: text}}}
+}
+
+// Assistant returns an assistant message carrying text.
+func Assistant(text string) Message {
+	return Message{Role: RoleAssistant, Parts: []Part{Text{Text: text}}}
+}
+
+// UserParts returns a user message with arbitrary content parts (multimodal).
+func UserParts(parts ...Part) Message {
+	return Message{Role: RoleUser, Parts: parts}
+}
+
+// ToolResult returns a tool-role message carrying the output of one call.
+func ToolResult(callID, name, content string, isError bool) Message {
+	return Message{Role: RoleTool, Parts: []Part{ToolOutput{
+		CallID:  callID,
+		Name:    name,
+		Content: []Part{Text{Text: content}},
+		IsError: isError,
+	}}}
+}
+
+// Text concatenates every text part in the message. Reasoning parts are not
+// included: they are model scratch space, not the answer.
+func (m Message) Text() string {
+	var b strings.Builder
+	for _, p := range m.Parts {
+		if t, ok := p.(Text); ok {
+			b.WriteString(t.Text)
+		}
+	}
+	return b.String()
+}
+
+// ToolCalls returns every tool call requested in this message.
+func (m Message) ToolCalls() []ToolCall {
+	var calls []ToolCall
+	for _, p := range m.Parts {
+		if c, ok := p.(ToolCall); ok {
+			calls = append(calls, c)
+		}
+	}
+	return calls
+}

--- a/agentkit-bootstrap/provider.go
+++ b/agentkit-bootstrap/provider.go
@@ -1,0 +1,233 @@
+package agentkit
+
+import "context"
+
+// Provider is the only interface a model backend must implement. It is
+// deliberately small so third parties can implement it without depending on
+// framework internals, and so cross-cutting concerns (retry, rate limiting,
+// cost accounting, fallback) can be written once as decorators.
+type Provider interface {
+	// Name identifies the provider for diagnostics and telemetry
+	// (e.g. "openai", "anthropic", "ollama").
+	Name() string
+
+	// Generate runs one non-streaming model call.
+	Generate(ctx context.Context, req Request) (*Response, error)
+
+	// Stream runs one streaming model call. Implementations must deliver
+	// terminal errors through Stream.Err, never by silently ending.
+	Stream(ctx context.Context, req Request) (Stream, error)
+
+	// Capabilities reports what the named model supports. Callers branch on
+	// this instead of discovering unsupported features by silent degradation.
+	Capabilities(model string) Capabilities
+}
+
+// Embedder is implemented separately from Provider: many chat providers have
+// no embeddings API, and forcing them to stub one produced zero-vector
+// embeddings in a previous generation of this framework.
+type Embedder interface {
+	Embed(ctx context.Context, texts []string) ([][]float32, error)
+	// Dimensions reports the vector width, so stores can be provisioned and
+	// mismatches detected before the first write.
+	Dimensions() int
+}
+
+// Request is one model call.
+type Request struct {
+	Model      string
+	Messages   []Message
+	Tools      []ToolDef
+	ToolChoice ToolChoice
+	Params     Params
+
+	// Output requests schema-constrained output. Nil means free-form text.
+	Output *OutputSpec
+}
+
+// Params holds sampling parameters. Every field is a pointer so "unset" is
+// distinguishable from a meaningful zero — Temperature 0 (deterministic) is a
+// legitimate setting, not an absent one.
+type Params struct {
+	Temperature   *float32
+	TopP          *float32
+	MaxTokens     *int
+	StopSequences []string
+	Seed          *int
+}
+
+// ToolChoiceMode controls whether the model may, must, or must not call tools.
+type ToolChoiceMode string
+
+const (
+	// ToolChoiceAuto lets the model decide (default).
+	ToolChoiceAuto ToolChoiceMode = "auto"
+	// ToolChoiceNone forbids tool calls for this turn.
+	ToolChoiceNone ToolChoiceMode = "none"
+	// ToolChoiceRequired forces at least one tool call.
+	ToolChoiceRequired ToolChoiceMode = "required"
+	// ToolChoiceTool forces the specific tool named in ToolChoice.Name.
+	ToolChoiceTool ToolChoiceMode = "tool"
+)
+
+// ToolChoice constrains tool selection for one request.
+type ToolChoice struct {
+	Mode ToolChoiceMode
+	Name string
+}
+
+// OutputFormat selects how schema-constrained output is obtained. Declaring
+// the desired type and choosing the mechanism are separate decisions, because
+// the mechanism depends on model capability while the type does not.
+type OutputFormat string
+
+const (
+	// OutputTool passes the schema as a tool the model calls. Works on nearly
+	// every tool-capable model.
+	OutputTool OutputFormat = "tool"
+	// OutputNative uses the provider's JSON-schema response format.
+	OutputNative OutputFormat = "native"
+	// OutputPrompted injects the schema into the prompt. Last resort for
+	// models with neither capability.
+	OutputPrompted OutputFormat = "prompted"
+)
+
+// OutputSpec describes schema-constrained output for a request.
+type OutputSpec struct {
+	Format OutputFormat
+	Name   string
+	Schema []byte
+}
+
+// StopReason explains why generation ended.
+type StopReason string
+
+const (
+	StopEndTurn   StopReason = "end_turn"
+	StopToolUse   StopReason = "tool_use"
+	StopMaxTokens StopReason = "max_tokens"
+	StopStop      StopReason = "stop_sequence"
+	StopFiltered  StopReason = "content_filter"
+)
+
+// Usage reports token consumption for one call. Streaming providers must
+// populate this on the terminal event; cost accounting depends on it.
+type Usage struct {
+	InputTokens       int
+	OutputTokens      int
+	CachedInputTokens int
+	ReasoningTokens   int
+}
+
+// Add accumulates usage across the calls of a run.
+func (u *Usage) Add(o Usage) {
+	u.InputTokens += o.InputTokens
+	u.OutputTokens += o.OutputTokens
+	u.CachedInputTokens += o.CachedInputTokens
+	u.ReasoningTokens += o.ReasoningTokens
+}
+
+// Total returns all tokens counted for this usage.
+func (u Usage) Total() int { return u.InputTokens + u.OutputTokens }
+
+// Response is the result of a non-streaming call.
+type Response struct {
+	Message    Message
+	StopReason StopReason
+	Usage      Usage
+	// Model is the model that actually served the request, which may differ
+	// from the requested alias.
+	Model string
+}
+
+// Modality is an input or output content type a model supports.
+type Modality string
+
+const (
+	ModalityText  Modality = "text"
+	ModalityImage Modality = "image"
+	ModalityAudio Modality = "audio"
+	ModalityVideo Modality = "video"
+)
+
+// Capabilities describes what a model supports, so the runtime can choose a
+// strategy instead of failing silently.
+type Capabilities struct {
+	NativeTools     bool
+	ParallelTools   bool
+	NativeJSON      bool
+	Streaming       bool
+	PromptCaching   bool
+	Reasoning       bool
+	Input           []Modality
+	ContextWindow   int
+	MaxOutputTokens int
+}
+
+// Supports reports whether the model accepts the given input modality.
+func (c Capabilities) Supports(m Modality) bool {
+	for _, x := range c.Input {
+		if x == m {
+			return true
+		}
+	}
+	return false
+}
+
+// Event is one item in a stream. The closed set mirrors what modern chat UIs
+// need to render incrementally.
+type Event interface{ isEvent() }
+
+// TextDelta is an incremental chunk of assistant text.
+type TextDelta struct{ Text string }
+
+// ReasoningDelta is an incremental chunk of model reasoning.
+type ReasoningDelta struct{ Text string }
+
+// ToolCallStart announces a tool call whose arguments will stream.
+type ToolCallStart struct {
+	ID   string
+	Name string
+}
+
+// ToolCallDelta is an incremental chunk of a tool call's JSON arguments.
+type ToolCallDelta struct {
+	ID        string
+	InputJSON string
+}
+
+// ToolCallDone marks a tool call's arguments complete.
+type ToolCallDone struct {
+	ID    string
+	Input []byte
+}
+
+// Done is the terminal event, carrying the accounting a caller needs.
+type Done struct {
+	StopReason StopReason
+	Usage      Usage
+}
+
+func (TextDelta) isEvent()      {}
+func (ReasoningDelta) isEvent() {}
+func (ToolCallStart) isEvent()  {}
+func (ToolCallDelta) isEvent()  {}
+func (ToolCallDone) isEvent()   {}
+func (Done) isEvent()           {}
+
+// Stream is a cursor over stream events. The cursor shape (rather than a bare
+// channel) exists so a failed stream cannot be mistaken for a successful one:
+// Next returns false on both completion and failure, and Err is the single
+// source of truth for which occurred.
+type Stream interface {
+	// Next advances to the next event, returning false at end of stream or on
+	// error. Callers must consult Err after Next returns false.
+	Next() bool
+	// Event returns the event Next advanced to.
+	Event() Event
+	// Err returns the terminal error, or nil if the stream completed.
+	Err() error
+	// Close releases resources and cancels any in-flight request. It is safe
+	// to call more than once.
+	Close() error
+}

--- a/agentkit-bootstrap/schema.go
+++ b/agentkit-bootstrap/schema.go
@@ -1,0 +1,165 @@
+package agentkit
+
+import (
+	"encoding/json"
+	"reflect"
+	"strings"
+)
+
+// Schema is the subset of JSON Schema used to describe tool inputs and
+// structured outputs. It is generated from Go types so a schema can never
+// drift from the function signature it describes.
+type Schema struct {
+	Type                 string             `json:"type,omitempty"`
+	Description          string             `json:"description,omitempty"`
+	Properties           map[string]*Schema `json:"properties,omitempty"`
+	Required             []string           `json:"required,omitempty"`
+	Items                *Schema            `json:"items,omitempty"`
+	Enum                 []string           `json:"enum,omitempty"`
+	AdditionalProperties *bool              `json:"additionalProperties,omitempty"`
+}
+
+// SchemaOf derives a JSON Schema from a Go type.
+//
+// Field names come from json tags. A field is required unless it is a pointer
+// or carries omitempty. The jsonschema tag adds metadata:
+//
+//	Field string `json:"field" jsonschema:"description=What it is,enum=a|b"`
+func SchemaOf[T any]() *Schema {
+	var zero T
+	return schemaOfType(reflect.TypeOf(&zero).Elem(), map[reflect.Type]bool{})
+}
+
+// SchemaJSON returns SchemaOf marshaled, for passing to providers.
+func SchemaJSON[T any]() []byte {
+	b, err := json.Marshal(SchemaOf[T]())
+	if err != nil {
+		// Schema values are plain data with no unmarshalable fields; a failure
+		// here means the generator itself is broken.
+		panic("agentkit: schema marshal failed: " + err.Error())
+	}
+	return b
+}
+
+func schemaOfType(t reflect.Type, seen map[reflect.Type]bool) *Schema {
+	if t == nil {
+		return &Schema{}
+	}
+	for t.Kind() == reflect.Pointer {
+		t = t.Elem()
+	}
+
+	switch t.Kind() {
+	case reflect.String:
+		return &Schema{Type: "string"}
+	case reflect.Bool:
+		return &Schema{Type: "boolean"}
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64,
+		reflect.Uint, reflect.Uint8, reflect.Uint16, reflect.Uint32, reflect.Uint64:
+		return &Schema{Type: "integer"}
+	case reflect.Float32, reflect.Float64:
+		return &Schema{Type: "number"}
+	case reflect.Slice, reflect.Array:
+		// []byte marshals as a base64 string, so describe it as one.
+		if t.Elem().Kind() == reflect.Uint8 {
+			return &Schema{Type: "string"}
+		}
+		return &Schema{Type: "array", Items: schemaOfType(t.Elem(), seen)}
+	case reflect.Map:
+		yes := true
+		return &Schema{Type: "object", AdditionalProperties: &yes}
+	case reflect.Interface:
+		return &Schema{}
+	case reflect.Struct:
+		return structSchema(t, seen)
+	default:
+		return &Schema{}
+	}
+}
+
+func structSchema(t reflect.Type, seen map[reflect.Type]bool) *Schema {
+	// Recursive types would otherwise loop forever; emit an open object.
+	if seen[t] {
+		yes := true
+		return &Schema{Type: "object", AdditionalProperties: &yes}
+	}
+	seen[t] = true
+	defer delete(seen, t)
+
+	s := &Schema{Type: "object", Properties: map[string]*Schema{}}
+	for i := 0; i < t.NumField(); i++ {
+		f := t.Field(i)
+		if !f.IsExported() {
+			continue
+		}
+
+		name, omitempty, skip := jsonFieldName(f)
+		if skip {
+			continue
+		}
+
+		// Embedded structs without a json name are flattened, matching
+		// encoding/json.
+		if f.Anonymous && name == "" {
+			if inner := schemaOfType(f.Type, seen); inner.Properties != nil {
+				for k, v := range inner.Properties {
+					s.Properties[k] = v
+				}
+				s.Required = append(s.Required, inner.Required...)
+			}
+			continue
+		}
+		if name == "" {
+			name = f.Name
+		}
+
+		fs := schemaOfType(f.Type, seen)
+		required := !omitempty && f.Type.Kind() != reflect.Pointer
+		applyJSONSchemaTag(f.Tag.Get("jsonschema"), fs, &required)
+
+		s.Properties[name] = fs
+		if required {
+			s.Required = append(s.Required, name)
+		}
+	}
+	return s
+}
+
+func jsonFieldName(f reflect.StructField) (name string, omitempty, skip bool) {
+	tag := f.Tag.Get("json")
+	if tag == "-" {
+		return "", false, true
+	}
+	parts := strings.Split(tag, ",")
+	if len(parts) > 0 {
+		name = parts[0]
+	}
+	for _, o := range parts[1:] {
+		if o == "omitempty" {
+			omitempty = true
+		}
+	}
+	if name == "" && !f.Anonymous {
+		name = f.Name
+	}
+	return name, omitempty, false
+}
+
+// applyJSONSchemaTag reads `jsonschema:"description=...,enum=a|b,required"`.
+func applyJSONSchemaTag(tag string, s *Schema, required *bool) {
+	if tag == "" {
+		return
+	}
+	for _, opt := range strings.Split(tag, ",") {
+		switch {
+		case opt == "required":
+			*required = true
+		case opt == "optional":
+			*required = false
+		case strings.HasPrefix(opt, "description="):
+			s.Description = strings.TrimPrefix(opt, "description=")
+		case strings.HasPrefix(opt, "enum="):
+			s.Enum = strings.Split(strings.TrimPrefix(opt, "enum="), "|")
+		}
+	}
+}

--- a/agentkit-bootstrap/schema_test.go
+++ b/agentkit-bootstrap/schema_test.go
@@ -1,0 +1,110 @@
+package agentkit_test
+
+import (
+	"encoding/json"
+	"testing"
+
+	"github.com/agenticgokit/agentkit"
+)
+
+func TestSchemaOfStruct(t *testing.T) {
+	type nested struct {
+		Code string `json:"code"`
+	}
+	type args struct {
+		Query    string   `json:"query" jsonschema:"description=Search terms"`
+		Limit    int      `json:"limit,omitempty"`
+		Enabled  bool     `json:"enabled"`
+		Ratio    float64  `json:"ratio"`
+		Tags     []string `json:"tags,omitempty"`
+		Optional *string  `json:"optional,omitempty"`
+		Mode     string   `json:"mode" jsonschema:"enum=fast|slow"`
+		Inner    nested   `json:"inner"`
+		Hidden   string   `json:"-"`
+		unexp    string   //nolint:unused // verifies unexported fields are skipped
+	}
+
+	s := agentkit.SchemaOf[args]()
+
+	if s.Type != "object" {
+		t.Fatalf("Type = %q, want object", s.Type)
+	}
+
+	for name, want := range map[string]string{
+		"query":   "string",
+		"limit":   "integer",
+		"enabled": "boolean",
+		"ratio":   "number",
+		"tags":    "array",
+		"inner":   "object",
+	} {
+		p := s.Properties[name]
+		if p == nil {
+			t.Errorf("property %q missing", name)
+			continue
+		}
+		if p.Type != want {
+			t.Errorf("property %q type = %q, want %q", name, p.Type, want)
+		}
+	}
+
+	if _, ok := s.Properties["Hidden"]; ok {
+		t.Error(`field tagged json:"-" leaked into the schema`)
+	}
+	if _, ok := s.Properties["unexp"]; ok {
+		t.Error("unexported field leaked into the schema")
+	}
+
+	if got := s.Properties["query"].Description; got != "Search terms" {
+		t.Errorf("description = %q, want %q", got, "Search terms")
+	}
+	if got := s.Properties["mode"].Enum; len(got) != 2 || got[0] != "fast" || got[1] != "slow" {
+		t.Errorf("enum = %v, want [fast slow]", got)
+	}
+	if s.Properties["tags"].Items == nil || s.Properties["tags"].Items.Type != "string" {
+		t.Error("array items type not derived")
+	}
+	if s.Properties["inner"].Properties["code"] == nil {
+		t.Error("nested struct properties not derived")
+	}
+
+	required := map[string]bool{}
+	for _, r := range s.Required {
+		required[r] = true
+	}
+	if !required["query"] {
+		t.Error("query should be required")
+	}
+	if required["limit"] {
+		t.Error("omitempty field should not be required")
+	}
+	if required["optional"] {
+		t.Error("pointer field should not be required")
+	}
+}
+
+func TestSchemaHandlesRecursiveTypes(t *testing.T) {
+	type node struct {
+		Name     string  `json:"name"`
+		Children []*node `json:"children,omitempty"`
+	}
+	// Must terminate rather than recurse forever.
+	s := agentkit.SchemaOf[node]()
+	if s.Properties["children"] == nil {
+		t.Fatal("children property missing")
+	}
+}
+
+func TestSchemaJSONIsValid(t *testing.T) {
+	type out struct {
+		Score int `json:"score"`
+	}
+	raw := agentkit.SchemaJSON[out]()
+	var back map[string]any
+	if err := json.Unmarshal(raw, &back); err != nil {
+		t.Fatalf("schema is not valid JSON: %v", err)
+	}
+	if back["type"] != "object" {
+		t.Errorf("type = %v, want object", back["type"])
+	}
+}

--- a/agentkit-bootstrap/scripts/file-issues.sh
+++ b/agentkit-bootstrap/scripts/file-issues.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+# Create the milestones and issues described in ISSUES.md.
+#
+# Requires the gh CLI, authenticated with issue-write access to the repository.
+# Safe to re-run: existing milestones are reused, and issues whose exact title
+# already exists are skipped rather than duplicated.
+#
+#   ./scripts/file-issues.sh [owner/repo]
+
+set -euo pipefail
+
+REPO="${1:-agenticgokit/agentkit}"
+ISSUES_FILE="$(dirname "$0")/../ISSUES.md"
+
+if ! command -v gh >/dev/null; then
+  echo "gh CLI not found: https://cli.github.com" >&2
+  exit 1
+fi
+if [ ! -f "$ISSUES_FILE" ]; then
+  echo "cannot find $ISSUES_FILE" >&2
+  exit 1
+fi
+
+echo "Target repository: $REPO"
+
+# --- milestones -------------------------------------------------------------
+declare -a MILESTONES=(
+  "v0.1 Core contracts"
+  "v0.2 Durable"
+  "v0.3 Workflows"
+  "v0.4 Multi-agent"
+  "v0.5 Dev loop"
+)
+
+existing_milestones="$(gh api "repos/$REPO/milestones?state=all&per_page=100" --jq '.[].title')"
+for m in "${MILESTONES[@]}"; do
+  if grep -Fxq "$m" <<<"$existing_milestones"; then
+    echo "milestone exists: $m"
+  else
+    gh api "repos/$REPO/milestones" -f title="$m" >/dev/null
+    echo "milestone created: $m"
+  fi
+done
+
+# --- issues -----------------------------------------------------------------
+existing_titles="$(gh issue list --repo "$REPO" --state all --limit 500 --json title --jq '.[].title')"
+
+python3 - "$ISSUES_FILE" <<'PY' > /tmp/agentkit-issues.tsv
+import re, sys, json
+
+raw = open(sys.argv[1]).read()
+blocks = raw.split("\n===\n")[1:]  # everything before the first delimiter is prose
+for b in blocks:
+    m = re.match(r"\s*---\n(.*?)\n---\n(.*)", b, re.S)
+    if not m:
+        continue
+    fm, body = m.group(1), m.group(2).strip()
+    meta = {}
+    for line in fm.splitlines():
+        if ":" not in line:
+            continue
+        k, v = line.split(":", 1)
+        meta[k.strip()] = v.strip().strip('"')
+    labels = meta.get("labels", "[]").strip("[]")
+    labels = ",".join(x.strip() for x in labels.split(",") if x.strip())
+    print("\t".join([
+        meta.get("title", ""),
+        meta.get("milestone", ""),
+        labels,
+        json.dumps(body),
+    ]))
+PY
+
+created=0 skipped=0
+while IFS=$'\t' read -r title milestone labels body_json; do
+  [ -z "$title" ] && continue
+  if grep -Fxq "$title" <<<"$existing_titles"; then
+    echo "skip (exists): $title"
+    skipped=$((skipped + 1))
+    continue
+  fi
+
+  body="$(python3 -c 'import json,sys; print(json.loads(sys.argv[1]))' "$body_json")"
+
+  args=(--repo "$REPO" --title "$title" --body "$body")
+  [ -n "$milestone" ] && args+=(--milestone "$milestone")
+  if [ -n "$labels" ]; then
+    IFS=',' read -ra ls <<<"$labels"
+    for l in "${ls[@]}"; do
+      # Create the label on demand; ignore "already exists".
+      gh label create "$l" --repo "$REPO" >/dev/null 2>&1 || true
+      args+=(--label "$l")
+    done
+  fi
+
+  gh issue create "${args[@]}" >/dev/null
+  echo "created: $title"
+  created=$((created + 1))
+done < /tmp/agentkit-issues.tsv
+
+rm -f /tmp/agentkit-issues.tsv
+echo
+echo "done — $created created, $skipped skipped"

--- a/agentkit-bootstrap/tool.go
+++ b/agentkit-bootstrap/tool.go
@@ -1,0 +1,134 @@
+package agentkit
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+)
+
+// ToolDef is the provider-neutral description of a callable tool. Adapters
+// translate it to each provider's wire shape; callers never write provider
+// JSON by hand.
+type ToolDef struct {
+	Name         string
+	Description  string
+	InputSchema  *Schema
+	OutputSchema *Schema
+	Annotations  ToolAnnotations
+}
+
+// ToolAnnotations carry behavioral hints used for approval gating and UI
+// affordances. They mirror MCP's tool annotations so MCP-sourced tools map
+// across without loss.
+type ToolAnnotations struct {
+	ReadOnly    bool
+	Destructive bool
+	Idempotent  bool
+	OpenWorld   bool
+}
+
+// Tool is an executable capability offered to a model.
+type Tool interface {
+	Def() ToolDef
+	// Invoke runs the tool with raw JSON arguments and returns raw JSON
+	// output. Implementations validate their own input.
+	Invoke(ctx context.Context, input json.RawMessage) (json.RawMessage, error)
+}
+
+// typedTool adapts a typed Go function to the Tool interface.
+type typedTool[In, Out any] struct {
+	def ToolDef
+	fn  func(ctx context.Context, in In) (Out, error)
+}
+
+// NewTool builds a Tool from a typed Go function. Input and output schemas are
+// derived from In and Out, so the schema the model sees cannot drift from the
+// function that runs.
+//
+//	type SearchArgs struct {
+//	    Query string `json:"query" jsonschema:"description=Search terms"`
+//	    Limit int    `json:"limit,omitempty"`
+//	}
+//
+//	tool := agentkit.NewTool("search", "Search the web",
+//	    func(ctx context.Context, a SearchArgs) ([]Hit, error) { ... })
+func NewTool[In, Out any](name, description string, fn func(ctx context.Context, in In) (Out, error), opts ...ToolOption) Tool {
+	def := ToolDef{
+		Name:         name,
+		Description:  description,
+		InputSchema:  SchemaOf[In](),
+		OutputSchema: SchemaOf[Out](),
+	}
+	for _, o := range opts {
+		o(&def)
+	}
+	return &typedTool[In, Out]{def: def, fn: fn}
+}
+
+// ToolOption customizes a tool definition.
+type ToolOption func(*ToolDef)
+
+// ReadOnly marks a tool as having no side effects, which approval policies and
+// caching layers can rely on.
+func ReadOnly() ToolOption {
+	return func(d *ToolDef) { d.Annotations.ReadOnly = true }
+}
+
+// Destructive marks a tool as performing irreversible actions, so approval
+// policies can require confirmation.
+func Destructive() ToolOption {
+	return func(d *ToolDef) { d.Annotations.Destructive = true }
+}
+
+func (t *typedTool[In, Out]) Def() ToolDef { return t.def }
+
+func (t *typedTool[In, Out]) Invoke(ctx context.Context, input json.RawMessage) (json.RawMessage, error) {
+	var in In
+	if len(input) > 0 {
+		if err := json.Unmarshal(input, &in); err != nil {
+			// Argument errors are returned to the model for self-correction
+			// rather than aborting the run.
+			return nil, &RetryError{Message: fmt.Sprintf("invalid arguments for %q: %v", t.def.Name, err)}
+		}
+	}
+	out, err := t.fn(ctx, in)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(out)
+}
+
+// toolSet indexes tools by name and rejects duplicates, so a shadowed tool is
+// a build-time error rather than a silent first-wins surprise.
+type toolSet struct {
+	order  []Tool
+	byName map[string]Tool
+}
+
+func newToolSet() *toolSet { return &toolSet{byName: map[string]Tool{}} }
+
+func (s *toolSet) add(t Tool) error {
+	name := t.Def().Name
+	if name == "" {
+		return fmt.Errorf("%w: tool has no name", ErrInvalidConfig)
+	}
+	if _, dup := s.byName[name]; dup {
+		return fmt.Errorf("%w: duplicate tool %q", ErrInvalidConfig, name)
+	}
+	s.byName[name] = t
+	s.order = append(s.order, t)
+	return nil
+}
+
+func (s *toolSet) defs() []ToolDef {
+	defs := make([]ToolDef, 0, len(s.order))
+	for _, t := range s.order {
+		defs = append(defs, t.Def())
+	}
+	return defs
+}
+
+func (s *toolSet) get(name string) (Tool, bool) {
+	t, ok := s.byName[name]
+	return t, ok
+}

--- a/core/memory.go
+++ b/core/memory.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"strings"
 	"sync"
@@ -361,6 +362,23 @@ func NewDummyEmbeddingService(dimensions int) EmbeddingService {
 	return &noOpEmbeddingService{dimensions: dimensions}
 }
 
+// Sentinel errors for embedding configuration failures. They are wrapped
+// into the errors returned by NewEmbeddingServiceForConfig (and therefore
+// into memory/agent construction errors), so consumers can branch with
+// errors.Is instead of string-matching messages:
+//
+//	if errors.Is(err, core.ErrEmbeddingFactoryNotRegistered) { ... }
+var (
+	// ErrEmbeddingFactoryNotRegistered: a real embedding provider was
+	// requested but its factory was never registered (missing
+	// plugins/embedding import in the consumer binary).
+	ErrEmbeddingFactoryNotRegistered = errors.New("embedding factory not registered")
+
+	// ErrEmbeddingProviderUnsupported: the configured embedding provider
+	// name is not one of the supported values.
+	ErrEmbeddingProviderUnsupported = errors.New("unsupported embedding provider")
+)
+
 // NewEmbeddingServiceForConfig resolves the embedding service for a memory
 // provider configuration. Unlike the individual New*EmbeddingService helpers,
 // it fails loudly: requesting a provider whose factory has not been registered
@@ -376,14 +394,14 @@ func NewEmbeddingServiceForConfig(cfg AgentMemoryConfig) (EmbeddingService, erro
 	switch strings.ToLower(strings.TrimSpace(cfg.Embedding.Provider)) {
 	case "openai", "azure":
 		if openAIEmbeddingFactory == nil {
-			return nil, fmt.Errorf("embedding provider %q requested but no OpenAI embedding factory is registered; %s", cfg.Embedding.Provider, registrationHint)
+			return nil, fmt.Errorf("%w: embedding provider %q requested but no OpenAI embedding factory is registered; %s", ErrEmbeddingFactoryNotRegistered, cfg.Embedding.Provider, registrationHint)
 		}
 		svc := openAIEmbeddingFactory(cfg.Embedding.APIKey, cfg.Embedding.Model)
 		warnOnDimensionMismatch(cfg, svc)
 		return svc, nil
 	case "ollama":
 		if ollamaEmbeddingFactory == nil {
-			return nil, fmt.Errorf("embedding provider \"ollama\" requested but no Ollama embedding factory is registered; %s", registrationHint)
+			return nil, fmt.Errorf("%w: embedding provider \"ollama\" requested but no Ollama embedding factory is registered; %s", ErrEmbeddingFactoryNotRegistered, registrationHint)
 		}
 		svc := ollamaEmbeddingFactory(cfg.Embedding.Model, cfg.Embedding.BaseURL)
 		warnOnDimensionMismatch(cfg, svc)
@@ -400,7 +418,7 @@ func NewEmbeddingServiceForConfig(cfg AgentMemoryConfig) (EmbeddingService, erro
 				"or disable memory (v1beta: Memory.Enabled=false).")
 		return NewDummyEmbeddingService(cfg.Dimensions), nil
 	default:
-		return nil, fmt.Errorf("unsupported embedding provider %q (supported: openai, azure, ollama, dummy)", cfg.Embedding.Provider)
+		return nil, fmt.Errorf("%w: %q (supported: openai, azure, ollama, dummy)", ErrEmbeddingProviderUnsupported, cfg.Embedding.Provider)
 	}
 }
 

--- a/core/memory.go
+++ b/core/memory.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"fmt"
 	"strings"
 	"sync"
 	"time"
@@ -358,6 +359,43 @@ func NewDummyEmbeddingService(dimensions int) EmbeddingService {
 		dimensions = 1536
 	}
 	return &noOpEmbeddingService{dimensions: dimensions}
+}
+
+// NewEmbeddingServiceForConfig resolves the embedding service for a memory
+// provider configuration. Unlike the individual New*EmbeddingService helpers,
+// it fails loudly: requesting a provider whose factory has not been registered
+// returns an error instead of silently substituting the zero-vector no-op stub,
+// and an unknown provider name is an error instead of a silent dummy fallback.
+//
+// An empty provider keeps the historical dummy fallback (so zero-config memory
+// still constructs), but logs at Error level because semantic search over
+// dummy embeddings returns meaningless results.
+func NewEmbeddingServiceForConfig(cfg AgentMemoryConfig) (EmbeddingService, error) {
+	registrationHint := `register real embedding providers with: import _ "github.com/agenticgokit/agenticgokit/plugins/embedding"`
+
+	switch strings.ToLower(strings.TrimSpace(cfg.Embedding.Provider)) {
+	case "openai", "azure":
+		if openAIEmbeddingFactory == nil {
+			return nil, fmt.Errorf("embedding provider %q requested but no OpenAI embedding factory is registered; %s", cfg.Embedding.Provider, registrationHint)
+		}
+		return openAIEmbeddingFactory(cfg.Embedding.APIKey, cfg.Embedding.Model), nil
+	case "ollama":
+		if ollamaEmbeddingFactory == nil {
+			return nil, fmt.Errorf("embedding provider \"ollama\" requested but no Ollama embedding factory is registered; %s", registrationHint)
+		}
+		return ollamaEmbeddingFactory(cfg.Embedding.Model, cfg.Embedding.BaseURL), nil
+	case "dummy":
+		return NewDummyEmbeddingService(cfg.Dimensions), nil
+	case "":
+		Logger().Error().
+			Str("memory_provider", cfg.Provider).
+			Msg("Memory is enabled but no embedding provider is configured - falling back to dummy embeddings. " +
+				"Semantic search results will be meaningless. " +
+				"Set embedding provider (\"openai\" or \"ollama\") or disable memory.")
+		return NewDummyEmbeddingService(cfg.Dimensions), nil
+	default:
+		return nil, fmt.Errorf("unsupported embedding provider %q (supported: openai, azure, ollama, dummy)", cfg.Embedding.Provider)
+	}
 }
 
 // Register embedding service factories

--- a/core/memory.go
+++ b/core/memory.go
@@ -378,23 +378,51 @@ func NewEmbeddingServiceForConfig(cfg AgentMemoryConfig) (EmbeddingService, erro
 		if openAIEmbeddingFactory == nil {
 			return nil, fmt.Errorf("embedding provider %q requested but no OpenAI embedding factory is registered; %s", cfg.Embedding.Provider, registrationHint)
 		}
-		return openAIEmbeddingFactory(cfg.Embedding.APIKey, cfg.Embedding.Model), nil
+		svc := openAIEmbeddingFactory(cfg.Embedding.APIKey, cfg.Embedding.Model)
+		warnOnDimensionMismatch(cfg, svc)
+		return svc, nil
 	case "ollama":
 		if ollamaEmbeddingFactory == nil {
 			return nil, fmt.Errorf("embedding provider \"ollama\" requested but no Ollama embedding factory is registered; %s", registrationHint)
 		}
-		return ollamaEmbeddingFactory(cfg.Embedding.Model, cfg.Embedding.BaseURL), nil
+		svc := ollamaEmbeddingFactory(cfg.Embedding.Model, cfg.Embedding.BaseURL)
+		warnOnDimensionMismatch(cfg, svc)
+		return svc, nil
 	case "dummy":
 		return NewDummyEmbeddingService(cfg.Dimensions), nil
 	case "":
 		Logger().Error().
 			Str("memory_provider", cfg.Provider).
 			Msg("Memory is enabled but no embedding provider is configured - falling back to dummy embeddings. " +
-				"Semantic search results will be meaningless. " +
-				"Set embedding provider (\"openai\" or \"ollama\") or disable memory.")
+				"Chat history will still work, but semantic search and RAG will return meaningless results. " +
+				"Fix: set embedding.provider to \"openai\" or \"ollama\" " +
+				"(v1beta: Memory.Options[\"embedding_provider\"], plus embedding_model / embedding_api_key / embedding_url as needed), " +
+				"or disable memory (v1beta: Memory.Enabled=false).")
 		return NewDummyEmbeddingService(cfg.Dimensions), nil
 	default:
 		return nil, fmt.Errorf("unsupported embedding provider %q (supported: openai, azure, ollama, dummy)", cfg.Embedding.Provider)
+	}
+}
+
+// warnOnDimensionMismatch logs when the configured vector dimensions disagree
+// with what the embedding service reports. This is a warning rather than an
+// error because service-reported dimensions are heuristic for unrecognized
+// models, but a real mismatch makes vector-store writes fail (or silently
+// corrupts similarity search), so it should be visible before the first write.
+func warnOnDimensionMismatch(cfg AgentMemoryConfig, svc EmbeddingService) {
+	if cfg.Dimensions <= 0 || svc == nil {
+		return
+	}
+	if got := svc.GetDimensions(); got > 0 && got != cfg.Dimensions {
+		Logger().Warn().
+			Str("embedding_provider", cfg.Embedding.Provider).
+			Str("embedding_model", cfg.Embedding.Model).
+			Int("configured_dimensions", cfg.Dimensions).
+			Int("model_dimensions", got).
+			Msg("Configured memory dimensions do not match the embedding model's dimensions - " +
+				"vector-store writes may fail or similarity search may degrade. " +
+				"Set dimensions to match the embedding model (v1beta: Memory.Options[\"dimensions\"]), " +
+				"and re-ingest existing data if the store was created with different dimensions.")
 	}
 }
 

--- a/core/memory_embedding_test.go
+++ b/core/memory_embedding_test.go
@@ -1,0 +1,104 @@
+package core
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// saveEmbeddingFactories snapshots and clears the package-level embedding
+// factory registrations so each test controls the registration state.
+func saveEmbeddingFactories(t *testing.T) {
+	t.Helper()
+	savedOpenAI := openAIEmbeddingFactory
+	savedOllama := ollamaEmbeddingFactory
+	savedDummy := dummyEmbeddingFactory
+	t.Cleanup(func() {
+		openAIEmbeddingFactory = savedOpenAI
+		ollamaEmbeddingFactory = savedOllama
+		dummyEmbeddingFactory = savedDummy
+	})
+	openAIEmbeddingFactory = nil
+	ollamaEmbeddingFactory = nil
+	dummyEmbeddingFactory = nil
+}
+
+func TestNewEmbeddingServiceForConfig_UnregisteredFactoryFailsLoudly(t *testing.T) {
+	saveEmbeddingFactories(t)
+
+	for _, provider := range []string{"openai", "azure", "ollama"} {
+		cfg := AgentMemoryConfig{
+			Provider:  "chromem",
+			Embedding: EmbeddingConfig{Provider: provider, Model: "some-model"},
+		}
+		svc, err := NewEmbeddingServiceForConfig(cfg)
+		if err == nil {
+			t.Errorf("provider %q: expected error when no factory registered, got service %T", provider, svc)
+			continue
+		}
+		if !strings.Contains(err.Error(), "plugins/embedding") {
+			t.Errorf("provider %q: error should point at the plugins/embedding import, got: %v", provider, err)
+		}
+	}
+}
+
+func TestNewEmbeddingServiceForConfig_RegisteredFactoryUsed(t *testing.T) {
+	saveEmbeddingFactories(t)
+
+	called := false
+	RegisterOllamaEmbeddingFactory(func(model, baseURL string) EmbeddingService {
+		called = true
+		return &noOpEmbeddingService{dimensions: 768}
+	})
+
+	cfg := AgentMemoryConfig{
+		Provider:  "chromem",
+		Embedding: EmbeddingConfig{Provider: "ollama", Model: "nomic-embed-text"},
+	}
+	svc, err := NewEmbeddingServiceForConfig(cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !called {
+		t.Error("registered Ollama factory was not invoked")
+	}
+	if svc == nil {
+		t.Fatal("expected a service, got nil")
+	}
+}
+
+func TestNewEmbeddingServiceForConfig_UnknownProviderIsError(t *testing.T) {
+	saveEmbeddingFactories(t)
+
+	cfg := AgentMemoryConfig{
+		Provider:  "chromem",
+		Embedding: EmbeddingConfig{Provider: "anthropic"},
+	}
+	if _, err := NewEmbeddingServiceForConfig(cfg); err == nil {
+		t.Error("expected error for unknown embedding provider, got nil")
+	}
+}
+
+func TestNewEmbeddingServiceForConfig_ExplicitDummyAndEmptyStillConstruct(t *testing.T) {
+	saveEmbeddingFactories(t)
+
+	for _, provider := range []string{"dummy", ""} {
+		cfg := AgentMemoryConfig{
+			Provider:   "chromem",
+			Dimensions: 4,
+			Embedding:  EmbeddingConfig{Provider: provider},
+		}
+		svc, err := NewEmbeddingServiceForConfig(cfg)
+		if err != nil {
+			t.Errorf("provider %q: unexpected error: %v", provider, err)
+			continue
+		}
+		vec, err := svc.GenerateEmbedding(context.Background(), "hello")
+		if err != nil {
+			t.Errorf("provider %q: GenerateEmbedding failed: %v", provider, err)
+		}
+		if len(vec) != 4 {
+			t.Errorf("provider %q: got %d dimensions, want 4", provider, len(vec))
+		}
+	}
+}

--- a/core/memory_embedding_test.go
+++ b/core/memory_embedding_test.go
@@ -2,6 +2,7 @@ package core
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 )
@@ -39,6 +40,9 @@ func TestNewEmbeddingServiceForConfig_UnregisteredFactoryFailsLoudly(t *testing.
 		if !strings.Contains(err.Error(), "plugins/embedding") {
 			t.Errorf("provider %q: error should point at the plugins/embedding import, got: %v", provider, err)
 		}
+		if !errors.Is(err, ErrEmbeddingFactoryNotRegistered) {
+			t.Errorf("provider %q: error should wrap ErrEmbeddingFactoryNotRegistered for programmatic handling, got: %v", provider, err)
+		}
 	}
 }
 
@@ -74,8 +78,12 @@ func TestNewEmbeddingServiceForConfig_UnknownProviderIsError(t *testing.T) {
 		Provider:  "chromem",
 		Embedding: EmbeddingConfig{Provider: "anthropic"},
 	}
-	if _, err := NewEmbeddingServiceForConfig(cfg); err == nil {
-		t.Error("expected error for unknown embedding provider, got nil")
+	_, err := NewEmbeddingServiceForConfig(cfg)
+	if err == nil {
+		t.Fatal("expected error for unknown embedding provider, got nil")
+	}
+	if !errors.Is(err, ErrEmbeddingProviderUnsupported) {
+		t.Errorf("error should wrap ErrEmbeddingProviderUnsupported for programmatic handling, got: %v", err)
 	}
 }
 

--- a/docs/AGNOSTIC_FRAMEWORK_ANALYSIS.md
+++ b/docs/AGNOSTIC_FRAMEWORK_ANALYSIS.md
@@ -1,0 +1,203 @@
+# AgenticGoKit — Path to a Truly LLM-Agnostic & Platform-Agnostic Agentic Framework
+
+**Scope:** Full-codebase analysis of `github.com/agenticgokit/agenticgokit` (v0.x, `v1beta` API generation) assessing what is needed to make it a genuinely LLM-agnostic, platform-agnostic, developer-friendly agentic AI framework for Go.
+
+**Method:** Direct inspection of `v1beta/` (~14.5k LOC), `core/` (~9.4k LOC), `core/vnext/` (~11k LOC), `internal/` (~35k LOC), `plugins/`, `examples/`, and `docs/`. Every claim below cites a file (and line where useful).
+
+---
+
+## 1. Executive Summary
+
+AgenticGoKit has strong bones: a clean builder-based public API, streaming-first design, four workflow patterns plus subworkflows, MCP support, embedded-by-default memory (chromem), and genuinely good observability (OpenTelemetry + zerolog + `AGK_TRACE`). Ten LLM providers are wired up, and the docs/examples footprint is large.
+
+However, it is **not yet LLM-agnostic in the ways that matter**. The abstraction is *transport-agnostic* (many HTTP backends) but *semantically OpenAI-shaped and single-turn*:
+
+1. **The core `Prompt` has no message history.** `internal/llm/types.go:30-46` models a call as `{System string, User string}`. Multi-turn agent loops are emulated by string-concatenating previous output and tool results into the next `User` string (`v1beta/agent_impl.go:1623-1631`). This defeats provider-native conversation handling, prompt caching, and tool-call protocols — and is the single biggest blocker to agnosticism.
+2. **Tool calling is primarily prompt-engineered text parsing** (`TOOL_CALL{...}` markers parsed in `v1beta/utils.go:494-539`). Native tool calling exists only in the Anthropic and Ollama adapters (`internal/llm/anthropic_adapter.go:300`, `internal/llm/ollama_adapter.go:190`); the OpenAI adapter has **no tool support at all** (`internal/llm/openai_adapter.go`). The team knows this — see `docs/NATIVE_TOOL_CALLING_ANALYSIS.md`.
+3. **There are two disconnected provider systems.** `plugins/llm/*` register into the *deprecated* `core` registry (`core.RegisterModelProviderFactory`, `core/llm.go:113`), while the *recommended* `v1beta` bypasses plugins entirely with a hard-coded switch (`internal/llm/factory.go:137-162`). The plugin adapters silently drop tools, multimodal content, and `BaseURL` (`plugins/llm/openai/openai.go:16-73`). Blank plugin imports shown in examples are no-ops for v1beta code paths.
+4. **Three API generations coexist** (`core`, `core/vnext`, `v1beta`), and `v1beta` *imports the deprecated `core` package* (`v1beta/provider_factory.go:9`, `v1beta/agent_impl.go:16`), so the promised "delete core in v1.0" is not currently executable without internalizing it first.
+5. **Platform coupling is mostly dependency-graph coupling**: one root `go.mod` forces `pgx`, `azure-sdk azcore` (used only in one *test* file — `internal/llm/azure_adapter_test.go:10`), `prometheus`, `chromem`, and `gorilla/websocket` onto every consumer. MCP rides on a personal repo (`github.com/kunalkushwaha/mcp-navigator-go v0.0.2`) rather than the official MCP Go SDK. Workflows have **no checkpoint/resume** — nothing survives a process restart.
+
+The good news: none of these are architectural dead-ends. The fixes are well-understood and sequenced in §6.
+
+---
+
+## 2. Current Architecture Snapshot
+
+```
+v1beta/            ← recommended public API (builder, agent, workflow, streaming, memory, tools, eval server)
+  └─ imports → core (deprecated!) + internal/llm + internal/observability
+core/              ← legacy API #1 (deprecated, still load-bearing: registries, Memory, MCP init)
+core/vnext/        ← legacy API #2 (renamed to v1beta; still shipped)
+internal/llm/      ← real provider adapters (10 providers, hardcoded factory switch)
+internal/{memory,mcp,embedding,observability,orchestrator,...}
+plugins/
+  llm/*            ← init()-registration into core registry (NOT used by v1beta)
+  memory/*         ← chromem / pgvector / weaviate (registered into core registry; v1beta uses these via core)
+  mcp/*            ← stdio / tcp / http_sse / http_streaming transports
+observability/     ← thin re-export of internal/observability
+```
+
+**LLM interface** (`internal/llm/types.go:133-148`):
+```go
+type ModelProvider interface {
+    Call(ctx, Prompt) (Response, error)
+    Stream(ctx, Prompt) (<-chan Token, error)
+    Embeddings(ctx, texts []string) ([][]float64, error)
+}
+```
+
+**Provider capability matrix** (as implemented in `internal/llm/`):
+
+| Provider | Streaming | Native tool calls | Multimodal in | Embeddings | Notes |
+|---|---|---|---|---|---|
+| OpenAI | ✅ | ❌ (none) | ✅ (content parts) | ✅ | default model hardcoded `gpt-4o-mini` (`factory.go:174`) |
+| Azure OpenAI | ✅ | ❌ | ✅ | ✅ | requires embedding deployment even if unused (`factory.go:212`) |
+| Anthropic | ✅ | ✅ (`anthropic_adapter.go:300,486`) | ✅ | ❌ (no embeddings API) | default `claude-sonnet-4-20250514` |
+| Ollama | ✅ | ✅ (`ollama_adapter.go:190-291`) | ✅ | ✅ | |
+| OpenRouter | ✅ | ❌ | ✅ | varies | |
+| HuggingFace | ✅ | ❌ | partial | varies | 4 API sub-modes; default model `gpt2` (`factory.go:291`) |
+| vLLM | ✅ | ❌ | partial | ✅ | |
+| MLFlow Gateway | ✅ | ❌ | ❌ | ✅ | own retry config |
+| BentoML | ✅ | ❌ | ❌ | varies | own retry config |
+| Foundry Local | ✅ | ❌ | ❌ | ❌ | |
+| **Missing** | — | — | — | — | **Gemini/Vertex, AWS Bedrock, Mistral, Groq, Together, Cohere, xAI; no generic `openai-compatible` type** |
+
+---
+
+## 3. LLM-Agnosticism: Gaps & Evidence
+
+### 3.1 Single-turn prompt model (critical)
+- `Prompt{System, User}` with a `TODO: Add fields for message history` (`internal/llm/types.go:45`).
+- Agent tool loops re-prompt by string-stuffing: *"Previous response:\n%s\n\nTool execution results:\n%s\n\n..."* (`v1beta/agent_impl.go:1623-1631` and `1740-1748`).
+- Consequences: no assistant/tool role fidelity, no provider prompt caching, degraded quality on long multi-turn tasks, impossible to implement correct native tool-call loops (which require echoing `tool_use`/`tool_result` blocks), and conversation memory must be flattened to text.
+
+### 3.2 OpenAI-shaped neutral types
+- `ToolDefinition{Type, Function{...}}` mirrors OpenAI's wrapper exactly (`internal/llm/types.go:17-27`); the shared multimodal builder emits OpenAI content-part JSON (`internal/llm/types.go:154-240`). Anthropic/Gemini formats must be back-translated from OpenAI's shape rather than from a neutral IR.
+
+### 3.3 Tool calling is not provider-native by default
+- Primary path parses `TOOL_CALL{...}` text markers from completions (`v1beta/utils.go:494-539`, `v1beta/tools.go:354-496`); agent even instructs models to emit that syntax (`v1beta/tools.go:354-357`).
+- Native path exists but only Anthropic + Ollama adapters honor `prompt.Tools`; OpenAI/Azure/OpenRouter/vLLM ignore them silently — a call that "works" on Ollama silently loses native tools on OpenAI.
+- `Token` stream carries only `{Content, Error}` — no tool-call deltas, no usage, no finish reason (`internal/llm/types.go:121-129`), so streaming tool use can't be surfaced even where the provider supports it.
+
+### 3.4 Closed, duplicated provider factories
+- v1beta → `internal/llm` hardcoded `switch config.Type` (`internal/llm/factory.go:137-162`); adding a provider = editing framework internals.
+- `ProviderConfig` is a god-struct with per-provider flattened fields (`HFTopP`, `VLLMBestOf`, `BentoMLRunners`, ... — `internal/llm/factory.go:30-105`); it grows monotonically with every provider.
+- The open registry that *does* exist (`core.RegisterModelProviderFactory`, `core/llm.go:104-122`) belongs to the deprecated API, and its plugin adapters drop capabilities (tools/media/BaseURL) in translation (`plugins/llm/openai/openai.go:16-73`).
+- Three memory registries similarly coexist: `core/memory.go:322`, `core/vnext/memory.go:159-168`, `v1beta/memory.go:200-209`.
+
+### 3.5 Opinionated defaults leak through the abstraction
+- `MaxTokens` silently defaults to **150** (`internal/llm/factory.go:127-129`) — a surprising truncation for agent workloads.
+- `Temperature: 0` cannot be expressed (zero-value conflated with "unset", `factory.go:130-132`), even though `ModelParameters` correctly uses pointers (`types.go:10-14`).
+- Default embedding dimensions hardcoded to OpenAI's 1536 regardless of provider (`v1beta/provider_factory.go:87,119-126`).
+
+### 3.6 Missing cross-cutting LLM services
+- No capability-detection API (`SupportsNativeTools()`, `Modalities()`, `MaxContextWindow()`); callers can't branch safely.
+- No structured-output / JSON-schema mode; no `RunTyped[T]`-style API despite Go generics.
+- No unified retry/rate-limit/backoff middleware — retries are re-implemented ad hoc per adapter (MLFlow, BentoML configs) and per agent (`RunOptions.MaxRetries`).
+- No prompt-caching, reasoning-token, or cost-accounting abstractions; `UsageStats` exists (`types.go:49-53`) but streaming discards it.
+
+---
+
+## 4. Platform-Agnosticism: Gaps & Evidence
+
+### 4.1 Dependency-graph coupling (single go.mod)
+Every consumer of the framework pulls: `pgx/v5` + `pgvector-go` (Postgres), `chromem-go`, `prometheus/client_golang`, `gorilla/websocket`, `fsnotify`, and `Azure azcore` — the last used **only in a test helper** (`internal/llm/azure_adapter_test.go:10`) yet listed as a direct dependency in `go.mod:7`. A multi-module layout (core + per-plugin modules) is the standard fix (cf. LangChainGo, OTel).
+
+### 4.2 MCP on a personal fork
+`github.com/kunalkushwaha/mcp-navigator-go v0.0.2` (`go.mod:12`) instead of the official `modelcontextprotocol/go-sdk`. Supply-chain and protocol-drift risk; MCP spec is moving fast (auth, streamable HTTP, elicitation).
+
+### 4.3 No durable execution
+No checkpoint/resume/persist anywhere in the 2,269-line workflow engine (`v1beta/workflow.go`); state lives in process memory. A crash mid-DAG loses everything. No pluggable state store, no idempotency keys, no distributed runner story — the features that make Temporal-style or serverless deployment possible.
+
+### 4.4 Framework/app boundary blur
+- An HTTP eval server ships inside the library package (`v1beta/eval_server.go:38,89,123`).
+- Trace files are written to a hardcoded `.agk/runs/<run-id>` relative path (`v1beta/builder.go:790`) — awkward in read-only container filesystems; needs an env override that is documented as primary.
+
+### 4.5 Storage & embeddings
+- Vector stores: chromem, pgvector, weaviate only (`plugins/memory/*`). No Qdrant, Milvus, Redis, sqlite-vec, or cloud-managed stores.
+- Embeddings are welded to `ModelProvider` (every LLM adapter must implement `Embeddings()` even when the provider has none, e.g., Anthropic) *and* to a separate internal factory supporting only openai/azure/ollama/dummy (`internal/embedding/factory.go:17-42`) — where the "azure" case constructs the *OpenAI* service (`factory.go:35`).
+- No document loaders/chunkers as first-class pluggable components; no reranking interface.
+
+### 4.6 What's already good
+- Observability is genuinely pluggable and cloud-neutral: OTel tracer with console/file/OTLP exporters selected by env (`v1beta/builder.go:780-806`), zerolog, run-ID context propagation (`observability/exports.go`).
+- Config: TOML with `${ENV_VAR}` expansion (`v1beta/config.go:542`) — solid, though TOML-only.
+- Pure-Go HTTP adapters (no cgo), so cross-compilation and containers work today.
+
+---
+
+## 5. Developer Experience: Gaps & Evidence
+
+1. **Three coexisting API surfaces** (`core` 9.4k + `core/vnext` 11k + `v1beta` 14.5k LOC over `internal` 35k). New users meet all three in examples: `examples/vllm-quickstart`, `bentoml-quickstart`, `mlflow-gateway-demo` still use `core`; 16 example imports alias v1beta as `vnext`; several blank-import LLM plugins that v1beta never consults.
+2. **v1beta cannot shed `core`** without work: it imports `core` in `provider_factory.go`, `agent_impl.go`, `core_wrappers.go`, `tool_discovery.go`, `utils.go` — mostly for Memory and MCP machinery. The v1.0 plan ("remove core entirely", `DEPRECATION.md:126-135`) requires migrating those internals first.
+3. **API bloat / legacy compat in the flagship types**: `Result` carries duplicated legacy fields (`v1beta/agent.go:71-77`), `RunOptions` is a 15-field god-struct (`agent.go:424-463`), `ToolManager` mixes MCP-specific methods into the general interface (`agent.go:282-303`).
+4. **Reliability of tool use** — because default tool invocation depends on the model emitting `TOOL_CALL{...}` text, results vary wildly by model; this is the #1 practical DX complaint this design will generate.
+5. **Versioning confusion**: a directory named `v1beta` inside a v0 module, with a stated plan to become directory `v1` — colliding conceptually with Go's semantic-import-versioning (`/v2` module suffixes). Needs an explicit decision and doc (`docs/API_VERSIONING.md` exists but the module-major story should be spelled out).
+6. **Testing kit**: an internal `mock` provider exists (`internal/llm/factory.go:26,477-484`) and is reachable via config `provider="mock"`, but there is no documented public fake LLM/memory/tool kit for user unit tests (compare Genkit's test helpers).
+7. **Docs drift**: `docs/ROADMAP.md` calls CLI tooling "completed" in-repo while the CLI now lives in a separate `agk` repo; `docs/reference/api/vnext/` still documents the renamed API; badges point at `kunalkushwaha/agenticgokit` (`README.md:14-15`).
+8. **Genuinely good DX already present**: fluent builder (`v1beta/builder.go`), rich stream chunk taxonomy (`v1beta/streaming.go:32-45`), structured error codes (`v1beta/agent.go:577-617`), Mermaid workflow visualization, `AGK_TRACE=true` one-liner observability.
+
+---
+
+## 6. Recommendations (Prioritized)
+
+### P0 — The agnosticism foundation (breaking, do before v1.0)
+
+| # | Recommendation | Addresses |
+|---|---|---|
+| 1 | **Message-based chat IR.** Replace `Prompt{System, User}` with `Messages []Message` (roles `system/user/assistant/tool`; multi-part content: text/image/audio/tool_use/tool_result). Provide `Prompt`→`Messages` shim for compat. | §3.1 |
+| 2 | **One open provider registry.** Make `v1beta` resolve providers through a public registry (`v1beta.RegisterProvider(name, factory)`); reimplement `internal/llm` adapters as self-registering plugins; delete the hardcoded switch and the god-config (per-provider options become typed option structs or `map[string]any` validated by the plugin). | §3.4 |
+| 3 | **Native tool calling everywhere, parsing as fallback.** Implement `tools` in the OpenAI/Azure/OpenRouter/vLLM adapters; translate a *neutral* ToolDefinition per provider; keep `TOOL_CALL{}` parsing only as an explicit opt-in fallback for non-tool models. Add tool-call deltas + usage + finish reason to the stream type. | §3.3, §3.2 |
+| 4 | **Capability discovery.** `type Capabilities struct { NativeTools, JSONMode, Streaming bool; Modalities []Modality; ContextWindow int }` on every provider; agents branch on it instead of silently degrading. | §3.6 |
+| 5 | **Fix parameter semantics.** Pointers (or `omitzero`-style options) for all sampling params; kill the 150-token default; allow `temperature=0`. | §3.5 |
+
+### P1 — Platform agnosticism
+
+| # | Recommendation | Addresses |
+|---|---|---|
+| 6 | **Multi-module split.** `agenticgokit` (zero heavy deps) + `plugins/llm/*`, `plugins/memory/pgvector`, `observability/prometheus`, etc. as separate Go modules. Remove `azcore` from root deps (test-only). | §4.1 |
+| 7 | **Adopt the official MCP Go SDK** (`modelcontextprotocol/go-sdk`), keeping the transport plugins as thin wrappers. | §4.2 |
+| 8 | **Separate `Embedder` from `ModelProvider`**; add embedding plugins (Gemini, Voyage, Cohere, local/ONNX); make vector-store an independent `VectorStore` interface; add Qdrant/Redis/sqlite-vec providers; per-provider default dimensions. | §4.5 |
+| 9 | **Durable workflows.** `CheckpointStore` interface (memory/file/Postgres/S3 implementations), step-level checkpoints on the existing workflow engine, `workflow.Resume(runID)`. This is the wedge that enables serverless & distributed execution later. | §4.3 |
+| 10 | **Move the eval HTTP server and websocket demos out of the library** (separate module or the `agk` repo); make `.agk` trace dir fully configurable with documented env/opt. | §4.4 |
+| 11 | **Add the missing majors:** Gemini (native, not proxy), AWS Bedrock, Mistral, Groq — plus a generic `openai-compatible` provider type so any conforming endpoint works with zero code. | §2 matrix |
+
+### P2 — Developer experience
+
+| # | Recommendation |
+|---|---|
+| 12 | **Execute the deprecation:** migrate the `core` machinery v1beta needs into `internal/`, delete `core` + `core/vnext` from the public surface, convert all examples to plain `v1beta` imports (no `vnext` alias, no dead blank imports). |
+| 13 | **Structured output:** `agent.RunTyped[T](ctx, input)` using provider JSON-mode where available, schema-guided retry elsewhere. |
+| 14 | **Public testing kit:** `v1beta/agenttest` with scriptable fake provider (incl. tool-call scripts and stream scripts), fake memory, fake tools. |
+| 15 | **Cross-provider middleware:** retry/backoff/rate-limit/cost-tracking as provider-wrapping middleware (one implementation, all providers). |
+| 16 | **Slim the flagship types:** split `Result` legacy fields behind a compat layer; decompose `ToolManager` (core tools vs MCP extension interface); document the module-major versioning decision. |
+| 17 | **Docs hygiene:** retire `docs/reference/api/vnext`, fix `kunalkushwaha/*` badges, align ROADMAP with the split CLI repo. |
+
+### Suggested sequencing
+1. **Milestone A (unblocks everything):** #1 messages IR + #3 native tools + #5 params — one coherent breaking change to `internal/llm`.
+2. **Milestone B:** #2 registry + #4 capabilities + #11 new providers (community can now contribute providers without touching internals).
+3. **Milestone C:** #6 module split + #8 embedder/vector split + #7 MCP SDK.
+4. **Milestone D:** #9 durability, then the P2 DX items riding along each release.
+
+---
+
+## 7. How this compares to the Go ecosystem
+
+| Dimension | AgenticGoKit today | LangChainGo | Firebase Genkit (Go) | CloudWeGo Eino |
+|---|---|---|---|---|
+| Chat IR (multi-turn messages) | ❌ single-turn | ✅ | ✅ | ✅ |
+| Native tool calling | partial (2/10 providers) | ✅ | ✅ | ✅ |
+| Open provider registry | ❌ (in deprecated API only) | ✅ | ✅ (plugins) | ✅ |
+| Structured output | ❌ | partial | ✅ (typed, generics) | ✅ |
+| Multi-agent workflows (seq/par/DAG/loop/sub) | ✅ strong | ❌ weak | partial (flows) | ✅ (graphs) |
+| Streaming-first API | ✅ strong | partial | ✅ | ✅ |
+| Built-in RAG w/ zero config | ✅ (chromem default) | ❌ | partial | ❌ |
+| MCP | ✅ (unofficial SDK) | partial | ✅ | ✅ |
+| Durable execution | ❌ | ❌ | partial (via Firebase) | ❌ |
+| Observability out of the box | ✅ strong | ❌ | ✅ | ✅ |
+
+**Positioning insight:** AgenticGoKit's differentiators are the workflow engine, streaming, batteries-included memory, and observability. Its deficits are exactly the two things every competitor got right first — a message-based LLM IR and native tool calling behind an open registry. Closing §6 P0 makes the framework competitive; P1 makes it the most deployment-flexible option in Go.
+
+---
+
+*Report generated from static analysis of the repository at commit `e4efbc3` ("Guard generated data before persistence (#135)").*

--- a/docs/CONSOLIDATED_REPORT.md
+++ b/docs/CONSOLIDATED_REPORT.md
@@ -1,0 +1,201 @@
+# AgenticGoKit — Consolidated Assessment & Roadmap
+
+**Date:** 2026-07-31 · **Branch:** `claude/go-agnostic-framework-analysis-ekyl3a` (PR #156)
+**Scope of work behind this report:** full static analysis of the repository; a 10-agent deep-research pass (4 codebase subsystem deep-dives + 6 competitive-landscape studies from primary sources, 146 findings); evaluation of the org ecosystem (`agk` CLI, `agk-templates` registry); 17 GitHub issues filed; 2 critical bugs fixed, tested, and shipped on this branch.
+
+**Companion documents (full detail):**
+- `docs/AGNOSTIC_FRAMEWORK_ANALYSIS.md` — LLM/platform-agnosticism analysis with file:line evidence
+- `docs/DEVELOPER_FIRST_ROADMAP.md` — full research synthesis: trust-layer bug tables, feature pillars, ecosystem evaluation
+- Issues #139–#155 (umbrella: #155) · PR #156 (fixes for #137/#143)
+
+---
+
+## 1. Executive summary
+
+AgenticGoKit has the right ambitions and several genuinely strong assets: a builder-based v1beta API, streaming-first design, four workflow modes plus subworkflows, batteries-included memory, OTel-based observability, and an ecosystem shape (CLI + template registry) that matches what Genkit/Mastra/ADK converged on. The `agk` TUI trace explorer and LLM-judge eval matchers are ahead of most Go competition.
+
+Against the goal — *the best developer-focused, LLM-agnostic, platform-agnostic agentic framework in Go* — there are four gaps, in order of severity:
+
+1. **The LLM abstraction is single-turn and OpenAI-shaped.** No message history (`Prompt{System, User}`); tool calling is mostly prompt-parsed `TOOL_CALL{...}` text; native tool calls exist in only 2 of 10 adapters; the plugin registry serves only the deprecated `core` API while v1beta uses a hardcoded switch.
+2. **A trust layer of correctness debt.** Deep re-reading found data races (`go test -race` fails), silent semantic divergences (DAG streams as Sequential; `Transform` applied twice), broken cancellation, error-swallowing streams, fabricated tool results, and an extensive surface of *decorative configuration* — documented knobs (retry, rate-limit, circuit breaker, cache backends, flush intervals) that no code reads.
+3. **No durability.** Workflows are in-process only; nothing survives a restart; no checkpoint/resume, no human-in-the-loop suspension.
+4. **Ecosystem without contracts.** `agk` pins framework v0.5.5 and consumes undocumented internals (debug-format trace files, an eval server whose traces are empty); scaffolded templates bake known framework bugs into every new project.
+
+None are dead ends. The strategy: **fix the trust layer, then bet on Go's unfair advantages — typed everything, durable by default, and the best dev loop in the ecosystem.**
+
+---
+
+## 2. What was already delivered on this branch (PR #156)
+
+| Item | Status |
+|---|---|
+| Zero-vector/dummy embedding silent degradation (#137) — factories now always registered in v1beta; fail-loud resolver (`core.NewEmbeddingServiceForConfig`); real embedding models derived from LLM provider (never the chat model); dimensions auto-derived; `NewMemory` no longer swallows errors | ✅ fixed + tested |
+| `WithConfig` discarding `NewBuilder` name; `Memory.Enabled=false` ignored (#137 A/B) | ✅ fixed + tested |
+| `MaxTokens` silent 150 default; temperature 0 unexpressible; per-run sampling overrides never reaching the provider (#143 quick wins) | ✅ fixed + tested |
+| Actionable errors (`ollama pull <model>`, `ollama serve`, API-key hints); dimension-mismatch warning at construction | ✅ shipped |
+| Consumer-facing diagnostics: typed `Diagnostic` values via `WithDiagnosticHandler`/`DiagnosticsOf`, typed sentinel errors (`errors.Is`-able) — findings as values, not black-hole logs | ✅ shipped |
+| 25 new tests across 7 test files; all touched suites green; no new failures vs master | ✅ |
+
+**Issues filed:** #139–#154 (16 findings) + #155 (umbrella tracker), cross-referenced with pre-existing #121, #137, #138.
+
+---
+
+## 3. LLM- & platform-agnosticism assessment (condensed)
+
+*(Full evidence: `docs/AGNOSTIC_FRAMEWORK_ANALYSIS.md`)*
+
+### Blockers to true LLM-agnosticism
+- **Single-turn prompt model** — multi-turn is emulated by string-stuffing prior output into the next `User` string; breaks provider conversations, prompt caching, and correct tool loops. → **#139** (message-based chat IR).
+- **Tool calling** — `TOOL_CALL{}` text parsing by default; OpenAI adapter has zero native tool support; streams can't carry tool-call deltas or usage. → **#140**.
+- **Two disconnected provider systems** — `plugins/llm/*` register into deprecated `core` (and drop tools/multimodal/BaseURL in translation); v1beta uses a hardcoded factory switch with a per-provider god-config. → **#141, #142** (open registry + capability discovery).
+- **Missing providers** — no Gemini, Bedrock, Mistral, Groq; no generic `openai-compatible` type. → **#149**.
+- **Parameter semantics** — fixed in part (PR #156); full pointer-based optionals remain in **#143**.
+
+### Blockers to platform-agnosticism
+- **One fat go.mod** — every consumer pulls pgx, chromem, Prometheus, websocket, and an Azure SDK used only in a test. → **#144** (multi-module split).
+- **MCP on a personal fork** (`kunalkushwaha/mcp-navigator-go v0.0.2`) instead of the official v1.0-stable `modelcontextprotocol/go-sdk`. → **#145**.
+- **No durable execution** — no checkpoint/resume anywhere in the 2,270-line workflow engine. → **#147**.
+- **Embedded HTTP eval server in the library package**; hardcoded `.agk/runs` relative path. → **#148**.
+- **Embeddings welded to `ModelProvider`**; three parallel memory registries; vector stores limited to chromem/pgvector/weaviate. → **#146**.
+
+### API-surface debt
+Three coexisting generations (`core` ~9.4k LOC, `core/vnext` ~11k, `v1beta` ~14.5k over `internal` ~35k); **v1beta imports the deprecated `core`**, so "delete core at v1.0" requires internalizing it first (**#150**). `Result`/`RunOptions`/`ToolManager` bloat → **#154**.
+
+---
+
+## 4. The trust layer: new correctness findings (deep-research pass)
+
+*(Full tables with file:line evidence: `docs/DEVELOPER_FIRST_ROADMAP.md` §1. These are new findings beyond §3, discovered by subsystem re-reads; none yet filed as issues.)*
+
+### Workflow engine
+- DAG + `RunStream` **silently executes as Sequential** (stub delegates; dependencies ignored).
+- `Step.Transform` **applied twice** in every streaming path.
+- Workflows are **single-use and racy**: shared mutable `WorkflowContext` across runs; unlocked writes under Parallel mode.
+- **No per-step retry/timeout/failure strategy**; parallel errors collapse to `errors[0]`; DAG runs ready steps *serially* and reports cycles only mid-run as "deadlock".
+- Stringly-typed data flow: fan-in is a lossy `"\n"`-join; step errors flattened to strings (breaks `errors.Is/As`).
+- Library **prints to stdout and uses `os.Setenv` as IPC** between workflow and agents (races across concurrent workflows).
+
+### Streaming
+- **`Stream.Cancel()` never cancels the LLM request** (tokens and money keep flowing).
+- **Producer errors never reach `Wait()`** — failed agent steps are marked `Success=true` and empty output feeds the next step.
+- `RunStreamWithOptions` mutates the live agent (races; `ToolMode:"none"` permanently strips tools).
+- Parallel workflow streaming is a **data race** on the shared stream writer.
+- `Capabilities.Tools`/`Memory` never wired — the entire handler-augmentation library silently no-ops; three incompatible tool-call prompt protocols coexist.
+- `StreamChunk.Error` doesn't JSON-serialize; no SSE/WS bridge (examples hand-roll three ~236-line servers); `FlushInterval`/`Config.Streaming` are dead config that docs tell users to tune.
+
+### Tools & MCP
+- **Reliability config is decorative**: tool `Timeout`/`MaxRetries`/`RateLimit`/`MaxConcurrent`/`CircuitBreaker` validated, documented, never enforced.
+- **`MCPAwareAgent` fabricates successful tool results** when caching is off (never contacts a server).
+- Unified MCP transport **dials + handshakes + disconnects per tool call**; 1,800 lines of pooling/LB/retry code never instantiated; health checks pass via a no-op `Connect()`.
+- Fallback tool schema `{"input": string}` corrupts native tool calls (framework ships a hack to undo its own fallback).
+- stdio MCP servers can't receive args/env; the stdio plugin error messages recommend is an unimplemented stub; unknown tools route to an arbitrary server.
+- No parallel tool execution, no approval hooks/dangerous-tool gating, one global auth token for all MCP servers.
+
+### Config, observability, eval
+- **Unknown TOML keys silently ignored**; `timeout = 30` parses as **30 nanoseconds** and passes validation.
+- TOML provider whitelist **rejects five providers the factory supports**; env expansion is a 12-field whitelist and unset `${VAR}` passes through as a literal.
+- Spans use bespoke `agk.*` attributes instead of **OTel GenAI semconv (`gen_ai.*`)** — invisible to LLM observability tooling; OTLP export broken as documented (scheme bug, no headers); trace.jsonl is OTel's *unstable debug format*; `manifest.json` fabricates stats (0 tokens, $0 — #138).
+- Eval server: traces are empty shells, sessions never feed history to the agent, workflow success hardcoded `true`, binds all interfaces with no auth.
+
+**Verdict:** the "Trustworthy" release (§7, v0.6) exists to zero this list. Brand promise: `-race` clean, every documented knob enforced or deleted, `errors.Is` end-to-end, no fabricated data anywhere.
+
+---
+
+## 5. Feature roadmap: six pillars (landscape-informed)
+
+*(Full design sketches and sources: `docs/DEVELOPER_FIRST_ROADMAP.md` §2. Landscape studied: LangGraph, PydanticAI, OpenAI Agents SDK, Genkit Go, ADK-go, Eino, Temporal/Restate/DBOS/Inngest/River, MCP go-sdk, Vercel AI SDK v5, Mastra, mem0/Letta, smolagents.)*
+
+**A. Typed everything** — Go's headline advantage:
+`Agent[Deps, Output]` generics with typed DI (`RunContext[D]`) and test overrides (PydanticAI); `tools.New[In, Out]` with schemas inferred from struct tags, input *and* output validated (Eino/ADK-go/MCP-SDK convergence); structured output declared once with pluggable mode (tool/native/prompted) and a validation-driven retry loop (`ModelRetry`); typed workflow steps with compile-time edge checking, per-step retry/timeout/fallback/cache, `Validate()` + Mermaid export (Mastra/Eino); provider fallback and declarative throttle/debounce as decorators.
+
+**B. Durable by default** — the strategic wedge, nothing in Go agent-land has it:
+journal-skip execution (DBOS/Restate model — *no* Temporal determinism constraints) over an embedded **SQLite journal** (two tables, zero infrastructure; Postgres for scale); a tiny 5-method `Checkpointer` contract with a conformance suite (LangGraph's winning move); LLM/tool/MCP calls auto-wrapped as durable steps (`agk.Durable(store)`, per-run `Durability(Exit|Async|Sync)`); `Interrupt`/`Resume` for human approval; awakeables, durable sleep/cron; **fork-from-step time travel** ("agent derailed at tool call 7 — fork from 6 without re-paying for 1–6"); deterministic idempotency keys surfaced to tools; a `workflowcheck`-style `go vet` analyzer.
+
+**C. Streaming as a product**:
+fix semantics first (Part 4); then speak the **Vercel AI SDK v5 UIMessage SSE protocol** natively (`uistream` http.Handler — every `useChat` frontend works instantly; PydanticAI and Mastra already emit it); resumable streams via a pluggable `EventStore`; stream-aware routing (decide tool-vs-answer from the first frame); typed custom progress events from any tool/step.
+
+**D. Multi-agent primitives the industry converged on**:
+agents-as-tools as the primary currency (Eino deprecated transfer-handoffs); handoffs with typed payloads + history filters where control must move (OpenAI); dynamic fan-out `Send` for map-reduce (LangGraph — Go's errgroup makes it a marquee feature); guardrails with tripwires raced in parallel via context cancellation; 4-method `Session` interface + ADK scope-prefixed shared state (`app:`/`user:`/`temp:`) with `OutputKey`; hard `UsageLimits` and `stop_on_first_tool`.
+
+**E. The dev loop** — adoption is won here:
+`agk dev` single-binary playground (embed.FS web UI + the existing TUI, one reflection protocol; Genkit/Mastra's most-loved feature); an `Action` registry as the substrate (agents/workflows/tools/prompts/evaluators all introspectable — Genkit's architectural insight); `.prompt` files (dotprompt) for versioned prompts with typed schemas; **evals under `go test`** (data + task + scorers, trials, LLM-judge, span-based assertions, capture-live-session→eval-case loop); LLM-free `TestModel`/`ScriptModel` + `BlockRealRequests()` CI guard; scaffold `AGENTS.md` and publish `llms.txt` (your users' coding agents are your docs' main readers).
+
+**F. Ecosystem & interop**:
+official MCP go-sdk both directions — client (replaces fork, fixes transports/auth) and `agent.AsMCPServer()` + `agk mcp publish` to the official registry; OTel GenAI semconv + honest cost rollups; memory with extraction semantics (mem0-style pipeline + Letta-style tiers) on the existing storage layer; A2A via `a2a-go`; opt-in **code-as-action** sandbox (Starlark/wazero — natively safe in Go, impossible for Python without external sandboxes).
+
+---
+
+## 6. Ecosystem: agk CLI + template registry
+
+*(Full detail: `docs/DEVELOPER_FIRST_ROADMAP.md` §5.)*
+
+**Assets** — stronger than the framework docs advertise: `agk init` scaffolding with a real template manifest contract (`agk-template.toml`); template registry with fetcher/cache; a substantial **bubbletea TUI trace explorer** + Mermaid export; `agk eval` with embedding/LLM-judge/hybrid matchers, markdown reports, CI recipe. The eval server's missing consumer turned out to live here.
+
+**Risks:**
+1. **Version skew by construction** — agk pins framework v0.5.5; no compatibility contract; no cross-repo CI.
+2. **CLI stands on the two least-stable framework contracts** — the debug-format trace.jsonl and the empty-shell eval traces; `agk trace show` inherits fabricated 0-token/$0 stats.
+3. **Scaffolder amplifies framework bugs** — generated projects carry no-op plugin imports (v1beta ignores the plugin registry) and no embedding config (pre-fix, that reproduced #137 in every memory scaffold).
+4. **Registry index is a bare name→repo map** — no versions/pins/checksums, `min_agk_version` unenforced, templates fetch mutable branches and can run `post_create` hooks (soft supply-chain risk).
+
+**Recommendations (G1–G6):** a versioned framework↔CLI contract (stable trace schema + OpenAPI eval spec in a shared module, nightly cross-repo CI); fix the scaffolds (real imports, embedding config, generated `AGENTS.md`, starter eval file); registry v2 (versions, pins, enforced `min_agk_version`, published template-conformance CI action); `agk dev` absorbs the dev-loop pillar; unify eval matchers into a framework package with two frontends; distribution polish (released binaries, compat check).
+
+---
+
+## 7. Sequenced release plan
+
+| Release | Theme | Contents |
+|---|---|---|
+| **v0.6 "Trustworthy"** | Zero known lies | All §4 fixes (`-race` clean CI gate); strict TOML + duration parsing; enforce-or-delete every config knob; honest manifests/health/results; framework↔CLI contract (G1) + scaffold fixes (G2); ship `AGENTS.md`/`llms.txt`. |
+| **v0.7 "Typed"** | Compile-time safety | Message IR (#139) → native tools everywhere (#140) → open provider registry + capabilities (#141/#142) → `Agent[D,O]`, `tools.New[In,Out]`, structured output w/ retry, typed steps; testing kit (#152); Gemini/Bedrock/`openai-compatible` (#149); registry v2 (G3). |
+| **v0.8 "Durable"** | The wedge | SQLite journal-skip engine, `Checkpointer` contract, auto-wrapped steps, `Interrupt`/`Resume` + approval events, sessions & scoped state, durable sleep/cron; multi-module split (#144). |
+| **v0.9 "Delightful"** | Dev loop | Action registry → `agk dev` playground (G4) → AI SDK v5 wire format + resumable SSE → `.prompt` files → evals under `go test` + capture loop (G5) → OTel GenAI semconv. |
+| **v1.0 "Complete"** | Ecosystem | Multi-agent primitives (agents-as-tools, handoffs, Send, guardrails, usage limits), MCP server export + registry publish, memory tiers, A2A, fork-from-step; delete `core`/`core/vnext` (#150); API-surface cleanup (#154). |
+
+**Dependency spine:** message IR → typed agents/tools → sessions → durability → dev UI → evals.
+
+---
+
+## 8. Capability checklist (today → target)
+
+| Capability | Today | Reference |
+|---|---|---|
+| Multi-turn message IR | ❌ | everyone |
+| Typed agents / tools / steps | ❌ | PydanticAI / Eino / Mastra |
+| Structured output + self-correction | ❌ | PydanticAI |
+| Per-step retry/timeout/fallback/cache | ❌ | LangGraph |
+| Durable checkpoint/resume (zero infra) | ❌ | DBOS design, LangGraph contract |
+| Interrupt / HITL / time travel | ❌ | LangGraph / Mastra / DBOS |
+| Streaming: cancel, usage, tool deltas | ❌ broken | AI SDK v5 / Eino |
+| useChat-compatible wire protocol | ❌ | Vercel AI SDK v5 |
+| Guardrails / handoffs / Send / sessions / usage limits | ❌ | OpenAI SDK / LangGraph / ADK |
+| Dev UI playground (single binary) | ❌ (TUI trace viewer ✅ in agk) | Genkit / Mastra |
+| Prompts as artifacts | partial (`prompts/*.txt` in templates) | Genkit dotprompt |
+| Evals in `go test` + CI + live traces | partial (`agk eval` HTTP-only) | Braintrust / DeepEval / Mastra |
+| LLM-free TestModel/ScriptModel | partial (mock provider) | PydanticAI |
+| OTel GenAI semconv | ❌ `agk.*` | PydanticAI / OpenAI SDK |
+| MCP official SDK client + server export | ❌ fork, client-only | MCP go-sdk |
+| A2A | ❌ | ADK |
+| Memory extraction pipeline + tiers | ❌ storage only | mem0 / Letta |
+| Code-as-action sandbox (native) | ❌ | smolagents (idea), Go-unique execution |
+| Template registry + scaffolding | ✅ shape right, contracts missing | (ahead of Go competition) |
+| Race-clean guarantee | ❌ fails | Go table stakes |
+
+---
+
+## 9. What NOT to build
+
+1. **No literal Python ports** — LangChainGo's `map[string]any` chains + single-maintainer stall is the cautionary tale. Tiny interfaces, conformance tests, community-owned backends.
+2. **No Temporal programming model** — event-replay determinism constraints would poison Go DX; journal-skip gives ~90% of the value. Offer a Temporal *adapter* instead.
+3. **No four streaming paradigms** — Eino's concept load is its own documented regret. Public API: `Invoke` and `Stream`.
+4. **No proprietary wire formats** — speak AI SDK v5 SSE and MCP; the clients already exist.
+5. **No decorative config** — a knob that does nothing is a lie a customer discovers in production. Enforce or delete (CI-checkable).
+6. **No silent fallbacks** — #137 generalizes. Fail loudly; return diagnostics as values (the `Diagnostic`/sentinel pattern now in v1beta); make "no fabricated data" a review gate.
+
+---
+
+## 10. Recommended immediate next steps
+
+1. **Merge PR #156** (bug fixes + diagnostics + this report set).
+2. **File the §4 trust-layer findings as issues** (~35, mostly small; several are one-line fixes with outsized credibility value: double-Transform, DAG-streams-as-sequential, Cancel, Wait errors).
+3. **Start v0.6** with the race fixes and enforce-or-delete pass — it requires no design debate and rebuilds the foundation everything else stands on.
+4. **Decide the two strategic bets** (typed core in v0.7, embedded durability in v0.8) — both need early API-shape decisions (`Agent[D,O]` signature; `Checkpointer` contract) since the community will build against them.

--- a/docs/DEVELOPER_FIRST_ROADMAP.md
+++ b/docs/DEVELOPER_FIRST_ROADMAP.md
@@ -1,0 +1,266 @@
+# AgenticGoKit — Roadmap to the Best Developer-Focused Agentic Framework in Go
+
+**Method:** 10-agent deep research pass — 4 agents re-reading this codebase subsystem by subsystem (workflow engine, streaming/handlers, tools/MCP, config/observability/eval), 6 agents studying the current framework landscape from primary sources (LangGraph, PydanticAI, OpenAI Agents SDK, Genkit Go, Google ADK-go, CloudWeGo Eino, Temporal/Restate/DBOS/Inngest/River, MCP go-sdk, Vercel AI SDK v5, Mastra, mem0/Letta, smolagents). 146 findings synthesized here. Companion documents: `docs/AGNOSTIC_FRAMEWORK_ANALYSIS.md` (LLM/platform agnosticism) and issues #139–#155.
+
+---
+
+## 0. Thesis: what "best developer-focused" means in Go
+
+Every successful 2025–26 framework won on a different axis: LangGraph on **durable state**, PydanticAI on **type safety**, Genkit/Mastra on the **dev loop**, Eino on **typed streaming orchestration**, the OpenAI SDK on **small proven primitives** (handoffs, guardrails, sessions). Nobody in Go has combined them, and the incumbent Go options are weak: LangChainGo is a pre-generics port stuck at v0.1.x openly seeking maintainers; Eino is powerful but carries a steep concept load (four streaming paradigms, boxing, pregel-vs-dag) that its own docs apologize for.
+
+Go's unfair advantages line up exactly with what agent developers are missing:
+
+1. **Compile-time safety** → typed agents, tools, and workflow steps that fail at build, not on request N in production.
+2. **Single static binary** → dev UI, API server, console REPL, and A2A endpoint from *one* compiled artifact (embed.FS) — no npm, no sidecar.
+3. **Real concurrency** → parallel tool calls, guardrails racing the main agent, streaming fan-in — things Python frameworks emulate.
+4. **`go test` culture** → evals and LLM-free agent tests as ordinary tests, race-detector-clean as a brand promise.
+5. **Temporal-class durability heritage** → Go is *the* language of durable execution (Temporal, DBOS, Restate, River all ship first-class Go SDKs); an embedded journal-skip engine is a natural fit.
+
+The strategy: **fix the trust layer, then bet on three differentiators — typed everything, durable by default, and the best dev loop in the ecosystem.**
+
+---
+
+## 1. Part I — The trust layer: correctness debt that blocks "best DX" claims
+
+Deep re-reading found bugs that would end an evaluation by a serious Go team. These come **before** any feature work; several fail `go test -race`.
+
+### 1.1 Workflow engine (v1beta/workflow.go)
+
+| # | Finding | Evidence |
+|---|---------|----------|
+| W1 | **DAG + RunStream silently executes as Sequential** — `executeDAGStreaming` is a stub delegating to sequential; dependencies ignored, no validation. Same object, different semantics per entry point. | workflow.go:796-801 |
+| W2 | **`Step.Transform` applied twice in every streaming path** ("Summarize: Summarize: ..."). | workflow.go:599-614, 712-727 vs 928-931 |
+| W3 | **Workflows are single-use and racy**: one shared `WorkflowContext` across runs (stale StepResults on second Run), unlocked writes to `CurrentStep`/`IterationNum` under Parallel mode. Needs per-run state; Workflow should be a reusable template like `http.Handler`. | workflow.go:248-256, 271-272, 1694, 1537 |
+| W4 | **No per-step retry/timeout/failure strategy**; parallel mode returns `errors[0]` and discards the rest (no `errors.Join`), no fail-fast cancellation. Ironically tools config *has* retry/circuit-breaker knobs. | workflow.go:60-67, 1324-1327; config.go:158-169 |
+| W5 | **DAG execution is serial** (ready steps run one-at-a-time), O(n²), and cycles/typo'd dependencies surface only mid-run as "deadlock" after burning tokens. | workflow.go:1375-1497 |
+| W6 | **Stringly-typed data flow**: fan-in is `"\n"`-join of dependency outputs — a step can't tell which dep produced what; failures silently fall back to original input. | workflow.go:1737-1757 |
+| W7 | Streaming discards the whole `WorkflowResult` (no StepResults/IterationInfo) and **emits the final output twice**. | workflow.go:493-517, 472-476 |
+| W8 | Step errors flattened to strings with `%s` — `errors.Is/As` impossible; the framework's own typed-error package is unusable against its own engine. | workflow.go:1715-1726, 1174-1181 |
+| W9 | Loop condition builders are stateful one-shot closures (reuse silently mis-converges); `Convergence` "edit distance" is a positional byte compare. | workflow.go:1914-1961 |
+| W10 | Library **prints to stdout and `os.Setenv`s AGK_RUN_ID/TRACE vars as IPC** — races across concurrent workflows; unacceptable in a server. | workflow.go:332-388 |
+| W11 | SubWorkflow recursion guard inert (depth never propagates); `RunStreamWithOptions` drops options; nil-deref on error path. | subworkflow.go:117, 229-232, 154-160 |
+
+### 1.2 Streaming (v1beta/streaming.go, agent_impl.go)
+
+| # | Finding | Evidence |
+|---|---------|----------|
+| S1 | **`Stream.Cancel()` never cancels the LLM request** — provider gets the parent ctx; tokens (and money) keep flowing after cancel. | streaming.go:277-280 vs agent_impl.go:1003 |
+| S2 | **Producer errors never reach `Wait()`** — failed streams return `(nil, nil)`; workflow steps mark failed agents `Success=true` and feed empty output onward. | agent_impl.go:947-949, 1004-1013; workflow.go:1017-1029 |
+| S3 | **`RunStreamWithOptions` mutates the live agent** (config swap restored before the goroutine reads it — a straight race; `a.tools` filtered with *no restore at all* — one `ToolMode:"none"` call permanently strips tools). | agent_impl.go:1151-1223 |
+| S4 | **Parallel workflow streaming is a data race** on `basicStream.Write` (unlocked `chunkIdx`, concurrent user handler). | workflow.go:688-729; streaming.go:346-393 |
+| S5 | **`Capabilities.Tools`/`Memory` are never wired** — the entire handlers.go augmentation library (`WithToolAugmentation` etc.) silently no-ops; three incompatible tool-call prompt protocols coexist. | agent_impl.go:573-585; handlers.go:77-86, 100-131 |
+| S6 | `StreamChunk.Error` is type `error` → JSON-marshals as `{}`; **no SSE/WebSocket bridge exists**, so examples hand-roll three ~236-line websocket servers with a parallel message taxonomy. | streaming.go:60; examples/*/websocket_server.go |
+| S7 | `FlushInterval`, `Config.Streaming` are **dead config** — docs recommend tuning knobs nothing reads. | streaming.go:174-250; docs/v1beta/performance.md:81-87 |
+| S8 | Backpressure undefined: blocking Write + hidden always-on 5-minute timeout; sync handler in the hot path; handler `false` doesn't stop generation. | streaming.go:378-392, 187 |
+| S9 | Tool calls parsed only after stream ends — raw `TOOL_CALL{...}` text streams to the user; no tool-call deltas; no post-tool synthesis in stream path; ToolRes chunks lack ToolID. | agent_impl.go:1068-1087, 2094-2145 |
+
+### 1.3 Tools & MCP
+
+| # | Finding | Evidence |
+|---|---------|----------|
+| T1 | **Reliability config is decorative**: `Timeout`, `MaxRetries`, `RateLimit`, `MaxConcurrent`, `CircuitBreaker` are validated, documented — and never enforced anywhere in the execution path. A hung tool blocks forever. | tools.go:214-239 vs agent_impl.go:1515-1638 |
+| T2 | **`MCPAwareAgent` fabricates successful tool results** when caching is off (`executeToolDirect` returns hardcoded "Result from %s" — never contacts a server). Plausible wrong answers, silently. | internal/mcp/mcp_agent.go:277-310 |
+| T3 | **Unified MCP transport dials + handshakes + disconnects per tool call**; the 1,800 lines of pooling/load-balancing/retry code in internal/mcp are never instantiated. `Connect()` is a no-op bool-flip, so health checks lie. | plugins/mcp/unified/unified.go:817-831, 602-624 |
+| T4 | Fallback tool schema is `{"input": string}` — teaches models to double-wrap args; the framework ships a `normalizeToolArgs` hack to undo its own fallback. | agent_impl.go:2077-2092; unified.go:33-70 |
+| T5 | Only tool registration is a **global unlocked map**; every agent inherits every tool; no `WithTool(t Tool)` builder option. | tool_discovery.go:25-31; builder.go:226-287 |
+| T6 | stdio MCP servers can't receive **args/env** (`npx -y server-filesystem /path` unconfigurable); the stdio plugin the error messages recommend is an unimplemented stub. | core/mcp.go:212-220; plugins/mcp/stdio/stdio.go:28-53 |
+| T7 | Transport selection is last-`init()`-wins on an unsynchronized global; unknown tools **route to an arbitrary server**; names collide first-wins. | plugins/mcp/*/…; unified.go:783-800 |
+| T8 | No parallel tool execution despite `ParallelExecution: true` config; no human-approval hooks or dangerous-tool gating anywhere; MCP auth is one global env token for all servers. | agent_impl.go:1691-1702; unified.go:962-998 |
+| T9 | Weather-demo heuristics (`"sf"→"san francisco"`) hardcoded in the generic pipeline. | agent_impl.go:1893-1905 |
+| T10 | Cache config accepts redis/file backends and lfu/ttl eviction — only in-memory LRU exists; size caps not enforced. | internal/mcp/cache_manager.go:57 |
+
+### 1.4 Config, observability, eval
+
+| # | Finding | Evidence |
+|---|---------|----------|
+| C1 | **Unknown TOML keys silently ignored** (BurntSushi `md.Undecoded()` makes strict mode a ~10-line fix). | config.go:348, 379 |
+| C2 | **`timeout = 30` parses as 30 nanoseconds** and passes validation → instant, undebuggable deadline errors. | config.go:24; builder.go:767 |
+| C3 | TOML provider whitelist **rejects five providers the factory supports** (openrouter, huggingface, vllm, mlflow, bentoml). | config.go:650 vs internal/llm/factory.go:15-26 |
+| C4 | Env expansion is a 12-field whitelist (misses `Memory.Options` where `embedding_api_key` lives); **unset `${VAR}` passes through as the literal string** and becomes a 401 downstream. | config.go:433-457, 556-566 |
+| C5 | Non-critical validation errors are computed, then thrown away. | config.go:640-645 |
+| C6 | Span attributes are bespoke `agk.*`, not **OTel GenAI semconv (`gen_ai.*`)** — invisible to Langfuse/Datadog/Braintrust LLM views; no per-LLM-call span; cost attribute defined, never emitted. | internal/observability/attributes.go:12-23 |
+| C7 | OTLP export broken as documented (scheme passed to `WithEndpoint`; needs `WithEndpointURL`); no headers → no SaaS backend reachable; std `OTEL_*` env vars ignored. | builder.go:839-841; tracer.go:78 |
+| C8 | `.agk/runs/trace.jsonl` is OTel's *debug* stdouttrace format — explicitly unstable; manifest parser pokes at Go field names; 64KB Scanner limit truncates detailed spans. | internal/observability/exporters.go:42-68 |
+| C9 | `manifest.json` fabricates stats: `llm_calls` always 0 (name-match on "llm" that no span satisfies), tokens/cost never computed (already tracked as #138). | agent_impl.go:1436-1463 |
+| C10 | Eval server: traces are empty shells (no spans/IO, never persisted), **sessions don't feed history to the agent**, workflow success hardcoded `true`, binds `:8787` all-interfaces, no auth, no HTTP timeouts. | eval_handlers.go:140-307; eval_server.go:122-126 |
+| C11 | Agent metrics unsynchronized (race), private, write-only; Prometheus dep serves only the legacy MCP path. | agent_impl.go:142-148, 716-728 |
+
+**Deliverable for Part I: a "Trustworthy" release whose banner claims are `go test -race` clean, `go vet` clean, every documented config knob enforced or deleted, `errors.Is/As` works end-to-end, and no fabricated data anywhere (results, manifests, health checks).** File issues per row; most are individually small.
+
+---
+
+## 2. Part II — The differentiating feature set
+
+Six pillars, each grounded in proven patterns from the landscape research, each with a Go-idiomatic design sketch.
+
+### Pillar A — Typed everything (Go's headline advantage)
+
+**A1. Generic agents — `Agent[Deps, Output]`** *(PydanticAI's headline feature; maps perfectly to Go generics)*
+```go
+agent := agk.New[Deps, Verdict](model,
+    agk.Output(agk.ToolMode),        // structured-output strategy: tool | native | prompted
+    agk.Retries(agk.RetryBudget{Tools: 2, Output: 1}),
+)
+res, err := agent.Run(ctx, prompt, deps)   // res.Output is Verdict — no casting
+```
+Typed dependency injection via `RunContext[Deps]` (deps, retry count, usage-so-far) as the second arg to tools/validators; `agent.Override(deps|model)` for tests.
+
+**A2. Typed tools with inferred schemas — kill `map[string]interface{}`** *(convergent across Eino InferTool, adk-go functiontool, MCP go-sdk, AI SDK v5)*
+```go
+tool := tools.New[SearchArgs, []Result]("search", "Search the web",
+    func(ctx context.Context, rc *agk.RunContext[Deps], in SearchArgs) ([]Result, error) { ... })
+```
+Input *and output* JSON schemas derived from struct tags (`jsonschema:"required,enum=..."`), schema-aware arg coercion, output validated before returning to the model. Fixes T4/T5 as a side effect (per-agent `WithTool`, no global map, no `{"input":...}` fallback).
+
+**A3. Structured output with validation-driven self-correction** — declare once (`Output[T]`), choose mode independently (tool-call schema / provider-native JSON / prompted), and wire `agk.Retry("use a full name")` errors back to the model with per-tool/output budgets (PydanticAI `ModelRetry` — the proven reliability loop).
+
+**A4. Typed workflow steps** *(Mastra `.then/.branch/.parallel`, Eino compile-time edge checks — fixes W6)*
+```go
+wf := flow.New[Query, Report]().
+    Then(classify).                       // Step[Query, Class]
+    Branch(flow.Case(isRefund, refundFlow), flow.Default(generalFlow)).
+    Parallel(fetchDocs, fetchHistory).    // fan-out, typed merge
+    Then(compose)                         // compile error if types don't line up
+```
+Keep the existing string-based API as a compatibility layer over the typed core. Per-step `Retry`, `Timeout`, `OnError(Skip|Fail|Fallback)`, `Cache(ttl, keyFn)`; `Validate()` (cycles, unknown deps) and `Mermaid()/DOT()` export before any token is spent.
+
+**A5. Model fallback & flow control as decorators** — `llm.NewFallback(primary, secondary, llm.FallbackOn(...))` over the existing `ModelProvider` interface; declarative per-agent throttle/debounce/rate-limit/priority (Inngest-style) instead of hand-rolled `x/time/rate`.
+
+### Pillar B — Durable by default (the strategic wedge)
+
+Nothing in the Go agent space has this; Go's durable-execution pedigree makes it the highest-leverage bet. Design synthesis from the research:
+
+**B1. Journal-skip, not event-replay.** Re-invoke the function from the top on recovery; completed steps return checkpointed results (DBOS/Restate/Inngest model). *No* Temporal-style determinism constraints on user code — plain goroutines and `time.Now` stay legal outside steps.
+
+**B2. Embedded SQL journal, zero infrastructure.** Two tables (run status + step journal) on SQLite by default, Postgres for scale (DBOS proved this is a library, not a server). The journal doubles as the debugger: standard SQL to inspect any run.
+
+**B3. One tiny contract, community backends.** LangGraph won persistence via a 5-method `Checkpointer` interface + conformance test suite. Copy that discipline: `Put/PutWrites/Get/List/DeleteThread`, addressed by `(threadID, namespace, checkpointID)` with pending-writes so successful parallel siblings aren't re-executed.
+
+**B4. Auto-wrap LLM/tool/MCP calls as durable steps** (PydanticAI-Temporal pattern) — durability is a builder option, not a different agent type: `agk.Durable(store)`. Per-run knob `Durability(Exit|Async|Sync)`.
+
+**B5. `Interrupt`/`Resume` for human-in-the-loop** — the #1 production ask. LangGraph semantics (node re-executes to the interrupt point; recorded value returned on resume) are implementable in Go *without* stack serialization:
+```go
+approval, err := flow.Interrupt[Approval](ctx, payload)  // suspends durably
+// later: runner.Resume(ctx, runID, approval)
+```
+Plus awakeables (hand an ID to an external system; run suspends until resolved), durable `Sleep`/cron, and ADK's wire-level convention (a reserved `request_confirmation` event any frontend can render).
+
+**B6. Time travel & fork-from-step** — `ForkRun(runID, fromStep)` reusing checkpointed results: "the agent went off the rails at tool call 7 — fork from 6 with a corrected prompt" *without re-paying for steps 1-6*. Uniquely valuable when steps cost real money.
+
+**B7. Exactly-once honesty** — deterministic idempotency keys `(runID, stepSeq)` surfaced to tools via context; transactional checkpoint+side-effect for DB writes (River's insight); DBOS-style boolean `Patch("change-id")` for code versioning of in-flight runs; a `workflowcheck`-style `go vet` analyzer flagging raw I/O outside steps — a distinctly Go advantage.
+
+### Pillar C — Streaming that's a product feature, not a liability
+
+**C1. Fix the semantics first** (Part I S1-S9): `Wait()` as the single source of truth for errors, real cancellation, race-free writer, usage/finish-reason on the final token, incremental tool-call deltas with stable IDs, suppression of protocol text.
+
+**C2. Speak the Vercel AI SDK v5 UIMessage SSE protocol natively.** It is the de facto frontend contract (PydanticAI and Mastra both emit it). A `uistream` package — `http.Handler` that serves any agent/workflow stream as v5-typed SSE parts (text-delta, reasoning, tool-input-delta, tool-output-available, data-*) — makes every React/Svelte `useChat` frontend work against AgenticGoKit out of the box, and deletes the three hand-rolled websocket servers in examples.
+
+**C3. Resumable streams** — pluggable `EventStore` (memory/Redis) with `Last-Event-ID` replay; both AI SDK v5 and MCP streamable-HTTP converged on this design.
+
+**C4. Stream-aware routing** (Eino's trick): decide "tool call or final answer?" from the first frame with a pluggable checker — preserve first-token latency in ReAct loops. Expose only `Invoke`/`Stream` publicly; keep Eino's Collect/Transform machinery internal (their concept-load mistake is our lesson).
+
+**C5. Custom progress events** — LangGraph's `get_stream_writer()` equivalent: any tool/step can emit typed progress ("fetched 3/10 pages") into the client stream.
+
+### Pillar D — Multi-agent primitives the industry converged on
+
+**D1. Agents-as-tools as the primary composition currency** (Eino explicitly deprecated transfer-style handoffs; OpenAI ships both). `subAgent.AsTool(name, desc, WithOutputExtractor(...))` — parent keeps control; sub-agent events pass through to the parent stream.
+
+**D2. Handoffs where control must move** — auto-generated `transfer_to_X` tools with typed, schema-validated payloads and history filters (OpenAI SDK), implemented as `Command{Update, Goto}` returns (LangGraph) so state-update+routing is one primitive.
+
+**D3. Dynamic fan-out (`Send`)** — orchestrator-worker/map-reduce over collections not known at build time; with Go this is `errgroup` + semaphore under a typed API, a marquee "Go does this better" feature.
+
+**D4. Guardrails with tripwires, raced in parallel** — cheap model screens while the expensive agent runs; tripwire cancels via context. Input/output/tool-level. Go's cancellation makes this *genuinely better* than the Python original.
+
+**D5. Sessions & shared state** — OpenAI's 4-method `Session` interface (Items/Append/PopItem/Clear — the pop enables undo) + ADK's scope-prefixed state (`app:`/`user:`/session/`temp:`) with `OutputKey` auto-write and `{key}` instruction templating. Depends on the message-IR work (#139).
+
+**D6. Usage limits as hard brakes** — `UsageLimits{Requests, ToolCalls, InputTokens, OutputTokens}` per run (PydanticAI); `tool_choice` forcing + `stop_on_first_tool` (skip a whole LLM round-trip when the tool result *is* the answer).
+
+### Pillar E — The dev loop (adoption is won here)
+
+**E1. `agk dev` — a single-binary playground.** Genkit's Dev UI and Mastra's playground are their most-loved features; Eino built an IDE plugin for the same reason. Go can do it best: embed the UI with `embed.FS`, expose a small reflection protocol (list actions, run action, stream trace), and ship chat-with-any-agent, workflow graph visualization, run/suspend/resume, trace inspection with per-step payloads, and an eval tab — from the compiled binary, zero npm. The ADK-go **launcher pattern** completes it: the *same* binary runs `console` | `dev` | `api` | `a2a`.
+
+**E2. An `Action` registry as the substrate** (Genkit's architectural insight): agents, workflows, tools, prompts, evaluators all register as one introspectable unit (name, kind, in/out schema, run fn). The Dev UI, HTTP serving, eval runner, and MCP-server export all become one lookup away.
+
+**E3. `.prompt` files** (dotprompt): prompts as versioned artifacts — YAML frontmatter (model, config, typed input/output schema) + template body, loaded from a directory or `embed.FS`, with `name.variant.prompt` for A/B tests and typed wrappers (`LookupPrompt[In, Out]`).
+
+**E4. Evals under `go test`.** The industry converged on Eval = data + task + scorers (Braintrust), native-test-runner integration (DeepEval), CI thresholds (promptfoo), and scorers that also run against sampled production traces (Mastra). Go shape: `agkeval.Run(t, dataset, task, scorers...)` with trials, LLM-judge + heuristic scorers, span-based assertions ("was tool X called before Y?"), and — ADK's differentiator — **capture a live session in the dev UI → save as an eval case**. Rebuild the eval server on this (fixes C10).
+Prereq: honest cost/token accounting per run (fixes C9, #138/#153).
+
+**E5. LLM-free testing kit** (extends #152 with proven designs): `TestModel` (auto-calls every tool with schema-valid fabricated args — exercises plumbing with zero LLM), `ScriptModel` (scripted tool-call/text turns), `agk.BlockRealRequests()` global guard for CI, `CaptureMessages()` transcript assertions.
+
+**E6. Meta-DX for the AI era**: scaffold `AGENTS.md` in generated projects and ship one in-repo (framework users build *with* coding agents; 60k+ repos, Linux Foundation spec); publish `llms.txt`/`llms-full.txt` + per-page markdown docs — the dominant consumer of framework docs is now an assistant in Cursor/Claude Code.
+
+### Pillar F — Ecosystem & interop
+
+**F1. Official MCP go-sdk, both directions** (#145, expanded): the SDK is v1.0-stable with streamable HTTP, OAuth, elicitation, sampling, resumable event stores. Client side replaces the personal fork *and* fixes T3/T6/T7; server side is one line — `agent.AsMCPServer()` — making any AgenticGoKit agent installable in Claude/VS Code/Cursor; `agk mcp publish` generates `server.json` for the official MCP Registry.
+
+**F2. OTel GenAI semantic conventions** (fixes C6-C8): `gen_ai.*` attributes, per-LLM-call CLIENT spans, `WithEndpointURL` + headers + standard `OTEL_*` env vars, a stable documented trace schema, real per-run manifest rollups. Every LLM observability vendor reads this dialect.
+
+**F3. Memory with extraction semantics** (builds on #146): keep the storage layer, add the two proven architectures — a mem0-style background pipeline (extract → consolidate → ADD/UPDATE/DELETE facts, invisible to the agent loop) and Letta-style tiers (core/recall/archival) with agent-editable core memory as tools; thread/resource scoping aligned with D5 sessions.
+
+**F4. A2A via `a2a-go`** when agents cross team/vendor boundaries: serve an Agent Card + task lifecycle from the launcher (`agk a2a`), and consume remote agents as sub-agents. Adopt the SDK; don't reimplement.
+
+**F5. Code-as-action mode (opt-in, differentiating):** smolagents showed ~30% fewer steps when the model writes code instead of JSON tool calls; Python needs external sandboxes — Go can embed one natively (Starlark via starlark-go, or WASM via wazero) with registered typed tools injected as functions. No other Go framework can demo this safely today.
+
+---
+
+## 3. Part III — Sequenced roadmap
+
+| Release | Theme | Contents |
+|---|---|---|
+| **v0.6 "Trustworthy"** | Zero known lies | All Part I fixes (W/S/T/C tables). Brand promise: `-race` clean, every config knob real, `errors.Is` end-to-end, honest manifests/health/results. Strict TOML + duration parsing (C1-C4). Ship `AGENTS.md` + `llms.txt` (E6 — near-zero cost). |
+| **v0.7 "Typed"** | Compile-time safety story | Message IR (#139) → native tools everywhere (#140) → open provider registry (#141-142) → `Agent[D,O]` (A1) + `tools.New[In,Out]` (A2) + structured output w/ retry loop (A3) + typed workflow steps (A4). Testing kit E5. Gemini/Bedrock/`openai-compatible` (#149). |
+| **v0.8 "Durable"** | The wedge | Journal-skip engine on SQLite (B1-B3), auto-wrapped steps (B4), Interrupt/Resume + approval events (B5), sessions & scoped state (D5), durable sleep/cron. Multi-module split lands here (#144) so the journal store is a plugin. |
+| **v0.9 "Delightful"** | Dev loop | Action registry (E2) → `agk dev` playground + launcher (E1) → AI SDK v5 wire format + resumable SSE (C2-C3) → `.prompt` files (E3) → evals under `go test` + capture-loop (E4) → OTel GenAI (F2). |
+| **v1.0 "Complete"** | Ecosystem | Multi-agent primitives (D1-D4, D6), MCP server export + registry publish (F1), memory extraction tiers (F3), A2A (F4), fork-from-step time travel (B6), guardrails, fallback/flow-control decorators (A5). Delete `core`/`core/vnext` (#150). |
+
+**Dependency spine:** message IR → typed agents/tools → sessions → durability → dev UI → evals. Everything else hangs off that spine.
+
+---
+
+## 4. The checklist: "best developer-focused Go agentic framework"
+
+| Capability | AGK today | Target | Best-in-class reference |
+|---|---|---|---|
+| Multi-turn message IR | ❌ single-turn | ✅ | everyone |
+| Typed agents `Agent[D,O]` | ❌ | ✅ | PydanticAI |
+| Typed tools, inferred schemas (in+out) | ❌ map[string]any | ✅ | Eino / adk-go / MCP SDK |
+| Structured output + self-correction | ❌ | ✅ | PydanticAI |
+| Typed workflow steps, build-time checks | ❌ strings | ✅ | Eino / Mastra |
+| Per-step retry/timeout/fallback/cache | ❌ | ✅ | LangGraph / Temporal |
+| Dynamic fan-out (Send/map-reduce) | ❌ | ✅ | LangGraph |
+| Durable checkpoint/resume, zero infra | ❌ | ✅ SQLite journal | DBOS (design), LangGraph (contract) |
+| Interrupt/HITL approval, resumable | ❌ | ✅ | LangGraph / Mastra / ADK |
+| Time travel / fork-from-step | ❌ | ✅ | DBOS / LangGraph |
+| Streaming: usage, tool deltas, cancel | ❌ broken | ✅ | AI SDK v5 / Eino |
+| Frontend wire protocol (useChat-compatible) | ❌ hand-rolled WS | ✅ v5 SSE | Vercel AI SDK |
+| Guardrails (parallel, tripwire) | ❌ | ✅ | OpenAI SDK |
+| Handoffs / agents-as-tools | ❌ | ✅ | OpenAI SDK / Eino |
+| Sessions + scoped shared state | ❌ | ✅ | OpenAI SDK / ADK |
+| Usage limits / cost brakes | ❌ | ✅ | PydanticAI |
+| Dev UI playground (single binary) | ❌ | ✅ embed.FS | Genkit / Mastra / EinoDev |
+| Prompts as artifacts (.prompt) | ❌ | ✅ | Genkit dotprompt |
+| Evals in native test runner + CI + live traces | ❌ shell | ✅ | Braintrust/DeepEval/Mastra |
+| LLM-free TestModel/ScriptModel | partial (mock) | ✅ | PydanticAI |
+| OTel GenAI semconv | ❌ agk.* | ✅ | PydanticAI / OpenAI SDK |
+| MCP client (official SDK, OAuth, streamable) | ❌ fork | ✅ | MCP go-sdk |
+| Agent → MCP server export + registry | ❌ | ✅ | (open field) |
+| A2A | ❌ | ✅ via a2a-go | ADK |
+| Memory extraction pipeline + tiers | ❌ storage only | ✅ | mem0 / Letta |
+| Code-as-action sandbox (native) | ❌ | ✅ Starlark/wazero | smolagents (idea) |
+| Race-clean guarantee | ❌ fails | ✅ CI-enforced | (Go table stakes) |
+
+---
+
+## 5. What NOT to build (negative space from the research)
+
+1. **Don't port Python literally** — LangChainGo's `Chain.Call(ctx, map[string]any)` shape is the cautionary tale: pre-generics design, huge in-tree integration surface, single-maintainer burnout at v0.1.x. Keep interfaces tiny and contracts conformance-tested so the community owns backends.
+2. **Don't adopt Temporal's programming model** — event-history replay imposes determinism constraints (no goroutines/`time.Now`/map iteration) that would poison Go DX. Journal-skip gives 90% of the value with none of the constraints; offer a Temporal *adapter* for enterprises instead.
+3. **Don't expose four streaming paradigms** — Eino's own docs concede the concept load. Public API: `Invoke` and `Stream`. Period.
+4. **Don't build a proprietary wire format** — speak AI SDK v5 SSE and MCP; the frontends and clients already exist.
+5. **Don't ship features as config-only surface** — the current codebase's core credibility problem (decorative retry/rate-limit/cache/metrics knobs). A knob that does nothing is worse than no knob: it's a lie a customer discovers in production. Enforce or delete.
+6. **Don't hide failures to look friendly** — the zero-vector embedding incident (#137) generalizes: every silent fallback found in Part I converts a user's debugging session into distrust. Fail loudly, return diagnostics as values (the `Diagnostic`/sentinel-error pattern now in v1beta), and make "no fabricated data" a review gate.
+
+---
+
+*Sources: 10-agent research run (4 codebase, 6 landscape, 936k tokens, all primary sources cited inline in the underlying findings). Repository findings reference the PR #156 branch (`claude/go-agnostic-framework-analysis-ekyl3a`).*

--- a/docs/DEVELOPER_FIRST_ROADMAP.md
+++ b/docs/DEVELOPER_FIRST_ROADMAP.md
@@ -252,7 +252,47 @@ Prereq: honest cost/token accounting per run (fixes C9, #138/#153).
 
 ---
 
-## 5. What NOT to build (negative space from the research)
+## 5. Part IV — The ecosystem: agk CLI + template registry
+
+The framework does not ship alone: the `AgenticGoKit` org carries **agk** (developer CLI, ~78 files) and **agentic-examples**, and the **agk-templates** org carries a template registry plus community templates. Evaluated from the public repos (July 2026):
+
+### 5.1 What exists — and it's more than the framework docs let on
+
+| Asset | State |
+|---|---|
+| `agk init` scaffolding | Embedded quickstart + workflow templates (Go text/template + Sprig), variables for provider/model, post-create hooks |
+| Template registry | `agk template add/remove/list`, go-git fetcher, local cache, `agk-template.toml` manifest contract (variables, include/exclude, `min_agk_version`, hooks); registry = `agk-templates/registry/index.json` |
+| `agk trace list/show/view/mermaid` | A substantial **bubbletea TUI trace explorer** (52KB viewer + span tree) over `.agk/runs`, plus Mermaid export — a genuine differentiator no other Go framework ships |
+| `agk eval` | YAML test files → HTTP calls against the v1beta eval server (`AGK_EVAL_MODE`, `:8787`, `/invoke`, `/traces/{id}`), with **embedding, LLM-judge, and hybrid matchers**, thresholded confidence scores, markdown reports with progress bars and trace links, documented CI recipe |
+| Community templates | `test-agent`, `translate-workflow`, `flight-search-assistant`; templates already keep prompts as separate files (`prompts/*.system.txt`) — convergent with the dotprompt direction (E3) |
+
+This resolves an earlier finding: the eval server has no in-repo consumers (C10) because **its consumer lives in the agk repo**. The two are halves of one product, split across repositories.
+
+### 5.2 Ecosystem gaps and risks
+
+1. **Version skew by construction.** agk pins `agenticgokit v0.5.5`; every framework fix (including PR #156) reaches CLI users only after a framework release *and* an agk bump. There is no compatibility contract, no cross-repo CI, and `min_agk_version` exists in template manifests but nothing comparable binds agk↔framework.
+2. **The CLI is built on the framework's two least stable contracts.** `agk trace` parses `.agk/runs/trace.jsonl` — the OTel stdouttrace *debug* format (C8) that can break on any otel-go upgrade — and inherits the fabricated manifest stats (C9: 0 tokens, $0.00, 0 llm_calls in `agk trace show`). `agk eval`'s trace links point at eval-server traces that are empty shells, its multi-turn sessions don't actually feed history to the agent, and workflow evals report hardcoded success (C10). The CLI's flagship features silently degrade because their upstream contracts were never designed as contracts.
+3. **Templates scaffold the framework's known bugs into every new project.** Generated code blank-imports `plugins/llm/<provider>` — a **no-op for v1beta** (the dual-registry split, #141); `translate-workflow` imports three provider plugins it doesn't need. No template imports `plugins/embedding`, so any memory-enabled scaffold reproduced #137 pre-fix. The scaffolder is a bug amplifier: whatever the templates get wrong, every new user starts wrong.
+4. **The registry index is a bare name→repo map.** No versions, no checksums/signatures, no descriptions/categories, no enforcement of `min_agk_version` at resolve time; `agk template add` fetches a mutable default branch — unpinned, unreproducible, and a soft supply-chain risk the moment templates execute `post_create` hooks.
+5. **Three homes for examples** (framework `examples/`, `agentic-examples`, templates) with no shared CI — drift among them is already visible in the framework's own examples.
+6. **Residual fork confusion:** `AgenticGoKit/mcp-navigator-go` exists in the org, but the framework's go.mod still depends on the personal `kunalkushwaha/mcp-navigator-go` (superseded by #145 either way).
+
+### 5.3 Ecosystem roadmap items
+
+| # | Recommendation | Ties to |
+|---|---|---|
+| G1 | **A versioned contract between framework and CLI**: a stable, documented trace schema (fixes C8) and an OpenAPI-specified eval-server API, in a small shared module both repos import; nightly cross-repo CI (agk against framework master). | v0.6 |
+| G2 | **Fix the scaffolds**: remove no-op plugin imports (or make them real via #141), single provider per scaffold, embedding config for memory templates, generated `AGENTS.md` (E6) + a starter eval YAML in every template. | v0.6 |
+| G3 | **Registry v2**: index entries carry version, commit pin/checksum, description, `min_agk_version` (enforced at `agk init`); a published **template conformance action** (render × providers → `go build` → `go vet`) required for registry PRs. | v0.7 |
+| G4 | **`agk dev` absorbs the dev-loop pillar** (E1): the playground/launcher work should land in agk, upgrading the existing TUI investment — TUI for terminals, embedded web UI for browsers, one reflection protocol underneath. | v0.9 |
+| G5 | **Unify the eval stack**: the matchers (embedding/LLM-judge/hybrid) move into a framework `agkeval` package consumed by both `go test` (E4) and `agk eval` HTTP mode — one scorer implementation, two frontends; wire real trace IDs and honest workflow results (C10) underneath. | v0.9 |
+| G6 | **Distribution polish**: released binaries via the existing goreleaser (brew tap/scoop), `agk version --check` compatibility warnings against the project's framework version. | v0.7 |
+
+**Strategic read:** the ecosystem's *shape* is exactly right — CLI + registry + templates is what Genkit/Mastra/ADK all converged on — and the TUI trace viewer plus LLM-judge eval matchers are ahead of most Go competition. What's missing is *contracts*: the CLI consumes undocumented internals across a repo boundary, and the scaffolder amplifies framework bugs. Contract-first is cheaper than any new feature and multiplies the value of everything in Parts I–III.
+
+---
+
+## 6. What NOT to build (negative space from the research)
 
 1. **Don't port Python literally** — LangChainGo's `Chain.Call(ctx, map[string]any)` shape is the cautionary tale: pre-generics design, huge in-tree integration surface, single-maintainer burnout at v0.1.x. Keep interfaces tiny and contracts conformance-tested so the community owns backends.
 2. **Don't adopt Temporal's programming model** — event-history replay imposes determinism constraints (no goroutines/`time.Now`/map iteration) that would poison Go DX. Journal-skip gives 90% of the value with none of the constraints; offer a Temporal *adapter* for enterprises instead.

--- a/docs/SCOPE_AND_BOUNDARIES.md
+++ b/docs/SCOPE_AND_BOUNDARIES.md
@@ -1,0 +1,145 @@
+# Scope and boundaries
+
+A decision record for the recurring question: *does X belong, and if so, where?* Written to stop the same debates being re-litigated per feature.
+
+Companion to `docs/CONSOLIDATED_REPORT.md` (assessment) and `docs/DEVELOPER_FIRST_ROADMAP.md` (what to build). This document is about **where things live and what to refuse**.
+
+---
+
+## 1. The layering rule
+
+Four questions, asked in order. The first "yes" decides the home.
+
+| # | Question | Home |
+|---|---|---|
+| 1 | Does it change the *shape* of user code, or become impossible to add later without breaking everyone? | **`agentkit` core** — contracts only, zero dependencies |
+| 2 | Does it need a third-party dependency, or speak an external protocol? | **Official module** (`agentkit/providers/*`, `agentkit/mcp`, `agentkit/a2a`, `agentkit/otel`) |
+| 3 | Does it need a human at a terminal or browser? | **`agk` CLI** |
+| 4 | Does Go or the existing ecosystem already solve it well? | **Don't build it** |
+
+The fourth question is the one frameworks skip, and it is where most bloat comes from.
+
+---
+
+## 2. A2A: yes, but not in core, and not yet
+
+**Verdict: build it, as `agentkit/a2a`, after durable execution lands (v0.2). Not before.**
+
+### Why it fits the ecosystem
+
+A2A solves agent↔agent interop across organizational boundaries: an Agent Card for discovery, a Task lifecycle (`submitted → working → input-required / auth-required ⇄ → completed / failed / canceled`), named artifacts, SSE streaming, and webhook push for long-running or disconnected work. That is a genuinely different problem from MCP's agent↔tools scope, and it is not expressible as a tool call: a tool call is request/response, while an A2A task can run for hours, come back asking for input, and notify by webhook.
+
+### Why it must not go in the core
+
+**A2A's task lifecycle is a projection of a durable run's state machine, not a separate concept.** A durable run already has: a stable ID, a status, suspension with a typed reason (needs input, needs approval, needs auth), resumption with a value, named outputs, and completion or failure.
+
+Line those up and the mapping is nearly one-to-one:
+
+| Durable run (v0.2) | A2A task |
+|---|---|
+| `runID` | `taskId` |
+| running | `working` |
+| `Interrupt` awaiting input | `input-required` |
+| `Interrupt` awaiting approval/auth | `auth-required` |
+| `Resume(runID, value)` | task update with the input |
+| typed output / artifacts | `artifacts` |
+| terminal error | `failed` |
+
+Build the interior model first and A2A becomes a **serialization** of it — a small module that maps an existing state machine onto a wire format. Build A2A first and you implement a second state machine, then spend years reconciling the two whenever either changes. This ordering argument is the whole reason to wait.
+
+### Why not immediately
+
+- **MCP-server export covers most of "let another system use my agent" today**, with vastly more client support (Claude, VS Code, Cursor, and every MCP-aware tool). Ship that first — it is in the v0.5 milestone — and A2A becomes an addition rather than the only interop story.
+- A2A adoption is real but much thinner than MCP's. Speculative protocol surface in a pre-1.0 core is a maintenance liability.
+- The users who need A2A (multi-vendor, cross-org, long-running) are not the users who will judge the framework in its first year.
+
+### When it does land
+
+- Module `agentkit/a2a`, built on the `a2a-go` SDK. **Adopt, do not reimplement** — the same rule applied to MCP.
+- Both directions: serve an agent as an A2A endpoint (Agent Card generated from agent metadata and tool definitions), and consume a remote A2A agent as an ordinary sub-agent so the calling code cannot tell local from remote.
+- Push notifications map onto the durable journal, so a task that outlives a process still delivers.
+
+---
+
+## 3. What else the core should have (not yet in the roadmap)
+
+Five additions, ordered by how often a developer will feel their absence.
+
+### 3.1 `log/slog`, injected — never a global logger
+
+Accept `*slog.Logger` through an option; default to `slog.Default()`. **No package-level `Logger()`, no bundled logging library.** The previous generation baked in zerolog behind a global, which means a library that cannot be silenced, cannot be routed, and cannot participate in a host application's structured logging. slog is standard library now; there is no excuse for a framework logging dependency.
+
+### 3.2 Context compaction and history management
+
+The most-felt real-world pain that no Go framework addresses: long-running agents blow the context window, and the failure mode is a hard error mid-run after the user has already paid for the conversation.
+
+- A `Compactor` interface invoked when history approaches a budget: summarize older turns, offload oversized tool outputs to a store and replace them with truncated stubs plus a retrieval handle.
+- A token budget derived from `Capabilities.ContextWindow`, with a diagnostic before the wall, not an error at it.
+- Ship one default implementation (summarize-oldest) and keep the interface small.
+
+This is arguably higher day-to-day value than A2A, workflows, or multi-agent primitives — it is the difference between an agent that works in a demo and one that survives an afternoon.
+
+### 3.3 Record/replay testing ("cassettes")
+
+`agenttest` covers scripted behavior. The complement is recording *real* provider interactions once and replaying them forever: a `Recorder` provider decorator writing request/response pairs to JSON, and a `Replayer` reading them back. Tests then exercise real model quirks with no key, no cost, and no flake, and a provider's behavioral change shows up as a diff. Cheap to build on top of an existing `Provider` interface, and it is what makes an eval suite runnable in a fork's CI.
+
+### 3.4 Policy-based model routing
+
+Distinct from failure fallback: routing chooses a model *by policy* before a call — cheap model for classification, expensive one for synthesis, long-context model when history exceeds a threshold. `router.New(rules...)` implementing `Provider`, so it composes with fallback and middleware. Cost control is the top production concern after correctness, and today every team hand-rolls this.
+
+### 3.5 Prompt-cache control as a first-class concept
+
+Cache breakpoints are the single largest cost lever on long system prompts and reused context, and they are provider-specific enough that users get them wrong. Model it in the request (mark a message or prefix as cacheable), let adapters translate or ignore, and report cache hits through `Usage.CachedInputTokens` — which the core type already carries.
+
+---
+
+## 4. What I would now cut
+
+Being willing to cut one's own proposals is part of scope discipline.
+
+- **Code-as-action sandbox (Starlark/wazero).** Listed earlier as a differentiator. It is a compelling demo, but it forks the tool story — every tool must now be callable two ways — and it carries a permanent security-review burden. Park it as an experiment, not a roadmap item.
+- **A framework-owned HTTP eval server.** `agk` already has one and evals belong primarily in `go test`. Keep the HTTP mode only because the CLI already depends on it; do not grow it.
+- **Memory extraction pipelines (mem0-style) in the core roadmap.** A product in its own right. Ship the storage and retrieval contracts; let the opinionated extraction loop be a separate module that can fail without taking the core with it.
+
+---
+
+## 5. What the ecosystem must not build
+
+| Don't build | Because |
+|---|---|
+| A hosted platform / SaaS control plane | Premature by years; splits a small team's focus away from the library that has to be excellent first |
+| A React/Svelte component library | Emit the AI SDK v5 protocol instead and inherit every existing chat UI |
+| A model gateway or proxy | That is LiteLLM's and OpenRouter's turf; a first-class `openai-compatible` provider reaches all of it with no ongoing cost |
+| A vector database | Wrap the ones that exist behind a small interface |
+| A custom logger, config loader, or DI container | `log/slog`, plain structs, and constructors. Users pick their own config library |
+| A bespoke job queue | River and Asynq exist. The durable journal is a different thing — it is execution state, not work distribution |
+| A fork of MCP or A2A | Protocol churn is constant; adopt the official SDKs and let them absorb it |
+| A plugin marketplace | The template registry is enough surface for the community size |
+
+---
+
+## 6. Ecosystem division of labor
+
+| Repository | Owns | Must not own |
+|---|---|---|
+| **`agentkit`** | Contracts and runtime: message IR, provider/tool/embedder interfaces, agent loop, durability, workflows. Zero third-party dependencies, enforced in CI. | HTTP servers, CLIs, UIs, storage engines, protocol implementations |
+| **`agentkit/providers/*`, `/mcp`, `/a2a`, `/otel`, `/stores/*`** | Everything with a dependency or a wire protocol. Multi-module in the same repository so a contract change and its adapters move in one PR, with one CI. | Opinions about project structure |
+| **`AgenticGoKit`** | The brand, the docs site, the umbrella examples. `v1beta` frozen with a published sunset date and a migration guide. | New feature work — evolving two cores splits a small team and confuses adopters |
+| **`agk`** | Everything needing a human: scaffolding, dev playground, trace explorer, eval runner, `mcp publish`. | Runtime logic. Its eval matchers (embedding, LLM-judge, hybrid) belong in a library so `go test` can use them too — the CLI should be one of two frontends, not the only home |
+| **`agk-templates`** | Opinions about project structure, one per credible starting point. Versioned, pinned, conformance-tested in CI. | Workarounds for framework bugs. A scaffolder that papers over a defect ships that defect to every new user |
+
+### The one structural change worth making now
+
+**Move the eval scorers out of `agk` and into a library**, and **publish a versioned contract between the framework and the CLI** (a stable trace schema and an OpenAPI-described eval API in a small shared module, with nightly cross-repo CI). Today the CLI's two best features stand on undocumented internals across a repository boundary — the debug-format trace file and an eval server whose traces are empty. That is not a feature gap; it is a structural one, and it gets more expensive every release.
+
+---
+
+## 7. The test for anything new
+
+Before adding a capability, answer:
+
+1. **Does it change user code shape?** If no, it does not belong in core.
+2. **Would its absence be felt in the first hour, the first week, or the first year?** First-hour and first-week items outrank first-year items regardless of how interesting they are.
+3. **Does something in the Go ecosystem already do this well?** If yes, integrate rather than implement.
+4. **Can it fail without taking the core down?** If not, it belongs behind an interface with a boring default.
+5. **Is there a real user waiting for it, or a hypothetical one?** Speculative surface in a pre-1.0 core is a promise that has to be kept forever.

--- a/docs/SCOPE_AND_BOUNDARIES.md
+++ b/docs/SCOPE_AND_BOUNDARIES.md
@@ -61,6 +61,67 @@ Build the interior model first and A2A becomes a **serialization** of it — a s
 
 ---
 
+## 2b. Agentic UI (AG-UI), and the unifying architecture
+
+The same reasoning applied to A2A generalizes, and it resolves the whole interop question at once.
+
+### One interior model, three exterior projections
+
+An agent has exactly three edges, and the industry has standardized one protocol per edge:
+
+| Edge | Protocol | What it carries |
+|---|---|---|
+| agent ↔ tools/data | **MCP** | capability invocation |
+| agent ↔ agent | **A2A** | task delegation across boundaries |
+| agent ↔ user interface | **AG-UI** | run events, shared state, user interaction |
+
+These look like three large integrations. They are not: **each is an encoder over the same interior state.** If the runtime owns a run identity, a lifecycle, an event stream, addressable state, and durable suspension, then every protocol module is a projection of that — a few hundred lines, addable or droppable without touching the core. Get the interior wrong and each protocol grows its own state machine, and they diverge forever.
+
+This is the single most consequential architectural decision in the project, and it is a v0.1 decision even though every protocol module ships later.
+
+### The finding that changes the core
+
+**Agentic UI needs something the current core does not have: addressable run state with deltas.**
+
+AG-UI is an event protocol over SSE (~17 event types) whose distinguishing feature is state synchronization: `STATE_SNAPSHOT` carries the full state, `STATE_DELTA` carries incremental updates as **JSON Patch (RFC 6902)** operations. That is what enables the interaction pattern chat streaming cannot express — an agent drafting a document, filling a form, or building a plan that the UI renders live and the user edits in place.
+
+Today `agentkit` has *messages*, not *state*. A message list is append-only prose; it cannot express "field 3 of the draft changed." Adding state later means either breaking the run API or bolting a parallel state channel beside it.
+
+**Recommendation:** give the run a typed state object with delta emission, decided before v0.1 freezes. **Do not add a third type parameter to `Agent`** — `Agent[D, S, O]` would tax every call site for a feature most agents don't use. State belongs to the *run/session*, reachable through the run context and snapshotted by the checkpointer, so `Agent[D, O]` stays intact and stateful runs opt in.
+
+### The second finding: four features are one primitive
+
+These all reduce to *durable suspension with a typed reason*:
+
+| Surface | Suspension reason |
+|---|---|
+| Human approval before a destructive tool | needs approval |
+| **Frontend tools** (executed in the browser, not the server) | needs client execution |
+| A2A `input-required` / `auth-required` | needs input |
+| AG-UI human-in-the-loop | needs input |
+
+A browser-executed tool is not a new concept — it is a tool call that suspends the run until an external party returns a result, which is exactly `Interrupt`/`Resume`. Build the primitive once and all four fall out.
+
+**Consequence for the roadmap:** durable execution (v0.2) is not merely a reliability feature. It is the keystone the entire interop story rests on — A2A, agentic UI, HITL, and frontend tools are all blocked behind it. That justifies its position ahead of workflows and multi-agent primitives more strongly than the reliability argument alone did.
+
+### Which wire format to emit
+
+AI SDK v5 and AG-UI are not competitors at the same layer, and the choice is not exclusive — both are encoders over one internal event stream.
+
+| | AI SDK v5 protocol | AG-UI |
+|---|---|---|
+| Reach | Very large — any `useChat` frontend | Growing, framework-neutral |
+| Shape | Chat-shaped | Agent-shaped: shared state, frontend tools, HITL, generative UI |
+| Go support | N/A (wire format only) | Go SDK exists but is **community-tier**, while TypeScript and Python are first-class |
+
+**Ship the AI SDK v5 encoder first** (v0.5): the largest install base, the shortest path to "my Go backend has a modern chat UI," and it needs nothing beyond the event stream. **Add the AG-UI encoder once run state lands**, because its distinguishing feature is precisely the thing that depends on state.
+
+### The Go opportunity
+
+AG-UI's Go SDK sitting in the community tier while TypeScript and Python are first-class is the same gap as MCP-server export: a protocol where Go is underserved and a well-built Go implementation is cheap differentiation. Worth targeting deliberately — but as a module, on the official protocol, and only after the interior model can feed it.
+
+---
+
 ## 3. What else the core should have (not yet in the roadmap)
 
 Five additions, ordered by how often a developer will feel their absence.

--- a/docs/v1beta/memory-and-rag.md
+++ b/docs/v1beta/memory-and-rag.md
@@ -165,7 +165,34 @@ Memory: &v1beta.MemoryConfig{
 },
 ```
 
-**Failure modes are loud, not silent:**
+**Failure modes are consumable, not just loud:**
+
+Non-fatal findings (dummy-embedding fallback, dimension mismatch, memory
+disabled with settings) are surfaced as **values**, not only log lines:
+
+```go
+agent, err := v1beta.NewBuilder("bot").
+    WithConfig(cfg).
+    WithDiagnosticHandler(func(d v1beta.Diagnostic) {
+        if d.Code == v1beta.DiagEmbeddingFallbackDummy {
+            log.Fatalf("refusing to deploy with dummy embeddings: %s", d.Message)
+        }
+    }).
+    Build()
+
+// or inspect after the fact:
+for _, d := range v1beta.DiagnosticsOf(agent) { ... }
+```
+
+Fatal embedding configuration errors wrap typed sentinels, so you can branch
+without string-matching:
+
+```go
+if errors.Is(err, core.ErrEmbeddingFactoryNotRegistered) { ... }
+if errors.Is(err, core.ErrEmbeddingProviderUnsupported)  { ... }
+```
+
+**Failure modes:**
 
 - Requesting `openai`/`azure`/`ollama` embeddings when no embedding factory is
   registered returns an error at build time (v1beta registers them for you; if

--- a/docs/v1beta/memory-and-rag.md
+++ b/docs/v1beta/memory-and-rag.md
@@ -130,6 +130,59 @@ agent, _ := v1beta.NewBuilder(cfg.Name).
 
 ---
 
+## Embeddings
+
+Semantic memory and RAG are only as good as the embeddings backing them.
+
+**Defaults (batteries included):** the v1beta builder registers the real
+embedding providers automatically and derives a sensible embedding setup from
+your LLM provider when you don't configure one:
+
+| LLM provider | Embedding provider | Default model | Dimensions |
+|---|---|---|---|
+| `ollama` | `ollama` (same BaseURL) | `nomic-embed-text` | 768 |
+| `openai` | `openai` (same API key) | `text-embedding-3-small` | 1536 |
+| anything else | none derived | — | — |
+
+For Ollama, pull the embedding model first: `ollama pull nomic-embed-text`.
+
+**Explicit configuration** via memory `Options`:
+
+```go
+Memory: &v1beta.MemoryConfig{
+    Enabled:  true,
+    Provider: "pgvector",
+    Connection: dsn,
+    Options: map[string]string{
+        "embedding_provider": "ollama",
+        "embedding_model":    "mxbai-embed-large",
+        // "dimensions" is derived automatically for known models
+        // (nomic-embed-text=768, mxbai-embed-large=1024,
+        //  text-embedding-3-small=1536, text-embedding-3-large=3072, ...);
+        // set it explicitly for models the framework doesn't know.
+    },
+},
+```
+
+**Failure modes are loud, not silent:**
+
+- Requesting `openai`/`azure`/`ollama` embeddings when no embedding factory is
+  registered returns an error at build time (v1beta registers them for you; if
+  you construct memory through `core` directly, blank-import
+  `github.com/agenticgokit/agenticgokit/plugins/embedding`).
+- An unknown `embedding_provider` returns an error listing supported values.
+- If memory is enabled with no embedding provider at all (and none can be
+  derived from your LLM provider), the framework falls back to **dummy
+  embeddings and logs at Error level**: chat history still works, but semantic
+  search results are meaningless. Configure a real embedding provider or set
+  `memory.enabled = false`.
+
+The embedding model's dimensions must match the vector store column. The
+framework derives dimensions for well-known models automatically; a mismatch
+on an existing store requires re-ingesting your data.
+
+---
+
 ## RAG basics
 
 ```go

--- a/docs/v1beta/memory-and-rag.md
+++ b/docs/v1beta/memory-and-rag.md
@@ -16,7 +16,8 @@ Add conversational memory and Retrieval-Augmented Generation (RAG) to v1beta age
 ## Defaults and options
 
 - Default: chromem is enabled when no memory config is provided. Imports register providers; no extra code needed.
-- Disable memory: set `memory.enabled = false` in TOML or skip `WithMemory` and provide a `Config` with memory disabled.
+- Disable memory: set `memory.enabled = false` in TOML, or `Memory: &MemoryConfig{Enabled: false}` in code.
+- When you provide a `MemoryConfig` yourself, set `Enabled: true` explicitly — the flag is honored as written (a zero-value `Enabled` means disabled).
 - MemoryOption helpers:
   - `WithMemoryProvider(provider string)` – "chromem" (embedded) or "pgvector" (PostgreSQL + pgvector).
   - `WithRAG(maxTokens int, personalWeight, knowledgeWeight float32)` – sets weights and a 10-message history window.

--- a/examples/conversation-memory-stream-demo/main.go
+++ b/examples/conversation-memory-stream-demo/main.go
@@ -45,6 +45,7 @@ Be conversational and engaging while being helpful.`,
 				MaxTokens:   2000, // Allow detailed responses
 			},
 			Memory: &v1beta.MemoryConfig{
+				Enabled: true,
 				// Provider defaults to "chromem" - embedded vector database
 				RAG: &v1beta.RAGConfig{
 					MaxTokens:       1000,

--- a/examples/memory-and-tools/main.go
+++ b/examples/memory-and-tools/main.go
@@ -31,6 +31,7 @@ Remember information from our conversation and provide personalized responses.`,
 				MaxTokens:   80, // Short responses for faster demo
 			},
 			Memory: &v1beta.MemoryConfig{
+				Enabled: true,
 				// Provider defaults to "chromem" - embedded vector database
 				RAG: &v1beta.RAGConfig{
 					MaxTokens:       500,

--- a/examples/memory-demo/main.go
+++ b/examples/memory-demo/main.go
@@ -22,6 +22,7 @@ func main() {
 				BaseURL:  "http://localhost:11434",
 			},
 			Memory: &v1beta.MemoryConfig{
+				Enabled:  true,
 				Provider: "chromem",
 				Options: map[string]string{
 					"dimensions": "1536", // Dummy embedder dimensions

--- a/examples/story-writer-chat-v2/workflow/agents.go
+++ b/examples/story-writer-chat-v2/workflow/agents.go
@@ -3,8 +3,8 @@ package workflow
 import (
 	"time"
 
-	vnext "github.com/agenticgokit/agenticgokit/v1beta"
 	"github.com/agenticgokit/agenticgokit/examples/story-writer-chat-v2/config"
+	vnext "github.com/agenticgokit/agenticgokit/v1beta"
 )
 
 // AgentConfig holds configuration for creating an agent
@@ -22,6 +22,7 @@ func CreateWriter(cfg *config.Config) (vnext.Agent, error) {
 		Timeout:      90 * time.Second,
 		Streaming:    &vnext.StreamingConfig{Enabled: true, BufferSize: 50, FlushInterval: 50},
 		Memory: &vnext.MemoryConfig{
+			Enabled:  true,
 			Provider: "memory", // In-memory provider
 			RAG: &vnext.RAGConfig{
 				MaxTokens:       2000, // Include up to 2000 tokens of conversation history
@@ -73,6 +74,3 @@ func CreatePublisher(cfg *config.Config) (vnext.Agent, error) {
 		},
 	})
 }
-
-
-

--- a/internal/embedding/providers/ollama.go
+++ b/internal/embedding/providers/ollama.go
@@ -79,7 +79,7 @@ func (s *OllamaEmbeddingService) GenerateEmbedding(ctx context.Context, text str
 	// Send request
 	resp, err := s.client.Do(httpReq)
 	if err != nil {
-		return nil, fmt.Errorf("failed to send request: %w", err)
+		return nil, fmt.Errorf("ollama embeddings request to %s failed: %w — is Ollama running? Start it with `ollama serve`, or point embedding_url at your Ollama instance", s.baseURL, err)
 	}
 	defer resp.Body.Close()
 
@@ -90,7 +90,11 @@ func (s *OllamaEmbeddingService) GenerateEmbedding(ctx context.Context, text str
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("API request failed with status %d: %s", resp.StatusCode, string(responseBody))
+		body := string(responseBody)
+		if resp.StatusCode == http.StatusNotFound || strings.Contains(body, "not found") {
+			return nil, fmt.Errorf("ollama embedding model %q is not available (status %d: %s) — pull it first: `ollama pull %s`", s.model, resp.StatusCode, body, s.model)
+		}
+		return nil, fmt.Errorf("ollama embeddings API (model %q at %s) failed with status %d: %s", s.model, s.baseURL, resp.StatusCode, body)
 	}
 
 	// Parse response

--- a/internal/embedding/providers/ollama_test.go
+++ b/internal/embedding/providers/ollama_test.go
@@ -1,0 +1,47 @@
+package providers
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+)
+
+// TestOllamaEmbeddingModelNotFoundHint verifies the error for a missing model
+// tells the user exactly how to fix it.
+func TestOllamaEmbeddingModelNotFoundHint(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		_, _ = w.Write([]byte(`{"error":"model \"nomic-embed-text\" not found, try pulling it first"}`))
+	}))
+	defer server.Close()
+
+	svc := NewOllamaEmbeddingService("nomic-embed-text", server.URL)
+	_, err := svc.GenerateEmbedding(context.Background(), "hello")
+	if err == nil {
+		t.Fatal("expected error for missing model, got nil")
+	}
+	if !strings.Contains(err.Error(), "ollama pull nomic-embed-text") {
+		t.Errorf("error should include the `ollama pull` fix, got: %v", err)
+	}
+}
+
+// TestOllamaEmbeddingConnectionRefusedHint verifies the error for an
+// unreachable Ollama instance points at starting/aiming Ollama.
+func TestOllamaEmbeddingConnectionRefusedHint(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	server.Close() // immediately close so the port refuses connections
+
+	svc := NewOllamaEmbeddingService("nomic-embed-text", server.URL)
+	_, err := svc.GenerateEmbedding(context.Background(), "hello")
+	if err == nil {
+		t.Fatal("expected error for unreachable Ollama, got nil")
+	}
+	if !strings.Contains(err.Error(), "ollama serve") {
+		t.Errorf("error should suggest starting Ollama, got: %v", err)
+	}
+	if !strings.Contains(err.Error(), server.URL) {
+		t.Errorf("error should include the attempted base URL, got: %v", err)
+	}
+}

--- a/internal/embedding/providers/openai.go
+++ b/internal/embedding/providers/openai.go
@@ -119,7 +119,10 @@ func (s *OpenAIEmbeddingService) GenerateEmbeddings(ctx context.Context, texts [
 
 	// Check for errors
 	if resp.StatusCode != http.StatusOK {
-		return nil, fmt.Errorf("API error %d: %s", resp.StatusCode, string(responseBody))
+		if resp.StatusCode == http.StatusUnauthorized {
+			return nil, fmt.Errorf("OpenAI embeddings API rejected the API key (status 401: %s) — set OPENAI_API_KEY or Memory.Options[\"embedding_api_key\"]", string(responseBody))
+		}
+		return nil, fmt.Errorf("OpenAI embeddings API (model %q) error %d: %s", s.model, resp.StatusCode, string(responseBody))
 	}
 
 	// Parse response

--- a/internal/llm/factory.go
+++ b/internal/llm/factory.go
@@ -121,14 +121,30 @@ func (f *ProviderFactory) SetHTTPClient(client *http.Client) {
 	f.httpClient = client
 }
 
+// Default sampling parameters applied when the corresponding ProviderConfig
+// field is left at its zero value. Because ProviderConfig uses plain (non
+// pointer) fields, a zero value means "unset" at this layer; explicit values
+// — including temperature 0 — can be passed per call via
+// Prompt.Parameters (see ModelParameters), which every adapter honors.
+const (
+	// DefaultMaxTokens is intentionally generous: agent, tool, and RAG
+	// responses are routinely longer than a chat one-liner, and a small
+	// silent cap truncates output mid-sentence (see issue #143; the old
+	// default was 150).
+	DefaultMaxTokens = 2048
+
+	// DefaultTemperature is applied when ProviderConfig.Temperature is 0.
+	DefaultTemperature float32 = 0.7
+)
+
 // CreateProvider creates a ModelProvider based on the configuration
 func (f *ProviderFactory) CreateProvider(config ProviderConfig) (ModelProvider, error) {
 	// Set defaults
 	if config.MaxTokens == 0 {
-		config.MaxTokens = 150
+		config.MaxTokens = DefaultMaxTokens
 	}
 	if config.Temperature == 0 {
-		config.Temperature = 0.7
+		config.Temperature = DefaultTemperature
 	}
 	if config.HTTPTimeout > 0 && f.httpClient.Timeout != config.HTTPTimeout {
 		f.httpClient = NewOptimizedHTTPClient(config.HTTPTimeout)

--- a/internal/llm/factory_defaults_test.go
+++ b/internal/llm/factory_defaults_test.go
@@ -1,0 +1,70 @@
+package llm
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// TestCreateProviderDefaultMaxTokens verifies the factory no longer applies
+// the surprising 150-token default (issue #143).
+func TestCreateProviderDefaultMaxTokens(t *testing.T) {
+	f := NewProviderFactory()
+	provider, err := f.CreateProvider(ProviderConfig{Type: ProviderTypeOllama})
+	if err != nil {
+		t.Fatalf("CreateProvider failed: %v", err)
+	}
+
+	adapter, ok := provider.(*OllamaAdapter)
+	if !ok {
+		t.Fatalf("unexpected provider type %T", provider)
+	}
+	if adapter.maxTokens != DefaultMaxTokens {
+		t.Errorf("maxTokens = %d, want DefaultMaxTokens (%d)", adapter.maxTokens, DefaultMaxTokens)
+	}
+	if DefaultMaxTokens < 1024 {
+		t.Errorf("DefaultMaxTokens = %d; agent workloads need a generous default", DefaultMaxTokens)
+	}
+	if adapter.temperature != DefaultTemperature {
+		t.Errorf("temperature = %v, want DefaultTemperature (%v)", adapter.temperature, DefaultTemperature)
+	}
+}
+
+// TestOllamaCallHonorsExplicitZeroTemperature verifies that an explicit
+// per-call temperature of 0 (deterministic sampling) reaches the request
+// payload instead of being replaced by the adapter default (issue #143).
+func TestOllamaCallHonorsExplicitZeroTemperature(t *testing.T) {
+	var gotPayload map[string]interface{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if err := json.NewDecoder(r.Body).Decode(&gotPayload); err != nil {
+			t.Errorf("failed to decode request payload: %v", err)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"message": {"role": "assistant", "content": "ok"}, "done": true}`))
+	}))
+	defer server.Close()
+
+	adapter, err := NewOllamaAdapter(server.URL, "test-model", 128, 0.9, 0)
+	if err != nil {
+		t.Fatalf("NewOllamaAdapter failed: %v", err)
+	}
+
+	zero := float32(0)
+	_, err = adapter.Call(context.Background(), Prompt{
+		User:       "hello",
+		Parameters: ModelParameters{Temperature: &zero},
+	})
+	if err != nil {
+		t.Fatalf("Call failed: %v", err)
+	}
+
+	temp, ok := gotPayload["temperature"].(float64)
+	if !ok {
+		t.Fatalf("temperature missing from payload: %v", gotPayload)
+	}
+	if temp != 0 {
+		t.Errorf("payload temperature = %v, want explicit 0 (not adapter default 0.9)", temp)
+	}
+}

--- a/internal/llm/ollama_adapter.go
+++ b/internal/llm/ollama_adapter.go
@@ -97,7 +97,9 @@ func (o *OllamaAdapter) Call(ctx context.Context, prompt Prompt) (Response, erro
 	}
 
 	var finalTemperature float32
-	if prompt.Parameters.Temperature != nil && *prompt.Parameters.Temperature > 0 {
+	// A non-nil pointer is an explicit setting: temperature 0 (deterministic
+	// sampling) is valid and must not fall back to the adapter default.
+	if prompt.Parameters.Temperature != nil {
 		finalTemperature = *prompt.Parameters.Temperature
 	} else {
 		finalTemperature = o.temperature

--- a/plugins/memory/chromem/chromem.go
+++ b/plugins/memory/chromem/chromem.go
@@ -7,18 +7,12 @@ import (
 
 func init() {
 	core.RegisterMemoryProviderFactory("chromem", func(config core.AgentMemoryConfig) (core.Memory, error) {
-		// Initialize embedding service
-		var embedder core.EmbeddingService
-		switch config.Embedding.Provider {
-		case "openai":
-			embedder = core.NewOpenAIEmbeddingService(config.Embedding.APIKey, config.Embedding.Model)
-		case "ollama":
-			embedder = core.NewOllamaEmbeddingService(config.Embedding.Model, config.Embedding.BaseURL)
-		case "dummy":
-			embedder = core.NewDummyEmbeddingService(config.Dimensions)
-		default:
-			// Default to dummy if not specified or unrecognized
-			embedder = core.NewDummyEmbeddingService(config.Dimensions)
+		// Initialize embedding service; fails loudly on unregistered factories
+		// or unknown providers instead of silently degrading to zero-vector
+		// embeddings (see issue #137).
+		embedder, err := core.NewEmbeddingServiceForConfig(config)
+		if err != nil {
+			return nil, err
 		}
 
 		return providers.NewChromemProvider(config, embedder)

--- a/plugins/memory/pgvector/pgvector.go
+++ b/plugins/memory/pgvector/pgvector.go
@@ -7,24 +7,12 @@ import (
 
 func init() {
 	core.RegisterMemoryProviderFactory("pgvector", func(cfg core.AgentMemoryConfig) (core.Memory, error) {
-		// Create embedding service via core registry-backed helpers
-		var embed core.EmbeddingService
-		switch cfg.Embedding.Provider {
-		case "openai":
-			// Pass empty string for API key to allow environment variable fallback
-			apiKey := cfg.Embedding.APIKey
-			embed = core.NewOpenAIEmbeddingService(apiKey, cfg.Embedding.Model)
-		case "azure":
-			// Pass empty string for API key to allow environment variable fallback
-			apiKey := cfg.Embedding.APIKey
-			embed = core.NewOpenAIEmbeddingService(apiKey, cfg.Embedding.Model)
-		case "ollama":
-			embed = core.NewOllamaEmbeddingService(cfg.Embedding.Model, cfg.Embedding.BaseURL)
-		case "dummy", "":
-			embed = core.NewDummyEmbeddingService(cfg.Dimensions)
-		default:
-			// Fallback to dummy if unknown provider
-			embed = core.NewDummyEmbeddingService(cfg.Dimensions)
+		// Create embedding service via core registry-backed helpers; fails
+		// loudly on unregistered factories or unknown providers instead of
+		// silently degrading to zero-vector embeddings (see issue #137).
+		embed, err := core.NewEmbeddingServiceForConfig(cfg)
+		if err != nil {
+			return nil, err
 		}
 		return providers.NewPgVectorProvider(cfg, embed)
 	})

--- a/plugins/memory/pgvector/pgvector.go
+++ b/plugins/memory/pgvector/pgvector.go
@@ -17,4 +17,3 @@ func init() {
 		return providers.NewPgVectorProvider(cfg, embed)
 	})
 }
-

--- a/test/vnext/benchmarks/vnext_benchmarks_test.go
+++ b/test/vnext/benchmarks/vnext_benchmarks_test.go
@@ -118,6 +118,7 @@ func BenchmarkConfig_Complex(b *testing.B) {
 				MaxTokens:   2000,
 			},
 			Memory: &vnext.MemoryConfig{
+				Enabled:    true,
 				Provider:   "memory",
 				Connection: "local",
 				RAG: &vnext.RAGConfig{
@@ -309,6 +310,3 @@ func BenchmarkValidationError_Creation(b *testing.B) {
 		}
 	}
 }
-
-
-

--- a/test/vnext/config/config_test.go
+++ b/test/vnext/config/config_test.go
@@ -701,6 +701,7 @@ func TestConfigWithAllFeatures(t *testing.T) {
 			MaxTokens:   2000,
 		},
 		Memory: &vnext.MemoryConfig{
+			Enabled:  true,
 			Provider: "memory",
 			RAG: &vnext.RAGConfig{
 				MaxTokens:       1000,

--- a/test/vnext/memory_access_verification_test.go
+++ b/test/vnext/memory_access_verification_test.go
@@ -58,10 +58,9 @@ func TestAgentMemoryAccess(t *testing.T) {
 			Model:    "gemma:2b",
 		},
 		Memory: &vnext.MemoryConfig{
+			Enabled:  true,
 			Provider: "chromem",
-			RAG:      &vnext.RAGConfig{
-				// Enabled is implied by presence
-			},
+			RAG:      &vnext.RAGConfig{},
 			// This test verifies memory accessor wiring, not embedding
 			// quality. Use dummy embeddings explicitly so it does not
 			// require a running Ollama instance (real embedding providers
@@ -173,7 +172,6 @@ func (m *vnextMockMemory) BuildContext(ctx context.Context, query string, opts .
 func (m *vnextMockMemory) AddMessage(ctx context.Context, role, content string) error {
 	return nil
 }
-
 
 func TestResultMemoryContext(t *testing.T) {
 	// Verify we can populate MemoryContext

--- a/test/vnext/memory_access_verification_test.go
+++ b/test/vnext/memory_access_verification_test.go
@@ -62,6 +62,13 @@ func TestAgentMemoryAccess(t *testing.T) {
 			RAG:      &vnext.RAGConfig{
 				// Enabled is implied by presence
 			},
+			// This test verifies memory accessor wiring, not embedding
+			// quality. Use dummy embeddings explicitly so it does not
+			// require a running Ollama instance (real embedding providers
+			// are derived from the LLM config by default).
+			Options: map[string]string{
+				"embedding_provider": "dummy",
+			},
 		},
 	}
 

--- a/test/vnext/realagent/agent_impl_test.go
+++ b/test/vnext/realagent/agent_impl_test.go
@@ -153,6 +153,7 @@ func TestAgentCapabilities(t *testing.T) {
 					BaseURL:  "http://localhost:11434",
 				},
 				Memory: &vnext.MemoryConfig{
+					Enabled:    true,
 					Provider:   "memory",
 					Connection: "memory",
 				},
@@ -397,6 +398,3 @@ func TestBuilderClone(t *testing.T) {
 	assert.Equal(t, "Original prompt", agent1.Config().SystemPrompt)
 	assert.Equal(t, "Cloned prompt", agent2.Config().SystemPrompt)
 }
-
-
-

--- a/v1beta/agent_impl.go
+++ b/v1beta/agent_impl.go
@@ -181,23 +181,14 @@ func newRealAgent(config *Config, handler HandlerFunc) (Agent, error) {
 		// Since we can't tell if it's explicitly false or just default, we'll assume
 		// if they provided a config object, they probably want it enabled.
 		config.Memory.Enabled = true
+	}
 
-		// Smart Default: If no embedding provider is specified, try to use the LLM provider
-		if config.Memory.Options == nil {
-			config.Memory.Options = make(map[string]string)
-		}
-		if _, ok := config.Memory.Options["embedding_provider"]; !ok {
-			config.Memory.Options["embedding_provider"] = config.LLM.Provider
-			if _, ok := config.Memory.Options["embedding_model"]; !ok {
-				config.Memory.Options["embedding_model"] = config.LLM.Model
-			}
-			if _, ok := config.Memory.Options["embedding_url"]; !ok {
-				config.Memory.Options["embedding_url"] = config.LLM.BaseURL
-			}
-			if _, ok := config.Memory.Options["embedding_api_key"]; !ok {
-				config.Memory.Options["embedding_api_key"] = config.LLM.APIKey
-			}
-		}
+	// Smart Default: derive embedding configuration from the LLM provider when
+	// the user did not configure embeddings explicitly. Only providers with a
+	// real embedding backend are mapped, and a proper embedding model is used
+	// (never the chat model — see issue #137).
+	if config.Memory.Enabled {
+		applyEmbeddingDefaults(config.Memory, &config.LLM)
 	}
 
 	// Initialize memory provider

--- a/v1beta/agent_impl.go
+++ b/v1beta/agent_impl.go
@@ -90,6 +90,37 @@ type realAgent struct {
 	tracerShutdown func(context.Context) error
 	runID          string
 	runDir         string
+
+	// Non-fatal findings collected during construction; exposed via
+	// Diagnostics() / DiagnosticsOf and dispatched to the builder's
+	// DiagnosticHandler.
+	diagnostics []Diagnostic
+}
+
+// Diagnostics returns the non-fatal findings collected while building this
+// agent (see DiagnosticsOf).
+func (a *realAgent) Diagnostics() []Diagnostic {
+	return a.diagnostics
+}
+
+// addDiagnostic records a diagnostic and logs it at the matching level, so
+// the finding is visible both programmatically and in logs.
+func (a *realAgent) addDiagnostic(d Diagnostic) {
+	a.diagnostics = append(a.diagnostics, d)
+
+	evt := Logger().Info()
+	switch d.Severity {
+	case DiagWarning:
+		evt = Logger().Warn()
+	case DiagError:
+		evt = Logger().Error()
+	}
+	evt.Str("agent", a.config.Name).
+		Str("diagnostic_code", string(d.Code))
+	for k, v := range d.Details {
+		evt.Str(k, v)
+	}
+	evt.Msg(d.Message)
 }
 
 // sessionState tracks per-session information for the agent
@@ -185,11 +216,13 @@ func newRealAgent(config *Config, handler HandlerFunc) (Agent, error) {
 		// {Enabled: false} is a deliberate disable and only worth an Info.
 		if config.Memory.Provider != "" || config.Memory.Connection != "" ||
 			config.Memory.RAG != nil || len(config.Memory.Options) > 0 {
-			Logger().Warn().
-				Str("agent", config.Name).
-				Str("memory_provider", config.Memory.Provider).
-				Msg("MemoryConfig has settings but Enabled is false - memory is DISABLED. " +
-					"If you meant to enable it, set Enabled: true in MemoryConfig (it is no longer implied by presence).")
+			agent.addDiagnostic(Diagnostic{
+				Severity: DiagWarning,
+				Code:     DiagMemoryDisabledWithConfig,
+				Message: "MemoryConfig has settings but Enabled is false - memory is DISABLED. " +
+					"If you meant to enable it, set Enabled: true in MemoryConfig (it is no longer implied by presence).",
+				Details: map[string]string{"memory_provider": config.Memory.Provider},
+			})
 		} else {
 			Logger().Info().
 				Str("agent", config.Name).
@@ -203,6 +236,43 @@ func newRealAgent(config *Config, handler HandlerFunc) (Agent, error) {
 	// (never the chat model — see issue #137).
 	if config.Memory.Enabled {
 		applyEmbeddingDefaults(config.Memory, &config.LLM)
+
+		// Surface degraded or risky embedding configurations as
+		// diagnostics the consumer can act on programmatically.
+		embeddingProvider := config.Memory.Options["embedding_provider"]
+		embeddingModel := config.Memory.Options["embedding_model"]
+		switch embeddingProvider {
+		case "":
+			agent.addDiagnostic(Diagnostic{
+				Severity: DiagError,
+				Code:     DiagEmbeddingFallbackDummy,
+				Message: "Memory is enabled but no embedding backend is configured or derivable from LLM provider \"" + config.LLM.Provider + "\" - " +
+					"falling back to dummy embeddings. Chat history will work; semantic search and RAG will return meaningless results. " +
+					"Fix: set Memory.Options[\"embedding_provider\"] to \"openai\" or \"ollama\" (with embedding_model / embedding_api_key / embedding_url as needed), " +
+					"or disable memory with Memory.Enabled=false.",
+				Details: map[string]string{
+					"llm_provider":   config.LLM.Provider,
+					"fix_option_key": "embedding_provider",
+				},
+			})
+		default:
+			if dims := config.Memory.Options["dimensions"]; dims != "" && embeddingModel != "" {
+				if known := dimensionsForEmbeddingModel(embeddingModel); known > 0 && dims != fmt.Sprintf("%d", known) {
+					agent.addDiagnostic(Diagnostic{
+						Severity: DiagWarning,
+						Code:     DiagEmbeddingDimensionMismatch,
+						Message: "Configured memory dimensions (" + dims + ") do not match embedding model \"" + embeddingModel + "\" (" + fmt.Sprintf("%d", known) + ") - " +
+							"vector-store writes may fail or similarity search may degrade. " +
+							"Set Memory.Options[\"dimensions\"] to match the model, and re-ingest data stored with different dimensions.",
+						Details: map[string]string{
+							"embedding_model":       embeddingModel,
+							"configured_dimensions": dims,
+							"model_dimensions":      fmt.Sprintf("%d", known),
+						},
+					})
+				}
+			}
+		}
 	}
 
 	// Initialize memory provider

--- a/v1beta/agent_impl.go
+++ b/v1beta/agent_impl.go
@@ -295,10 +295,28 @@ func (a *realAgent) execute(ctx context.Context, input string, opts *RunOptions)
 		return nil, fmt.Errorf("agent not properly initialized: LLM provider is nil")
 	}
 
-	// Step 1: Build the prompt with system context and user input
+	// Step 1: Build the prompt with system context and user input.
+	// Sampling parameters are passed per-call so configured values and
+	// RunOptions overrides actually reach the provider (the provider was
+	// constructed at Build() time; mutating config afterwards has no effect
+	// on it). RunOptions.Temperature is a pointer and survives as-is, so an
+	// explicit 0 (deterministic sampling) is honored (see #143).
+	params := llm.ModelParameters{
+		Temperature: convertFloat32ToFloat32Ptr(a.config.LLM.Temperature),
+		MaxTokens:   convertIntToInt32Ptr(a.config.LLM.MaxTokens),
+	}
+	if opts != nil && opts.Temperature != nil {
+		t := float32(*opts.Temperature)
+		params.Temperature = &t
+	}
+	if opts != nil && opts.MaxTokens > 0 {
+		m := int32(opts.MaxTokens)
+		params.MaxTokens = &m
+	}
 	prompt := llm.Prompt{
-		System: a.config.SystemPrompt,
-		User:   input,
+		System:     a.config.SystemPrompt,
+		User:       input,
+		Parameters: params,
 	}
 
 	// Capture prompt content at detailed trace level for evaluation/debugging

--- a/v1beta/agent_impl.go
+++ b/v1beta/agent_impl.go
@@ -179,9 +179,22 @@ func newRealAgent(config *Config, handler HandlerFunc) (Agent, error) {
 	// be force-enabled, which made it impossible to disable memory through
 	// Config — see issue #137, additional finding B.)
 	if !config.Memory.Enabled {
-		Logger().Info().
-			Str("agent", config.Name).
-			Msg("Memory is disabled (Memory.Enabled=false). Set Enabled: true in MemoryConfig to enable it.")
+		// A config that sets provider/connection/RAG/options but leaves
+		// Enabled at its zero value almost always means the user forgot
+		// Enabled: true (it used to be implied), so warn loudly; a bare
+		// {Enabled: false} is a deliberate disable and only worth an Info.
+		if config.Memory.Provider != "" || config.Memory.Connection != "" ||
+			config.Memory.RAG != nil || len(config.Memory.Options) > 0 {
+			Logger().Warn().
+				Str("agent", config.Name).
+				Str("memory_provider", config.Memory.Provider).
+				Msg("MemoryConfig has settings but Enabled is false - memory is DISABLED. " +
+					"If you meant to enable it, set Enabled: true in MemoryConfig (it is no longer implied by presence).")
+		} else {
+			Logger().Info().
+				Str("agent", config.Name).
+				Msg("Memory is disabled (Memory.Enabled=false).")
+		}
 	}
 
 	// Smart Default: derive embedding configuration from the LLM provider when

--- a/v1beta/agent_impl.go
+++ b/v1beta/agent_impl.go
@@ -173,14 +173,15 @@ func newRealAgent(config *Config, handler HandlerFunc) (Agent, error) {
 				KnowledgeWeight: 0.7,
 			},
 		}
-	} else {
-		// If MemoryConfig is provided, ensure it's Enabled by default unless explicitly false
-		// Actually, we should probably just treat a non-nil MemoryConfig as wanting memory.
-		// But follow the Enabled flag if it's there.
-		// Simple fix: if a config is there, we default Enabled to true if not specified.
-		// Since we can't tell if it's explicitly false or just default, we'll assume
-		// if they provided a config object, they probably want it enabled.
-		config.Memory.Enabled = true
+	}
+	// When a MemoryConfig is provided, its Enabled flag is honored as
+	// documented: Enabled=false disables memory. (A provided config used to
+	// be force-enabled, which made it impossible to disable memory through
+	// Config — see issue #137, additional finding B.)
+	if !config.Memory.Enabled {
+		Logger().Info().
+			Str("agent", config.Name).
+			Msg("Memory is disabled (Memory.Enabled=false). Set Enabled: true in MemoryConfig to enable it.")
 	}
 
 	// Smart Default: derive embedding configuration from the LLM provider when

--- a/v1beta/builder.go
+++ b/v1beta/builder.go
@@ -369,10 +369,23 @@ func NewBuilder(name string) Builder {
 	}
 }
 
-// WithConfig sets the complete configuration
+// WithConfig sets the complete configuration.
+// Fields the provided config leaves at their zero value fall back to the
+// builder's existing values (e.g. the name passed to NewBuilder and the
+// default timeout), so WithConfig(&Config{LLM: ...}) does not fail Build()
+// validation with a confusing "agent name is required" error.
 func (b *streamlinedBuilder) WithConfig(config *Config) Builder {
 	if b.built {
 		panic("Cannot modify frozen builder. Use Clone() first.")
+	}
+	if config == nil {
+		return b
+	}
+	if config.Name == "" && b.config != nil {
+		config.Name = b.config.Name
+	}
+	if config.Timeout <= 0 && b.config != nil {
+		config.Timeout = b.config.Timeout
 	}
 	b.config = config
 	return b

--- a/v1beta/builder.go
+++ b/v1beta/builder.go
@@ -30,6 +30,11 @@ type Builder interface {
 	// Observability
 	WithObservability(serviceName, serviceVersion string) Builder
 
+	// WithDiagnosticHandler registers a callback that receives non-fatal
+	// build-time findings (degraded embeddings, suspicious configs, ...)
+	// as values instead of only log lines. See also DiagnosticsOf.
+	WithDiagnosticHandler(handler DiagnosticHandler) Builder
+
 	// Convenience methods (5 methods)
 	WithMemory(opts ...MemoryOption) Builder
 	WithTools(opts ...ToolOption) Builder
@@ -349,6 +354,20 @@ type streamlinedBuilder struct {
 	observabilityEnabled bool
 	serviceName          string
 	serviceVersion       string
+
+	// Diagnostics
+	diagnosticHandler DiagnosticHandler
+}
+
+// WithDiagnosticHandler registers a callback invoked once per non-fatal
+// build-time finding after the agent is constructed. Diagnostics are also
+// always logged and remain readable via DiagnosticsOf(agent).
+func (b *streamlinedBuilder) WithDiagnosticHandler(handler DiagnosticHandler) Builder {
+	if b.built {
+		panic("Cannot modify frozen builder. Use Clone() first.")
+	}
+	b.diagnosticHandler = handler
+	return b
 }
 
 // NewBuilder creates a new streamlined agent builder
@@ -560,6 +579,13 @@ func (b *streamlinedBuilder) Build() (Agent, error) {
 		fmt.Printf("⚠️  Warning: Failed to setup observability: %v\n", err)
 	}
 
+	// Hand build-time diagnostics to the consumer's handler, if registered.
+	if b.diagnosticHandler != nil {
+		for _, d := range DiagnosticsOf(agent) {
+			b.diagnosticHandler(d)
+		}
+	}
+
 	return agent, nil
 }
 
@@ -720,6 +746,7 @@ func (b *streamlinedBuilder) Clone() Builder {
 		observabilityEnabled: b.observabilityEnabled,
 		serviceName:          b.serviceName,
 		serviceVersion:       b.serviceVersion,
+		diagnosticHandler:    b.diagnosticHandler,
 	}
 }
 

--- a/v1beta/builder.go
+++ b/v1beta/builder.go
@@ -1289,6 +1289,7 @@ Complete configuration example:
 				MaxTokens:   4096,
 			},
 			Memory: &MemoryConfig{
+				Enabled:  true,
 				Provider: "memory",
 				RAG: &RAGConfig{
 					MaxTokens:       2048,

--- a/v1beta/builder_config_test.go
+++ b/v1beta/builder_config_test.go
@@ -24,6 +24,42 @@ func TestWithConfigPreservesBuilderName(t *testing.T) {
 	}
 }
 
+// TestMemoryEnabledFalseIsHonored verifies that an explicitly disabled
+// MemoryConfig actually disables memory (issue #137, additional finding B).
+func TestMemoryEnabledFalseIsHonored(t *testing.T) {
+	agent, err := NewBuilder("no-memory").WithConfig(&Config{
+		LLM: LLMConfig{Provider: "mock", Model: "mock-model"},
+		Memory: &MemoryConfig{
+			Enabled:  false,
+			Provider: "chromem",
+		},
+	}).Build()
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+	if mem := agent.Memory(); mem != nil {
+		t.Errorf("agent.Memory() = %T, want nil when Memory.Enabled=false", mem)
+	}
+}
+
+// TestMemoryEnabledTrueProvidesMemory verifies the enabled path still works.
+func TestMemoryEnabledTrueProvidesMemory(t *testing.T) {
+	agent, err := NewBuilder("with-memory").WithConfig(&Config{
+		LLM: LLMConfig{Provider: "mock", Model: "mock-model"},
+		Memory: &MemoryConfig{
+			Enabled:  true,
+			Provider: "chromem",
+			Options:  map[string]string{"embedding_provider": "dummy"},
+		},
+	}).Build()
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+	if agent.Memory() == nil {
+		t.Error("agent.Memory() = nil, want memory provider when Enabled=true")
+	}
+}
+
 // TestWithConfigExplicitValuesWin verifies user-provided values are not
 // overwritten by builder defaults.
 func TestWithConfigExplicitValuesWin(t *testing.T) {

--- a/v1beta/builder_config_test.go
+++ b/v1beta/builder_config_test.go
@@ -1,0 +1,43 @@
+package v1beta
+
+import (
+	"testing"
+	"time"
+)
+
+// TestWithConfigPreservesBuilderName verifies that WithConfig does not
+// discard the name passed to NewBuilder (issue #137, additional finding A).
+func TestWithConfigPreservesBuilderName(t *testing.T) {
+	b := NewBuilder("sales").WithConfig(&Config{
+		LLM: LLMConfig{Provider: "mock", Model: "mock-model"},
+	})
+
+	sb, ok := b.(*streamlinedBuilder)
+	if !ok {
+		t.Fatalf("unexpected builder type %T", b)
+	}
+	if sb.config.Name != "sales" {
+		t.Errorf("config.Name = %q, want %q from NewBuilder", sb.config.Name, "sales")
+	}
+	if sb.config.Timeout <= 0 {
+		t.Errorf("config.Timeout = %v, want builder default preserved", sb.config.Timeout)
+	}
+}
+
+// TestWithConfigExplicitValuesWin verifies user-provided values are not
+// overwritten by builder defaults.
+func TestWithConfigExplicitValuesWin(t *testing.T) {
+	b := NewBuilder("ignored").WithConfig(&Config{
+		Name:    "explicit",
+		Timeout: 42 * time.Second,
+		LLM:     LLMConfig{Provider: "mock", Model: "mock-model"},
+	})
+
+	sb := b.(*streamlinedBuilder)
+	if sb.config.Name != "explicit" {
+		t.Errorf("config.Name = %q, want %q", sb.config.Name, "explicit")
+	}
+	if sb.config.Timeout != 42*time.Second {
+		t.Errorf("config.Timeout = %v, want 42s", sb.config.Timeout)
+	}
+}

--- a/v1beta/diagnostics.go
+++ b/v1beta/diagnostics.go
@@ -1,0 +1,84 @@
+package v1beta
+
+// Build-time diagnostics.
+//
+// A framework log line is easy to miss (or lost entirely when the consumer
+// wires their own logger). Non-fatal configuration findings are therefore
+// also surfaced as values: collect them with Builder.WithDiagnosticHandler,
+// or read them from a built agent with DiagnosticsOf. Every diagnostic is
+// still logged, so nothing changes for consumers that ignore this API.
+
+// DiagnosticSeverity classifies how serious a diagnostic is.
+type DiagnosticSeverity string
+
+const (
+	// DiagInfo is informational: expected behavior worth knowing about.
+	DiagInfo DiagnosticSeverity = "info"
+	// DiagWarning indicates configuration that is probably not what the
+	// user intended, but the agent still works.
+	DiagWarning DiagnosticSeverity = "warning"
+	// DiagError indicates a degraded mode: the agent constructs and runs,
+	// but a feature will not behave as advertised until fixed.
+	DiagError DiagnosticSeverity = "error"
+)
+
+// DiagnosticCode identifies a specific finding so consumers can handle it
+// programmatically instead of string-matching messages.
+type DiagnosticCode string
+
+const (
+	// DiagEmbeddingFallbackDummy: memory is enabled but no real embedding
+	// backend is configured or derivable from the LLM provider. Chat
+	// history works; semantic search and RAG return meaningless results.
+	DiagEmbeddingFallbackDummy DiagnosticCode = "EMBEDDING_FALLBACK_DUMMY"
+
+	// DiagMemoryDisabledWithConfig: a MemoryConfig carrying settings was
+	// provided with Enabled left false — likely a forgotten Enabled: true
+	// after the presence-implies-enabled behavior was removed.
+	DiagMemoryDisabledWithConfig DiagnosticCode = "MEMORY_DISABLED_WITH_CONFIG"
+
+	// DiagEmbeddingDimensionMismatch: the configured vector dimensions
+	// disagree with the embedding model's known dimensions; vector-store
+	// writes may fail or similarity search may degrade.
+	DiagEmbeddingDimensionMismatch DiagnosticCode = "EMBEDDING_DIMENSION_MISMATCH"
+)
+
+// Diagnostic is a non-fatal finding produced while building an agent.
+type Diagnostic struct {
+	Severity DiagnosticSeverity `json:"severity"`
+	Code     DiagnosticCode     `json:"code"`
+	// Message is human-readable and includes the suggested fix.
+	Message string `json:"message"`
+	// Details carries structured context (provider names, option keys,
+	// dimension values, ...) for programmatic handling.
+	Details map[string]string `json:"details,omitempty"`
+}
+
+// DiagnosticHandler receives diagnostics as they are produced during Build.
+type DiagnosticHandler func(Diagnostic)
+
+// diagnosticProvider is the optional interface implemented by agents that
+// collect build-time diagnostics. It is deliberately not part of the Agent
+// interface so existing Agent implementations remain valid.
+type diagnosticProvider interface {
+	Diagnostics() []Diagnostic
+}
+
+// DiagnosticsOf returns the build-time diagnostics collected by an agent,
+// or nil if the agent implementation does not expose any.
+//
+//	agent, err := v1beta.NewBuilder("bot").WithConfig(cfg).Build()
+//	for _, d := range v1beta.DiagnosticsOf(agent) {
+//	    if d.Code == v1beta.DiagEmbeddingFallbackDummy {
+//	        // fail deployment, alert, or reconfigure
+//	    }
+//	}
+func DiagnosticsOf(agent Agent) []Diagnostic {
+	if agent == nil {
+		return nil
+	}
+	if dp, ok := agent.(diagnosticProvider); ok {
+		return dp.Diagnostics()
+	}
+	return nil
+}

--- a/v1beta/diagnostics_test.go
+++ b/v1beta/diagnostics_test.go
@@ -1,0 +1,126 @@
+package v1beta
+
+import (
+	"testing"
+)
+
+// TestDiagnosticsSurfaceDummyEmbeddingFallback verifies that an agent whose
+// LLM provider has no embedding backend exposes the degraded-RAG condition as
+// a value — via DiagnosticsOf and the builder's DiagnosticHandler — instead
+// of only a log line.
+func TestDiagnosticsSurfaceDummyEmbeddingFallback(t *testing.T) {
+	var handled []Diagnostic
+	agent, err := NewBuilder("anthropic-bot").
+		WithConfig(&Config{
+			// "mock" has no embedding backend, like anthropic
+			LLM: LLMConfig{Provider: "mock", Model: "mock-model"},
+		}).
+		WithDiagnosticHandler(func(d Diagnostic) { handled = append(handled, d) }).
+		Build()
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+
+	diags := DiagnosticsOf(agent)
+	if !hasDiagnostic(diags, DiagEmbeddingFallbackDummy) {
+		t.Errorf("DiagnosticsOf missing %s, got %v", DiagEmbeddingFallbackDummy, diagCodes(diags))
+	}
+	if !hasDiagnostic(handled, DiagEmbeddingFallbackDummy) {
+		t.Errorf("DiagnosticHandler did not receive %s, got %v", DiagEmbeddingFallbackDummy, diagCodes(handled))
+	}
+
+	for _, d := range diags {
+		if d.Code == DiagEmbeddingFallbackDummy {
+			if d.Severity != DiagError {
+				t.Errorf("severity = %s, want %s", d.Severity, DiagError)
+			}
+			if d.Details["llm_provider"] != "mock" {
+				t.Errorf("details.llm_provider = %q, want %q", d.Details["llm_provider"], "mock")
+			}
+		}
+	}
+}
+
+// TestDiagnosticsSurfaceDisabledMemoryWithSettings verifies the
+// likely-forgotten-Enabled condition is exposed programmatically.
+func TestDiagnosticsSurfaceDisabledMemoryWithSettings(t *testing.T) {
+	agent, err := NewBuilder("forgot-enabled").
+		WithConfig(&Config{
+			LLM:    LLMConfig{Provider: "mock", Model: "mock-model"},
+			Memory: &MemoryConfig{Provider: "chromem"}, // Enabled left false
+		}).
+		Build()
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+	if !hasDiagnostic(DiagnosticsOf(agent), DiagMemoryDisabledWithConfig) {
+		t.Errorf("expected %s diagnostic, got %v", DiagMemoryDisabledWithConfig, diagCodes(DiagnosticsOf(agent)))
+	}
+}
+
+// TestDiagnosticsSurfaceDimensionMismatch verifies a dimensions/model
+// disagreement is exposed before the first vector-store write fails.
+func TestDiagnosticsSurfaceDimensionMismatch(t *testing.T) {
+	agent, err := NewBuilder("dims").
+		WithConfig(&Config{
+			LLM: LLMConfig{Provider: "mock", Model: "mock-model"},
+			Memory: &MemoryConfig{
+				Enabled:  true,
+				Provider: "chromem",
+				Options: map[string]string{
+					"embedding_provider": "ollama",
+					"embedding_model":    "nomic-embed-text", // 768 dims
+					"dimensions":         "1536",             // stale from a dummy-vector store
+				},
+			},
+		}).
+		Build()
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+
+	diags := DiagnosticsOf(agent)
+	if !hasDiagnostic(diags, DiagEmbeddingDimensionMismatch) {
+		t.Fatalf("expected %s diagnostic, got %v", DiagEmbeddingDimensionMismatch, diagCodes(diags))
+	}
+	for _, d := range diags {
+		if d.Code == DiagEmbeddingDimensionMismatch {
+			if d.Details["model_dimensions"] != "768" || d.Details["configured_dimensions"] != "1536" {
+				t.Errorf("details = %v, want model 768 / configured 1536", d.Details)
+			}
+		}
+	}
+}
+
+// TestDiagnosticsCleanConfigIsQuiet verifies a healthy configuration emits no
+// diagnostics — the surface must stay high-signal.
+func TestDiagnosticsCleanConfigIsQuiet(t *testing.T) {
+	agent, err := NewBuilder("clean").
+		WithConfig(&Config{
+			LLM: LLMConfig{Provider: "ollama", Model: "llama3.2"},
+		}).
+		Build()
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+	if diags := DiagnosticsOf(agent); len(diags) != 0 {
+		t.Errorf("clean config produced diagnostics: %v", diagCodes(diags))
+	}
+}
+
+func hasDiagnostic(diags []Diagnostic, code DiagnosticCode) bool {
+	for _, d := range diags {
+		if d.Code == code {
+			return true
+		}
+	}
+	return false
+}
+
+func diagCodes(diags []Diagnostic) []DiagnosticCode {
+	out := make([]DiagnosticCode, len(diags))
+	for i, d := range diags {
+		out[i] = d.Code
+	}
+	return out
+}

--- a/v1beta/embedding_defaults_test.go
+++ b/v1beta/embedding_defaults_test.go
@@ -1,0 +1,102 @@
+package v1beta
+
+import (
+	"testing"
+)
+
+func TestApplyEmbeddingDefaults_OllamaLLM(t *testing.T) {
+	mem := &MemoryConfig{Enabled: true, Provider: "chromem"}
+	llm := &LLMConfig{Provider: "ollama", Model: "llama3.2", BaseURL: "http://localhost:11434"}
+
+	applyEmbeddingDefaults(mem, llm)
+
+	if got := mem.Options["embedding_provider"]; got != "ollama" {
+		t.Errorf("embedding_provider = %q, want %q", got, "ollama")
+	}
+	// The chat model must never be reused as the embedding model (issue #137).
+	if got := mem.Options["embedding_model"]; got != defaultOllamaEmbeddingModel {
+		t.Errorf("embedding_model = %q, want %q", got, defaultOllamaEmbeddingModel)
+	}
+	if got := mem.Options["embedding_url"]; got != "http://localhost:11434" {
+		t.Errorf("embedding_url = %q, want LLM BaseURL", got)
+	}
+	if got := mem.Options["dimensions"]; got != "768" {
+		t.Errorf("dimensions = %q, want %q (nomic-embed-text)", got, "768")
+	}
+}
+
+func TestApplyEmbeddingDefaults_OpenAILLM(t *testing.T) {
+	mem := &MemoryConfig{Enabled: true, Provider: "chromem"}
+	llm := &LLMConfig{Provider: "openai", Model: "gpt-4o-mini", APIKey: "sk-test"}
+
+	applyEmbeddingDefaults(mem, llm)
+
+	if got := mem.Options["embedding_provider"]; got != "openai" {
+		t.Errorf("embedding_provider = %q, want %q", got, "openai")
+	}
+	if got := mem.Options["embedding_model"]; got != defaultOpenAIEmbeddingModel {
+		t.Errorf("embedding_model = %q, want %q", got, defaultOpenAIEmbeddingModel)
+	}
+	if got := mem.Options["embedding_api_key"]; got != "sk-test" {
+		t.Errorf("embedding_api_key = %q, want LLM APIKey", got)
+	}
+	if got := mem.Options["dimensions"]; got != "1536" {
+		t.Errorf("dimensions = %q, want %q (text-embedding-3-small)", got, "1536")
+	}
+}
+
+func TestApplyEmbeddingDefaults_NonEmbeddingLLMLeftUnset(t *testing.T) {
+	mem := &MemoryConfig{Enabled: true, Provider: "chromem"}
+	llm := &LLMConfig{Provider: "anthropic", Model: "claude-sonnet-4-20250514"}
+
+	applyEmbeddingDefaults(mem, llm)
+
+	// Anthropic has no embeddings API; the provider must be left unset so
+	// memory initialization can apply its own loud fallback, instead of the
+	// old behavior of copying the LLM provider/model verbatim.
+	if got, ok := mem.Options["embedding_provider"]; ok {
+		t.Errorf("embedding_provider = %q, want unset", got)
+	}
+	if got, ok := mem.Options["embedding_model"]; ok {
+		t.Errorf("embedding_model = %q, want unset", got)
+	}
+}
+
+func TestApplyEmbeddingDefaults_UserSettingsPreserved(t *testing.T) {
+	mem := &MemoryConfig{
+		Enabled:  true,
+		Provider: "pgvector",
+		Options: map[string]string{
+			"embedding_provider": "ollama",
+			"embedding_model":    "mxbai-embed-large",
+		},
+	}
+	llm := &LLMConfig{Provider: "openai", Model: "gpt-4o", APIKey: "sk-test"}
+
+	applyEmbeddingDefaults(mem, llm)
+
+	if got := mem.Options["embedding_provider"]; got != "ollama" {
+		t.Errorf("embedding_provider = %q, want user-provided %q", got, "ollama")
+	}
+	if got := mem.Options["embedding_model"]; got != "mxbai-embed-large" {
+		t.Errorf("embedding_model = %q, want user-provided %q", got, "mxbai-embed-large")
+	}
+	if got := mem.Options["dimensions"]; got != "1024" {
+		t.Errorf("dimensions = %q, want %q (mxbai-embed-large)", got, "1024")
+	}
+}
+
+func TestDimensionsForEmbeddingModel(t *testing.T) {
+	cases := map[string]int{
+		"nomic-embed-text":        768,
+		"nomic-embed-text:latest": 768, // Ollama tag suffix ignored
+		"Text-Embedding-3-Large":  3072,
+		"unknown-model":           0,
+		"":                        0,
+	}
+	for model, want := range cases {
+		if got := dimensionsForEmbeddingModel(model); got != want {
+			t.Errorf("dimensionsForEmbeddingModel(%q) = %d, want %d", model, got, want)
+		}
+	}
+}

--- a/v1beta/memory.go
+++ b/v1beta/memory.go
@@ -164,12 +164,17 @@ func NewMemory(config *MemoryConfig) (Memory, error) {
 
 	// Bridge to core memory factory (for plugins like chromem)
 	coreMem, err := createMemoryProvider(config)
-	if err == nil && coreMem != nil {
+	if err != nil {
+		// Fail loudly: silently returning a no-op memory here hides broken
+		// configuration (e.g. an unusable embedding provider) from the user.
+		return nil, fmt.Errorf("failed to create memory provider %q: %w", config.Provider, err)
+	}
+	if coreMem != nil {
 		// Wrap core.Memory with v1beta adapter
 		return &coreMemoryAdapter{mem: coreMem}, nil
 	}
 
-	// Fallback to no-op implementation
+	// Memory disabled by configuration
 	return &noOpMemory{}, nil
 }
 

--- a/v1beta/provider_factory.go
+++ b/v1beta/provider_factory.go
@@ -9,6 +9,11 @@ import (
 	"github.com/agenticgokit/agenticgokit/core"
 	"github.com/agenticgokit/agenticgokit/internal/llm"
 
+	// Register real embedding factories (OpenAI, Ollama). Without this import
+	// the core registry has no factories and memory would degrade to the
+	// zero-vector no-op embedding stub (see issue #137).
+	_ "github.com/agenticgokit/agenticgokit/plugins/embedding"
+
 	// Register memory providers
 	_ "github.com/agenticgokit/agenticgokit/plugins/memory/chromem"
 )
@@ -49,6 +54,95 @@ func createLLMProvider(config LLMConfig) (llm.ModelProvider, error) {
 	// Use the internal/llm factory to create the provider
 	factory := llm.NewProviderFactory()
 	return factory.CreateProvider(llmConfig)
+}
+
+// Default embedding models used when deriving embedding configuration from
+// the agent's LLM provider. Chat models are NOT valid embedding models, so we
+// must not reuse config.LLM.Model here (see issue #137).
+const (
+	defaultOllamaEmbeddingModel = "nomic-embed-text"
+	defaultOpenAIEmbeddingModel = "text-embedding-3-small"
+)
+
+// embeddingModelDimensions maps well-known embedding models to their vector
+// dimensions so users don't have to specify Options["dimensions"] manually.
+// A model/dimension mismatch silently corrupts the vector column, so getting
+// this right by default matters.
+var embeddingModelDimensions = map[string]int{
+	// Ollama models
+	"nomic-embed-text":       768,
+	"mxbai-embed-large":      1024,
+	"all-minilm":             384,
+	"snowflake-arctic-embed": 1024,
+	"bge-m3":                 1024,
+	// OpenAI models
+	"text-embedding-3-small": 1536,
+	"text-embedding-3-large": 3072,
+	"text-embedding-ada-002": 1536,
+}
+
+// dimensionsForEmbeddingModel returns the vector dimensions for a known
+// embedding model (Ollama ":tag" suffixes are ignored), or 0 if unknown.
+func dimensionsForEmbeddingModel(model string) int {
+	name := strings.ToLower(strings.TrimSpace(model))
+	if idx := strings.Index(name, ":"); idx >= 0 {
+		name = name[:idx]
+	}
+	return embeddingModelDimensions[name]
+}
+
+// applyEmbeddingDefaults fills Options["embedding_*"] from the agent's LLM
+// configuration when the user did not configure embeddings explicitly.
+//
+// Only LLM providers with a real embedding backend are mapped (ollama,
+// openai); for everything else the provider is left unset so that memory
+// initialization applies its own loud fallback instead of silently producing
+// meaningless vectors. When an embedding provider is set (by the user or
+// here) without a model, a proper default embedding model is chosen — the
+// chat model is never reused as an embedding model.
+func applyEmbeddingDefaults(mem *MemoryConfig, llmCfg *LLMConfig) {
+	if mem == nil {
+		return
+	}
+	if mem.Options == nil {
+		mem.Options = make(map[string]string)
+	}
+
+	if _, ok := mem.Options["embedding_provider"]; !ok && llmCfg != nil {
+		switch strings.ToLower(strings.TrimSpace(llmCfg.Provider)) {
+		case "ollama":
+			mem.Options["embedding_provider"] = "ollama"
+			if llmCfg.BaseURL != "" {
+				if _, ok := mem.Options["embedding_url"]; !ok {
+					mem.Options["embedding_url"] = llmCfg.BaseURL
+				}
+			}
+		case "openai":
+			mem.Options["embedding_provider"] = "openai"
+			if llmCfg.APIKey != "" {
+				if _, ok := mem.Options["embedding_api_key"]; !ok {
+					mem.Options["embedding_api_key"] = llmCfg.APIKey
+				}
+			}
+		}
+	}
+
+	// Choose a default embedding model for the resolved provider.
+	if _, ok := mem.Options["embedding_model"]; !ok {
+		switch mem.Options["embedding_provider"] {
+		case "ollama":
+			mem.Options["embedding_model"] = defaultOllamaEmbeddingModel
+		case "openai":
+			mem.Options["embedding_model"] = defaultOpenAIEmbeddingModel
+		}
+	}
+
+	// Derive dimensions from the embedding model when not set explicitly.
+	if _, ok := mem.Options["dimensions"]; !ok {
+		if dims := dimensionsForEmbeddingModel(mem.Options["embedding_model"]); dims > 0 {
+			mem.Options["dimensions"] = fmt.Sprintf("%d", dims)
+		}
+	}
 }
 
 // createMemoryProvider creates a Memory instance from MemoryConfig.
@@ -114,15 +208,17 @@ func createMemoryProvider(config *MemoryConfig) (core.Memory, error) {
 			if _, err := fmt.Sscanf(dim, "%d", &d); err == nil {
 				agentMemoryConfig.Dimensions = d
 			}
+		} else if dims := dimensionsForEmbeddingModel(config.Options["embedding_model"]); dims > 0 {
+			// Derive dimensions from the configured embedding model. A wrong
+			// dimension count silently corrupts the vector store.
+			agentMemoryConfig.Dimensions = dims
 		} else {
 			// Infer dimensions based on provider if possible
 			switch config.Options["embedding_provider"] {
 			case "openai":
 				agentMemoryConfig.Dimensions = 1536
 			case "ollama":
-				// This is a guess, but most small ollama models use 768 or 1024 or 4096.
-				// For dummy/fallback, 1536 is okay but we should ideally let the provider handle it.
-				agentMemoryConfig.Dimensions = 1536
+				agentMemoryConfig.Dimensions = 768 // matches defaultOllamaEmbeddingModel
 			}
 		}
 		if ep, ok := config.Options["embedding_provider"]; ok {

--- a/v1beta/regression_coverage_test.go
+++ b/v1beta/regression_coverage_test.go
@@ -1,0 +1,169 @@
+package v1beta
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/agenticgokit/agenticgokit/internal/llm"
+)
+
+// =============================================================================
+// Full-stack fail-loud memory construction (issue #137)
+// =============================================================================
+
+// TestNewMemoryPropagatesEmbeddingErrors verifies the whole chain fails
+// loudly: v1beta.NewMemory → core memory factory → chromem plugin →
+// core.NewEmbeddingServiceForConfig. Before the fix, this returned a silent
+// no-op memory.
+func TestNewMemoryPropagatesEmbeddingErrors(t *testing.T) {
+	_, err := NewMemory(&MemoryConfig{
+		Enabled:  true,
+		Provider: "chromem",
+		Options: map[string]string{
+			"embedding_provider": "not-a-real-provider",
+		},
+	})
+	if err == nil {
+		t.Fatal("NewMemory with an unknown embedding provider should return an error, got nil (silent no-op memory)")
+	}
+	if !strings.Contains(err.Error(), "unsupported embedding provider") {
+		t.Errorf("error should identify the unsupported embedding provider, got: %v", err)
+	}
+}
+
+// =============================================================================
+// Zero-config default memory path (issue #137)
+// =============================================================================
+
+// TestDefaultMemoryDerivesEmbeddingsFromLLM verifies the nil-Memory default
+// path: memory defaults to enabled chromem AND derives a real embedding
+// configuration from the LLM provider. It also proves the plugins/embedding
+// blank import registers real factories: if it did not, building the chromem
+// provider with embedding_provider=ollama would fail loudly.
+func TestDefaultMemoryDerivesEmbeddingsFromLLM(t *testing.T) {
+	agent, err := NewBuilder("default-memory").WithConfig(&Config{
+		LLM: LLMConfig{
+			Provider: "ollama",
+			Model:    "llama3.2",
+			BaseURL:  "http://localhost:11434",
+		},
+	}).Build()
+	if err != nil {
+		t.Fatalf("Build with default memory failed: %v", err)
+	}
+	if agent.Memory() == nil {
+		t.Fatal("default memory should be enabled when no MemoryConfig is provided")
+	}
+
+	opts := agent.Config().Memory.Options
+	if got := opts["embedding_provider"]; got != "ollama" {
+		t.Errorf("embedding_provider = %q, want %q (derived from LLM provider)", got, "ollama")
+	}
+	if got := opts["embedding_model"]; got != defaultOllamaEmbeddingModel {
+		t.Errorf("embedding_model = %q, want %q — the chat model must never be used", got, defaultOllamaEmbeddingModel)
+	}
+	if got := opts["dimensions"]; got != "768" {
+		t.Errorf("dimensions = %q, want %q for %s", got, "768", defaultOllamaEmbeddingModel)
+	}
+}
+
+// =============================================================================
+// Per-run sampling parameter plumbing (issue #143)
+// =============================================================================
+
+// recordingProvider is a llm.ModelProvider fake that records the last prompt
+// it received, so tests can assert what actually reaches the provider.
+type recordingProvider struct {
+	lastPrompt llm.Prompt
+}
+
+func (r *recordingProvider) Call(ctx context.Context, p llm.Prompt) (llm.Response, error) {
+	r.lastPrompt = p
+	return llm.Response{Content: "ok"}, nil
+}
+
+func (r *recordingProvider) Stream(ctx context.Context, p llm.Prompt) (<-chan llm.Token, error) {
+	r.lastPrompt = p
+	ch := make(chan llm.Token, 1)
+	ch <- llm.Token{Content: "ok"}
+	close(ch)
+	return ch, nil
+}
+
+func (r *recordingProvider) Embeddings(ctx context.Context, texts []string) ([][]float64, error) {
+	return nil, nil
+}
+
+func newRecordingAgent(t *testing.T) (Agent, *recordingProvider) {
+	t.Helper()
+	agent, err := NewBuilder("rec").WithConfig(&Config{
+		Timeout: 30 * time.Second,
+		LLM: LLMConfig{
+			Provider:    "mock",
+			Model:       "mock-model",
+			Temperature: 0.7,
+			MaxTokens:   2048,
+		},
+		Memory: &MemoryConfig{Enabled: false},
+	}).Build()
+	if err != nil {
+		t.Fatalf("Build failed: %v", err)
+	}
+	ra, ok := agent.(*realAgent)
+	if !ok {
+		t.Fatalf("unexpected agent type %T", agent)
+	}
+	rec := &recordingProvider{}
+	ra.llmProvider = rec
+	return agent, rec
+}
+
+// TestConfigSamplingParametersReachProvider verifies configured sampling
+// values are passed per call. Before the fix, execute() built prompts with no
+// Parameters at all, so the provider only ever saw its construction-time
+// values and per-run overrides were dead code.
+func TestConfigSamplingParametersReachProvider(t *testing.T) {
+	agent, rec := newRecordingAgent(t)
+
+	if _, err := agent.Run(context.Background(), "hello"); err != nil {
+		t.Fatalf("Run failed: %v", err)
+	}
+
+	p := rec.lastPrompt.Parameters
+	if p.Temperature == nil || *p.Temperature != 0.7 {
+		t.Errorf("Parameters.Temperature = %v, want configured 0.7", p.Temperature)
+	}
+	if p.MaxTokens == nil || *p.MaxTokens != 2048 {
+		t.Errorf("Parameters.MaxTokens = %v, want configured 2048", p.MaxTokens)
+	}
+}
+
+// TestRunOptionsOverridesReachProvider verifies RunOptions.Temperature and
+// MaxTokens overrides reach the provider — including an explicit temperature
+// of 0, which must not be conflated with "unset" (issue #143).
+func TestRunOptionsOverridesReachProvider(t *testing.T) {
+	agent, rec := newRecordingAgent(t)
+
+	zero := 0.0
+	opts := &RunOptions{
+		Temperature: &zero,
+		MaxTokens:   99,
+		ToolMode:    "none",
+	}
+	if _, err := agent.RunWithOptions(context.Background(), "hello", opts); err != nil {
+		t.Fatalf("RunWithOptions failed: %v", err)
+	}
+
+	p := rec.lastPrompt.Parameters
+	if p.Temperature == nil {
+		t.Fatal("Parameters.Temperature = nil; explicit 0 override was dropped")
+	}
+	if *p.Temperature != 0 {
+		t.Errorf("Parameters.Temperature = %v, want explicit 0", *p.Temperature)
+	}
+	if p.MaxTokens == nil || *p.MaxTokens != 99 {
+		t.Errorf("Parameters.MaxTokens = %v, want override 99", p.MaxTokens)
+	}
+}


### PR DESCRIPTION
Fixes #137. Addresses the quick-win portion of #143.

Also includes the LLM/platform-agnosticism analysis report (`docs/AGNOSTIC_FRAMEWORK_ANALYSIS.md`) that motivated issues #139–#155; the bug fixes below were developed on the same branch.

## #137 — memory silently used zero-vector / dummy embeddings

Three stacked silent fallbacks meant v1beta agents with memory enabled could produce meaningless semantic-search results with no error:

1. **Embedding factories were never registered** unless the consumer blank-imported `plugins/embedding`; core then fell back to the zero-vector no-op stub with a single Warn log. → `v1beta` now blank-imports `plugins/embedding`, so real factories are always registered for v1beta users.
2. **Unknown/unset embedding providers silently became dummy embeddings** in the chromem/pgvector plugins. → Both plugins now resolve embedders through a new `core.NewEmbeddingServiceForConfig`, which **errors** on unregistered factories (with the exact import to add) and on unknown providers, and logs at **Error** level for the unset-provider dummy fallback (kept so zero-config memory still constructs).
3. **`v1beta.NewMemory` swallowed construction errors** into a silent no-op memory. → Errors now propagate.

The embedding "smart default" also no longer copies the **chat model** as the embedding model. Ollama/OpenAI LLM configs derive a proper default (`nomic-embed-text` / `text-embedding-3-small`), dimensions are auto-derived for well-known embedding models (nomic-embed-text=768, mxbai-embed-large=1024, text-embedding-3-large=3072, …), and the zero-config default-memory path gets the same derivation. Docs gained an "Embeddings" section documenting defaults and failure modes.

Both additional findings from the issue are fixed too:
- **(A)** `WithConfig` no longer discards the name passed to `NewBuilder` (zero-valued `Name`/`Timeout` fall back to builder values; explicit values win).
- **(B)** `Memory.Enabled=false` in a provided config is now honored as documented instead of being force-enabled; in-repo config literals that relied on presence-implies-enabled now set `Enabled: true` explicitly.

## #143 — sampling-parameter defects (quick wins)

- `MaxTokens` no longer silently defaults to **150** (mid-sentence truncation); the default is a named, documented `DefaultMaxTokens = 2048`, matching the v1beta builder default.
- An explicit per-call **temperature of 0** (deterministic sampling) is honored: the Ollama `Call` path dropped it via a `> 0` check (the Stream path was already correct).
- `v1beta` `execute()` built prompts **without `Parameters`**, so configured sampling values and `RunOptions.Temperature`/`MaxTokens` overrides never reached the provider (the adapter is constructed at `Build()` time; mutating config afterwards has no effect). Parameters are now passed per call, and `RunOptions.Temperature` — a pointer — survives verbatim, making explicit 0 expressible end-to-end.

The full pointer-based optional-params API change stays tracked in #143.

## Consumer-facing diagnostics — findings as values, not black-hole logs

A framework shouldn't only *log* problems (invisible if the consumer never wires the framework logger); it should hand them to the consumer programmatically:

- **Typed build-time diagnostics** (`v1beta.Diagnostic` with stable codes `EMBEDDING_FALLBACK_DUMMY`, `MEMORY_DISABLED_WITH_CONFIG`, `EMBEDDING_DIMENSION_MISMATCH`, severity, fix-included message, structured details):
  ```go
  agent, err := v1beta.NewBuilder("bot").WithConfig(cfg).
      WithDiagnosticHandler(func(d v1beta.Diagnostic) {
          if d.Code == v1beta.DiagEmbeddingFallbackDummy { /* fail deploy, alert */ }
      }).Build()
  // or after the fact:
  diags := v1beta.DiagnosticsOf(agent)
  ```
  Implemented via an optional interface so the `Agent` interface is unchanged; every diagnostic is still logged, so nothing changes for consumers that ignore the API.
- **Typed sentinel errors** for fatal embedding misconfiguration: `errors.Is(err, core.ErrEmbeddingFactoryNotRegistered)` / `core.ErrEmbeddingProviderUnsupported` work through the whole agent/memory construction chain — no string matching.
- **Actionable error text**: missing Ollama model → ``run `ollama pull <model>` ``; unreachable instance → ``start `ollama serve` `` / set `embedding_url` (with the attempted URL); OpenAI 401 → set `OPENAI_API_KEY` / `embedding_api_key`.
- **Intent-aware logging**: bare `{Enabled: false}` → Info; a config carrying settings with `Enabled` unset → Warn that enablement is no longer implied by presence (migration aid for change B).

## Tests

- `core/memory_embedding_test.go` — fail-loud resolver incl. `errors.Is` on both sentinels; dummy/empty still construct.
- `v1beta/embedding_defaults_test.go` — LLM→embedding derivation, chat model never reused, user settings preserved, dimension lookup.
- `v1beta/builder_config_test.go` — WithConfig name/timeout preservation; Enabled=false honored; Enabled=true provides memory.
- `v1beta/regression_coverage_test.go` — full-stack NewMemory error propagation; zero-config embedding derivation incl. blank-import proof; recording-provider assertions that config values and RunOptions overrides (incl. explicit temp 0) reach the provider.
- `v1beta/diagnostics_test.go` — handler + `DiagnosticsOf` receive dummy-fallback (with details), disabled-with-settings, and dimension-mismatch diagnostics; clean configs stay quiet.
- `internal/llm/factory_defaults_test.go` — default constants; httptest-verified explicit temp-0 reaches the Ollama payload.
- `internal/embedding/providers/ollama_test.go` — httptest-verified `ollama pull` / `ollama serve` hints.
- `test/vnext/memory_access_verification_test.go` now uses dummy embeddings explicitly — it verifies accessor wiring and previously only passed because the zero-vector stub masked its missing Ollama dependency.
- `go test ./core/ ./v1beta/ ./internal/llm/ ./internal/embedding/... ./test/vnext/ ./test/vnext/config/` all pass. Remaining failures under `./...` are pre-existing on master: vet findings in several examples, the duplicate-main `performance-analysis` example, live-Ollama integration tests (`test/vnext/options`, `test/vnext/streaming`), and nested modules pinned to published versions.

## Behavior changes to review

- Agents whose LLM provider has no embedding backend (e.g. anthropic) and no explicit embedding config now emit an **Error-severity diagnostic** (dummy fallback) — programmatically via `WithDiagnosticHandler`/`DiagnosticsOf` and in logs — instead of silently pretending RAG works.
- A provided `MemoryConfig` without `Enabled: true` now means memory **disabled** (documented semantics); previously it was force-enabled. Presets and the nil-config default path still enable memory, and a `MEMORY_DISABLED_WITH_CONFIG` diagnostic fires when a config carries settings but leaves `Enabled` unset.
- Ollama-backed agents with default memory now derive real embeddings (`nomic-embed-text`, 768-dim). If the model isn't pulled, the first memory write fails with ``run `ollama pull nomic-embed-text` `` in the error; stores created with 1536-dim dummy vectors get an `EMBEDDING_DIMENSION_MISMATCH` diagnostic at construction and need re-ingestion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015u41mAT1miMPCkoG4kY9ZW