### PR TITLE
Circuit-breaker/retry provider, AgentMiddleware wiring, response_format propagation, and a few smaller fixes

### DIFF
--- a/core/prompt_format.go
+++ b/core/prompt_format.go
@@ -1,0 +1,86 @@
+package core
+
+import (
+	"bytes"
+	"fmt"
+	"regexp"
+	"text/template"
+)
+
+// FormatType selects the substitution syntax used by FormatPromptString.
+// Modeled after cloudwego/eino's schema.FormatType (FString/GoTemplate/Jinja2),
+// scoped down to the two syntaxes implementable without a new dependency.
+type FormatType uint8
+
+const (
+	// FormatGoTemplate interpolates using Go's text/template ({{.key}}).
+	// A string with no template directives passes through unchanged, so this
+	// is safe to apply unconditionally to existing plain-text system prompts.
+	FormatGoTemplate FormatType = iota
+	// FormatFString interpolates using Python str.format-style {key} placeholders.
+	FormatFString
+)
+
+var fstringPlaceholder = regexp.MustCompile(`\{([a-zA-Z_][a-zA-Z0-9_]*)\}`)
+
+// FormatPromptString substitutes vs into tpl according to formatType.
+//
+// Variable keys present in tpl but absent from vs produce an error for
+// FormatFString, and render as "<no value>" for FormatGoTemplate (the
+// text/template default) — there is no compile-time safety, consistent with
+// eino's ChatTemplate.Format contract.
+func FormatPromptString(tpl string, vs map[string]any, formatType FormatType) (string, error) {
+	switch formatType {
+	case FormatFString:
+		return formatFString(tpl, vs)
+	case FormatGoTemplate:
+		return formatGoTemplate(tpl, vs)
+	default:
+		return "", fmt.Errorf("core: unsupported FormatType %d", formatType)
+	}
+}
+
+func formatGoTemplate(tpl string, vs map[string]any) (string, error) {
+	t, err := template.New("prompt").Parse(tpl)
+	if err != nil {
+		return "", fmt.Errorf("core: parse go template: %w", err)
+	}
+	var buf bytes.Buffer
+	if err := t.Execute(&buf, vs); err != nil {
+		return "", fmt.Errorf("core: execute go template: %w", err)
+	}
+	return buf.String(), nil
+}
+
+func formatFString(tpl string, vs map[string]any) (string, error) {
+	var missing error
+	result := fstringPlaceholder.ReplaceAllStringFunc(tpl, func(match string) string {
+		key := match[1 : len(match)-1]
+		v, ok := vs[key]
+		if !ok {
+			if missing == nil {
+				missing = fmt.Errorf("core: missing variable %q for fstring template", key)
+			}
+			return match
+		}
+		return fmt.Sprintf("%v", v)
+	})
+	if missing != nil {
+		return "", missing
+	}
+	return result, nil
+}
+
+// StateVars snapshots a State's data map into a plain map[string]any suitable
+// for FormatPromptString. State does not expose its underlying map directly,
+// so this walks Keys()+Get().
+func StateVars(state State) map[string]any {
+	keys := state.Keys()
+	vs := make(map[string]any, len(keys))
+	for _, k := range keys {
+		if v, ok := state.Get(k); ok {
+			vs[k] = v
+		}
+	}
+	return vs
+}

--- a/core/prompt_format.go
+++ b/core/prompt_format.go
@@ -14,8 +14,15 @@ type FormatType uint8
 
 const (
 	// FormatGoTemplate interpolates using Go's text/template ({{.key}}).
-	// A string with no template directives passes through unchanged, so this
-	// is safe to apply unconditionally to existing plain-text system prompts.
+	// A string with no {{ ... }} sequence passes through unchanged. A string
+	// that DOES contain "{{" but isn't valid Go template syntax (e.g. a
+	// prompt that teaches the model Handlebars/Jinja/Vue syntax, or embeds a
+	// doc example containing literal "{{") fails template.Parse/Execute —
+	// formatGoTemplate falls back to returning tpl verbatim in that case
+	// (with a Warn log) rather than erroring the caller's Run, so this is
+	// safe to apply unconditionally even though the syntax collision is not
+	// hypothetical: it broke a real skill's frontmatter description in
+	// practice. See formatGoTemplate.
 	FormatGoTemplate FormatType = iota
 	// FormatFString interpolates using Python str.format-style {key} placeholders.
 	FormatFString
@@ -40,14 +47,37 @@ func FormatPromptString(tpl string, vs map[string]any, formatType FormatType) (s
 	}
 }
 
+// formatGoTemplate parses tpl as a Go template and executes it against vs.
+//
+// tpl containing no "{{" is unaffected by this parse/execute round-trip in
+// practice, but is not special-cased: it still goes through Parse/Execute
+// below, which is a correctness statement, not just a performance one —
+// there is no separate "fast path" that could drift from the template-path
+// behavior.
+//
+// tpl containing a literal "{{" that ISN'T valid Go template syntax (a
+// prompt documenting Handlebars/Jinja/Vue templating to the model, or a doc
+// example with "{{ }}" in it) is a real, observed failure mode, not a
+// hypothetical one — it broke a real skill's frontmatter description. Rather
+// than hard-failing the caller's Run on that input (the previous behavior:
+// return "", err), Parse/Execute failures fall back to tpl unchanged, so
+// FormatPromptString stays safe to apply unconditionally to every
+// SystemPrompt as the type's doc comment promises. The fallback is logged
+// at Warn so a real templating typo (an unclosed "{{if}}", a genuinely
+// misspelled ".Fieldname") is still visible instead of silently mis-rendering
+// forever — callers that need a hard error on bad template syntax (rather
+// than degrade-to-verbatim) should validate tpl with template.New(...).Parse
+// themselves before handing it to FormatPromptString.
 func formatGoTemplate(tpl string, vs map[string]any) (string, error) {
 	t, err := template.New("prompt").Parse(tpl)
 	if err != nil {
-		return "", fmt.Errorf("core: parse go template: %w", err)
+		Logger().Warn().Err(err).Msg("core: system prompt contains \"{{\" that isn't valid Go template syntax; using it verbatim instead of failing the run")
+		return tpl, nil
 	}
 	var buf bytes.Buffer
 	if err := t.Execute(&buf, vs); err != nil {
-		return "", fmt.Errorf("core: execute go template: %w", err)
+		Logger().Warn().Err(err).Msg("core: system prompt template failed to execute; using it verbatim instead of failing the run")
+		return tpl, nil
 	}
 	return buf.String(), nil
 }

--- a/core/prompt_format_test.go
+++ b/core/prompt_format_test.go
@@ -1,0 +1,82 @@
+package core
+
+import (
+	"strings"
+	"testing"
+)
+
+// Regression test for the blocker flagged in PR #157 review: a SystemPrompt
+// containing a literal "{{" that isn't valid Go template syntax (e.g. a
+// prompt documenting Handlebars/Jinja/Vue templating, or a doc example with
+// "{{ }}" in it) must not fail the run — it must pass through verbatim.
+func TestFormatPromptString_GoTemplate_InvalidBraceSyntaxFallsBackVerbatim(t *testing.T) {
+	tpl := "You are an assistant. Use the syntax {{foo}} to reference variables in Handlebars."
+
+	got, err := FormatPromptString(tpl, map[string]any{"Input": "hello"}, FormatGoTemplate)
+	if err != nil {
+		t.Fatalf("FormatPromptString returned an error for a non-template \"{{\" prompt, want verbatim fallback: %v", err)
+	}
+	if got != tpl {
+		t.Fatalf("FormatPromptString mangled a non-template prompt.\n got:  %q\nwant: %q", got, tpl)
+	}
+}
+
+// Same failure mode, but via an incomplete/invalid directive rather than a
+// non-Go-template dialect example (e.g. "{{if}}" with no condition).
+func TestFormatPromptString_GoTemplate_MalformedDirectiveFallsBackVerbatim(t *testing.T) {
+	tpl := "Some instructions. {{if}} more text."
+
+	got, err := FormatPromptString(tpl, nil, FormatGoTemplate)
+	if err != nil {
+		t.Fatalf("FormatPromptString returned an error for a malformed template, want verbatim fallback: %v", err)
+	}
+	if got != tpl {
+		t.Fatalf("FormatPromptString mangled a malformed-template prompt.\n got:  %q\nwant: %q", got, tpl)
+	}
+}
+
+// Valid Go template syntax must still interpolate correctly — the fallback
+// must not mask legitimate templating.
+func TestFormatPromptString_GoTemplate_ValidSyntaxStillInterpolates(t *testing.T) {
+	tpl := "Hello {{.Input}}!"
+
+	got, err := FormatPromptString(tpl, map[string]any{"Input": "world"}, FormatGoTemplate)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != "Hello world!" {
+		t.Fatalf("got %q, want %q", got, "Hello world!")
+	}
+}
+
+// Plain text with no "{{" at all must pass through unchanged (existing
+// guarantee, still covered as a baseline).
+func TestFormatPromptString_GoTemplate_PlainTextPassesThroughUnchanged(t *testing.T) {
+	tpl := "You are a helpful assistant. Respond in JSON: {\"k\":1}."
+
+	got, err := FormatPromptString(tpl, nil, FormatGoTemplate)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != tpl {
+		t.Fatalf("got %q, want %q", got, tpl)
+	}
+}
+
+// A template referencing an undefined execution directive (not a parse
+// error, but a runtime execute error) must also fall back verbatim rather
+// than erroring, per the same rationale.
+func TestFormatPromptString_GoTemplate_ExecuteErrorFallsBackVerbatim(t *testing.T) {
+	// {{index .Items 5}} parses fine (valid template syntax) but errors at
+	// Execute time (index out of range), reliably reproducing the
+	// execute-time (not parse-time) failure path.
+	tpl := "Value: {{index .Items 5}}"
+
+	got, err := FormatPromptString(tpl, map[string]any{"Items": []int{1, 2}}, FormatGoTemplate)
+	if err != nil {
+		t.Fatalf("FormatPromptString returned an error on an execute-time failure, want verbatim fallback: %v", err)
+	}
+	if !strings.Contains(got, "{{index .Items 5}}") {
+		t.Fatalf("expected verbatim fallback containing the original directive, got %q", got)
+	}
+}

--- a/go.mod
+++ b/go.mod
@@ -23,7 +23,9 @@ require (
 )
 
 require (
+	github.com/bahlo/generic-list-go v0.2.0 // indirect
 	github.com/beorn7/perks v1.0.1 // indirect
+	github.com/buger/jsonparser v1.1.1 // indirect
 	github.com/cenkalti/backoff/v5 v5.0.2 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
 	github.com/davecgh/go-spew v1.1.2-0.20180830191138-d8f796af33cc // indirect
@@ -31,9 +33,11 @@ require (
 	github.com/go-logr/stdr v1.2.2 // indirect
 	github.com/gorilla/websocket v1.5.3 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.1 // indirect
+	github.com/invopop/jsonschema v0.13.0 // indirect
 	github.com/jackc/pgpassfile v1.0.0 // indirect
 	github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 // indirect
 	github.com/jackc/puddle/v2 v2.2.2 // indirect
+	github.com/mailru/easyjson v0.7.7 // indirect
 	github.com/mattn/go-colorable v0.1.13 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
@@ -42,6 +46,7 @@ require (
 	github.com/prometheus/common v0.62.0 // indirect
 	github.com/prometheus/procfs v0.15.1 // indirect
 	github.com/vmihailenco/msgpack/v5 v5.4.1 // indirect
+	github.com/wk8/go-ordered-map/v2 v2.1.8 // indirect
 	go.opentelemetry.io/auto/sdk v1.1.0 // indirect
 	go.opentelemetry.io/otel/exporters/otlp/otlptrace v1.37.0 // indirect
 	go.opentelemetry.io/otel/metric v1.37.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,12 @@ github.com/Azure/azure-sdk-for-go/sdk/azcore v1.18.0 h1:Gt0j3wceWMwPmiazCa8MzMA0
 github.com/Azure/azure-sdk-for-go/sdk/azcore v1.18.0/go.mod h1:Ot/6aikWnKWi4l9QB7qVSwa8iMphQNqkWALMoNT3rzM=
 github.com/BurntSushi/toml v1.5.0 h1:W5quZX/G/csjUnuI8SUYlsHs9M38FC7znL0lIO+DvMg=
 github.com/BurntSushi/toml v1.5.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
+github.com/bahlo/generic-list-go v0.2.0 h1:5sz/EEAK+ls5wF+NeqDpk5+iNdMDXrh3z3nPnH1Wvgk=
+github.com/bahlo/generic-list-go v0.2.0/go.mod h1:2KvAjgMlE5NNynlg/5iLrrCCZ2+5xWbdbCW3pNTGyYg=
 github.com/beorn7/perks v1.0.1 h1:VlbKKnNfV8bJzeqoa4cOKqO6bYr3WgKZxO8Z16+hsOM=
 github.com/beorn7/perks v1.0.1/go.mod h1:G2ZrVWU2WbWT9wwq4/hrbKbnv/1ERSJQ0ibhJ6rlkpw=
+github.com/buger/jsonparser v1.1.1 h1:2PnMjfWD7wBILjqQbt530v576A/cAbQvEW9gGIpYMUs=
+github.com/buger/jsonparser v1.1.1/go.mod h1:6RYKKt7H4d4+iWqouImQ9R2FZql3VbhNgx27UK13J/0=
 github.com/cenkalti/backoff/v5 v5.0.2 h1:rIfFVxEf1QsI7E1ZHfp/B4DF/6QBAUhmgkxc0H7Zss8=
 github.com/cenkalti/backoff/v5 v5.0.2/go.mod h1:rkhZdG3JZukswDf7f0cwqPNk4K0sa+F97BxZthm/crw=
 github.com/cespare/xxhash/v2 v2.3.0 h1:UL815xU9SqsFlibzuggzjXhog7bL6oX9BbNZnL2UFvs=
@@ -36,6 +40,8 @@ github.com/gorilla/websocket v1.5.3 h1:saDtZ6Pbx/0u+bgYQ3q96pZgCzfhKXGPqt7kZ72aN
 github.com/gorilla/websocket v1.5.3/go.mod h1:YR8l580nyteQvAITg2hZ9XVh4b55+EU/adAjf1fMHhE=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.1 h1:X5VWvz21y3gzm9Nw/kaUeku/1+uBhcekkmy4IkffJww=
 github.com/grpc-ecosystem/grpc-gateway/v2 v2.27.1/go.mod h1:Zanoh4+gvIgluNqcfMVTJueD4wSS5hT7zTt4Mrutd90=
+github.com/invopop/jsonschema v0.13.0 h1:KvpoAJWEjR3uD9Kbm2HWJmqsEaHt8lBUpd0qHcIi21E=
+github.com/invopop/jsonschema v0.13.0/go.mod h1:ffZ5Km5SWWRAIN6wbDXItl95euhFz2uON45H2qjYt+0=
 github.com/jackc/pgpassfile v1.0.0 h1:/6Hmqy13Ss2zCq62VdNG8tM1wchn8zjSGOBJ6icpsIM=
 github.com/jackc/pgpassfile v1.0.0/go.mod h1:CEx0iS5ambNFdcRtxPj5JhEz+xB6uRky5eyVu/W2HEg=
 github.com/jackc/pgservicefile v0.0.0-20240606120523-5a60cdf6a761 h1:iCEnooe7UlwOQYpKFhBabPMi4aNAfoODPEFNiAnClxo=
@@ -50,6 +56,7 @@ github.com/jinzhu/now v1.1.5 h1:/o9tlHleP7gOFmsnYNz3RGnqzefHA47wQpKrrdTIwXQ=
 github.com/jinzhu/now v1.1.5/go.mod h1:d3SSVoowX0Lcu0IBviAWJpolVfI5UJVZZ7cO71lE/z8=
 github.com/jmoiron/sqlx v1.3.5 h1:vFFPA71p1o5gAeqtEAwLU4dnX2napprKtHr7PYIcN3g=
 github.com/jmoiron/sqlx v1.3.5/go.mod h1:nRVWtLre0KfCLJvgxzCsLVMogSvQ1zNJtpYr2Ccp0mQ=
+github.com/josharian/intern v1.0.0/go.mod h1:5DoeVV0s6jJacbCEi61lwdGj/aVlrQvzHFFd8Hwg//Y=
 github.com/klauspost/compress v1.18.0 h1:c/Cqfb0r+Yi+JtIEq73FWXVkRonBlf0CRNYc8Zttxdo=
 github.com/klauspost/compress v1.18.0/go.mod h1:2Pp+KzxcywXVXMr50+X0Q/Lsb43OQHYWRCY2AiWywWQ=
 github.com/kr/pretty v0.3.1 h1:flRD4NNwYAUpkphVc1HcthR4KEIFJ65n8Mw5qdRn3LE=
@@ -62,6 +69,8 @@ github.com/kylelemons/godebug v1.1.0 h1:RPNrshWIDI6G2gRW9EHilWtl7Z6Sb1BR0xunSBf0
 github.com/kylelemons/godebug v1.1.0/go.mod h1:9/0rRGxNHcop5bhtWyNeEfOS8JIWk580+fNqagV/RAw=
 github.com/lib/pq v1.10.9 h1:YXG7RB+JIjhP29X+OtkiDnYaXQwpS4JEWq7dtCCRUEw=
 github.com/lib/pq v1.10.9/go.mod h1:AlVN5x4E4T544tWzH6hKfbfQvm3HdbOxrmggDNAPY9o=
+github.com/mailru/easyjson v0.7.7 h1:UGYAvKxe3sBsEDzO8ZeWOSlIQfWFlxbzLZe7hwFURr0=
+github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
 github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
 github.com/mattn/go-isatty v0.0.16/go.mod h1:kYGgaQfpe5nmfYZH+SKPsOc2e4SrIfOl2e/yFXSvRLM=
@@ -112,6 +121,8 @@ github.com/vmihailenco/tagparser v0.1.2 h1:gnjoVuB/kljJ5wICEEOpx98oXMWPLj22G67Vb
 github.com/vmihailenco/tagparser v0.1.2/go.mod h1:OeAg3pn3UbLjkWt+rN9oFYB6u/cQgqMEUPoW2WPyhdI=
 github.com/vmihailenco/tagparser/v2 v2.0.0 h1:y09buUbR+b5aycVFQs/g70pqKVZNBmxwAhO7/IwNM9g=
 github.com/vmihailenco/tagparser/v2 v2.0.0/go.mod h1:Wri+At7QHww0WTrCBeu4J6bNtoV6mEfg5OIWRZA9qds=
+github.com/wk8/go-ordered-map/v2 v2.1.8 h1:5h/BUHu93oj4gIdvHHHGsScSTMijfx5PeYkE/fJgbpc=
+github.com/wk8/go-ordered-map/v2 v2.1.8/go.mod h1:5nJHM5DyteebpVlHnWMV0rPz6Zp7+xBAnxjb1X5vnTw=
 github.com/x448/float16 v0.8.4 h1:qLwI1I70+NjRFUR3zs1JPUCgaCXSh3SW62uAKT1mSBM=
 github.com/x448/float16 v0.8.4/go.mod h1:14CWIYCyZA/cWjXOioeEpHeN/83MdbZDRQHoFcYsOfg=
 go.opentelemetry.io/auto/sdk v1.1.0 h1:cH53jehLUN6UFLY71z+NDOiNJqDdPRaXzTel0sJySYA=

--- a/internal/agents/configurable.go
+++ b/internal/agents/configurable.go
@@ -168,7 +168,11 @@ func (ca *ConfigAwareUnifiedAgent) ApplySystemPrompt(ctx context.Context, state 
 	}
 
 	workingState := state.Clone()
-	workingState.Set("system_prompt", ca.config.SystemPrompt)
+	rendered, err := core.FormatPromptString(ca.config.SystemPrompt, core.StateVars(state), core.FormatGoTemplate)
+	if err != nil {
+		return state, err
+	}
+	workingState.Set("system_prompt", rendered)
 	workingState.Set("system_prompt_applied", true)
 
 	// If we have an LLM capability, we can potentially use the system prompt
@@ -344,7 +348,11 @@ func (ca *ConfigAwareSequentialAgent) ApplySystemPrompt(ctx context.Context, sta
 	}
 
 	workingState := state.Clone()
-	workingState.Set("sequential_system_prompt", ca.config.SystemPrompt)
+	rendered, err := core.FormatPromptString(ca.config.SystemPrompt, core.StateVars(state), core.FormatGoTemplate)
+	if err != nil {
+		return state, err
+	}
+	workingState.Set("sequential_system_prompt", rendered)
 	return workingState, nil
 }
 
@@ -481,7 +489,11 @@ func (ca *ConfigAwareParallelAgent) ApplySystemPrompt(ctx context.Context, state
 	}
 
 	workingState := state.Clone()
-	workingState.Set("parallel_system_prompt", ca.config.SystemPrompt)
+	rendered, err := core.FormatPromptString(ca.config.SystemPrompt, core.StateVars(state), core.FormatGoTemplate)
+	if err != nil {
+		return state, err
+	}
+	workingState.Set("parallel_system_prompt", rendered)
 	return workingState, nil
 }
 

--- a/internal/agents/loop.go
+++ b/internal/agents/loop.go
@@ -314,7 +314,11 @@ func (l *LoopAgent) ApplySystemPrompt(ctx context.Context, state agenticgokit.St
 	}
 
 	workingState := state.Clone()
-	workingState.Set("system_prompt", l.agentConfig.SystemPrompt)
+	rendered, err := core.FormatPromptString(l.agentConfig.SystemPrompt, internalStateVars(state), core.FormatGoTemplate)
+	if err != nil {
+		return state, err
+	}
+	workingState.Set("system_prompt", rendered)
 	workingState.Set("system_prompt_applied", true)
 	workingState.Set("system_prompt_source", "loop_agent")
 

--- a/internal/agents/parallel.go
+++ b/internal/agents/parallel.go
@@ -306,7 +306,11 @@ func (a *ParallelAgent) ApplySystemPrompt(ctx context.Context, state agenticgoki
 	}
 
 	workingState := state.Clone()
-	workingState.Set("system_prompt", a.agentConfig.SystemPrompt)
+	rendered, err := core.FormatPromptString(a.agentConfig.SystemPrompt, internalStateVars(state), core.FormatGoTemplate)
+	if err != nil {
+		return state, err
+	}
+	workingState.Set("system_prompt", rendered)
 	workingState.Set("system_prompt_applied", true)
 	workingState.Set("system_prompt_source", "parallel_agent")
 

--- a/internal/agents/prompt_vars.go
+++ b/internal/agents/prompt_vars.go
@@ -1,0 +1,20 @@
+package agents
+
+import (
+	agenticgokit "github.com/agenticgokit/agenticgokit/internal/core"
+)
+
+// internalStateVars snapshots an internal/core.State's data map into a plain
+// map[string]any for core.FormatPromptString. Mirrors core.StateVars, which
+// can't be reused here because internal/core.State and core.State are
+// distinct interfaces (differing Clone() return types).
+func internalStateVars(state agenticgokit.State) map[string]any {
+	keys := state.Keys()
+	vs := make(map[string]any, len(keys))
+	for _, k := range keys {
+		if v, ok := state.Get(k); ok {
+			vs[k] = v
+		}
+	}
+	return vs
+}

--- a/internal/agents/sequential.go
+++ b/internal/agents/sequential.go
@@ -242,7 +242,11 @@ func (s *SequentialAgent) ApplySystemPrompt(ctx context.Context, state agenticgo
 	}
 
 	workingState := state.Clone()
-	workingState.Set("system_prompt", s.config.SystemPrompt)
+	rendered, err := core.FormatPromptString(s.config.SystemPrompt, internalStateVars(state), core.FormatGoTemplate)
+	if err != nil {
+		return state, err
+	}
+	workingState.Set("system_prompt", rendered)
 	workingState.Set("system_prompt_applied", true)
 	workingState.Set("system_prompt_source", "sequential_agent")
 

--- a/internal/llm/azure_adapter.go
+++ b/internal/llm/azure_adapter.go
@@ -34,10 +34,11 @@ type azureChatMessage struct {
 
 // Request structure for the Chat Completions API
 type azureChatCompletionsRequest struct {
-	Messages    []azureChatMessage `json:"messages"`
-	Stream      bool               `json:"stream,omitempty"`
-	Temperature *float32           `json:"temperature,omitempty"`
-	MaxTokens   *int32             `json:"max_tokens,omitempty"`
+	Messages       []azureChatMessage `json:"messages"`
+	Stream         bool               `json:"stream,omitempty"`
+	Temperature    *float32           `json:"temperature,omitempty"`
+	MaxTokens      *int32             `json:"max_tokens,omitempty"`
+	ResponseFormat interface{}        `json:"response_format,omitempty"`
 	// TODO: Add other parameters like top_p, stop, presence_penalty etc.
 }
 
@@ -112,6 +113,7 @@ type AzureOpenAIAdapter struct {
 	chatDeployment      string // Deployment name for chat models
 	embeddingDeployment string // Deployment name for embedding models
 	apiVersion          string
+	responseFormat      interface{} // Passed through verbatim as "response_format"; Azure OpenAI is the same wire API family as OpenAI
 }
 
 // AzureOpenAIAdapterOptions holds configuration options for the AzureOpenAIAdapter.
@@ -122,6 +124,7 @@ type AzureOpenAIAdapterOptions struct {
 	EmbeddingDeployment string       // Deployment name for embedding models
 	HTTPClient          *http.Client // Optional: Provide a custom client
 	APIVersion          string       // API version to use
+	ResponseFormat      interface{}  // Optional: passed through verbatim as the request body's "response_format" field
 }
 
 // NewAzureOpenAIAdapter creates a new adapter for Azure OpenAI using direct HTTP calls.
@@ -148,6 +151,7 @@ func NewAzureOpenAIAdapter(opts AzureOpenAIAdapterOptions) (*AzureOpenAIAdapter,
 		chatDeployment:      opts.ChatDeployment,
 		embeddingDeployment: opts.EmbeddingDeployment,
 		apiVersion:          opts.APIVersion,
+		responseFormat:      opts.ResponseFormat,
 	}, nil
 }
 
@@ -257,10 +261,11 @@ func (a *AzureOpenAIAdapter) Call(ctx context.Context, prompt Prompt) (Response,
 	}
 
 	apiReq := azureChatCompletionsRequest{
-		Messages:    mapInternalPrompt(prompt),
-		Stream:      false,
-		Temperature: prompt.Parameters.Temperature,
-		MaxTokens:   prompt.Parameters.MaxTokens,
+		Messages:       mapInternalPrompt(prompt),
+		Stream:         false,
+		Temperature:    prompt.Parameters.Temperature,
+		MaxTokens:      prompt.Parameters.MaxTokens,
+		ResponseFormat: a.responseFormat,
 	}
 
 	url := a.buildURL(a.chatDeployment, a.apiVersion, "chat/completions")
@@ -377,10 +382,11 @@ func (a *AzureOpenAIAdapter) Stream(ctx context.Context, prompt Prompt) (<-chan 
 	}
 
 	apiReq := azureChatCompletionsRequest{
-		Messages:    mapInternalPrompt(prompt),
-		Stream:      true, // Enable streaming
-		Temperature: prompt.Parameters.Temperature,
-		MaxTokens:   prompt.Parameters.MaxTokens,
+		Messages:       mapInternalPrompt(prompt),
+		Stream:         true, // Enable streaming
+		Temperature:    prompt.Parameters.Temperature,
+		MaxTokens:      prompt.Parameters.MaxTokens,
+		ResponseFormat: a.responseFormat,
 	}
 
 	url := a.buildURL(a.chatDeployment, a.apiVersion, "chat/completions")

--- a/internal/llm/azure_adapter.go
+++ b/internal/llm/azure_adapter.go
@@ -187,17 +187,25 @@ func (a *AzureOpenAIAdapter) doRequest(ctx context.Context, method, url string, 
 		return nil, fmt.Errorf("http request failed: %w", err)
 	}
 
-	// Check for non-success status codes
+	// Check for non-success status codes. Returned as *APIStatusError (the
+	// same type openai_adapter.go produces), not a plain fmt.Errorf, so
+	// CircuitBreakerProvider's DefaultIsRetryable (internal/llm/circuit_
+	// breaker_provider.go) can classify a 429/5xx gateway blip as retryable
+	// via errors.As instead of silently treating every Azure error as
+	// non-retryable — previously the exact transient-failure class MaxRetries
+	// exists to cover was skipped for this provider.
 	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
 		defer resp.Body.Close()
 		errorBodyBytes, _ := io.ReadAll(resp.Body)
 		apiError := azureErrorResponse{}
 		if json.Unmarshal(errorBodyBytes, &apiError) == nil && apiError.Error.Message != "" {
-			return nil, fmt.Errorf("api request failed: status %d, type %s, code %s, message: %s",
-				resp.StatusCode, apiError.Error.Type, apiError.Error.Code, apiError.Error.Message)
+			return nil, &APIStatusError{
+				StatusCode: resp.StatusCode,
+				Body: fmt.Sprintf("type %s, code %s, message: %s", apiError.Error.Type, apiError.Error.Code, apiError.Error.Message),
+			}
 		}
-		// Fallback error message
-		return nil, fmt.Errorf("api request failed: status %d, body: %s", resp.StatusCode, string(errorBodyBytes))
+		// Fallback: no parseable structured error body.
+		return nil, &APIStatusError{StatusCode: resp.StatusCode, Body: string(errorBodyBytes)}
 	}
 
 	return resp, nil

--- a/internal/llm/azure_openrouter_retry_test.go
+++ b/internal/llm/azure_openrouter_retry_test.go
@@ -1,0 +1,157 @@
+package llm
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// Regression coverage for PR #157 review's "Medium" item: Azure and
+// OpenRouter didn't actually benefit from the new MaxRetries/circuit-breaker
+// support because DefaultIsRetryable only recognizes *APIStatusError
+// (produced by the OpenAI-family adapters), while azure_adapter.go and
+// openrouter_adapter.go returned plain fmt.Errorf on non-2xx — silently
+// classifying a transient 429/503 from either provider as non-retryable.
+
+func TestAzureAdapter_Call_NonOKStatus_ReturnsAPIStatusError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		w.Write([]byte(`{"error":{"message":"backend overloaded","type":"server_error","code":"503"}}`))
+	}))
+	defer server.Close()
+
+	adapter, err := NewAzureOpenAIAdapter(AzureOpenAIAdapterOptions{
+		Endpoint:            server.URL,
+		APIKey:              "test-key",
+		ChatDeployment:      "test-chat",
+		EmbeddingDeployment: "test-embed",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error constructing adapter: %v", err)
+	}
+
+	_, callErr := adapter.Call(context.Background(), Prompt{User: "hello"})
+	if callErr == nil {
+		t.Fatal("expected an error from a 503 response, got nil")
+	}
+
+	var apiErr *APIStatusError
+	if !errors.As(callErr, &apiErr) {
+		t.Fatalf("expected *APIStatusError (so DefaultIsRetryable can classify it), got %T: %v", callErr, callErr)
+	}
+	if apiErr.StatusCode != http.StatusServiceUnavailable {
+		t.Fatalf("got status %d, want %d", apiErr.StatusCode, http.StatusServiceUnavailable)
+	}
+	if !DefaultIsRetryable(callErr) {
+		t.Fatal("a 503 from Azure must be classified retryable by DefaultIsRetryable")
+	}
+}
+
+func TestAzureAdapter_Call_AuthFailure_NotRetryable(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		w.Write([]byte(`{"error":{"message":"invalid api key","type":"invalid_request_error","code":"401"}}`))
+	}))
+	defer server.Close()
+
+	adapter, err := NewAzureOpenAIAdapter(AzureOpenAIAdapterOptions{
+		Endpoint:            server.URL,
+		APIKey:              "test-key",
+		ChatDeployment:      "test-chat",
+		EmbeddingDeployment: "test-embed",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error constructing adapter: %v", err)
+	}
+
+	_, callErr := adapter.Call(context.Background(), Prompt{User: "hello"})
+	if callErr == nil {
+		t.Fatal("expected an error from a 401 response, got nil")
+	}
+	if DefaultIsRetryable(callErr) {
+		t.Fatal("a 401 (bad credentials) must NOT be classified retryable")
+	}
+}
+
+func TestOpenRouterAdapter_Call_NonOKStatus_ReturnsAPIStatusError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusTooManyRequests)
+		w.Write([]byte(`{"error":{"message":"rate limited","code":"429","type":"rate_limit"}}`))
+	}))
+	defer server.Close()
+
+	adapter, err := NewOpenRouterAdapter("test-key", "test-model", server.URL, 0, 0, "", "")
+	if err != nil {
+		t.Fatalf("unexpected error constructing adapter: %v", err)
+	}
+
+	_, callErr := adapter.Call(context.Background(), Prompt{User: "hello"})
+	if callErr == nil {
+		t.Fatal("expected an error from a 429 response, got nil")
+	}
+
+	var apiErr *APIStatusError
+	if !errors.As(callErr, &apiErr) {
+		t.Fatalf("expected *APIStatusError (so DefaultIsRetryable can classify it), got %T: %v", callErr, callErr)
+	}
+	if apiErr.StatusCode != http.StatusTooManyRequests {
+		t.Fatalf("got status %d, want %d", apiErr.StatusCode, http.StatusTooManyRequests)
+	}
+	if !DefaultIsRetryable(callErr) {
+		t.Fatal("a 429 from OpenRouter must be classified retryable by DefaultIsRetryable")
+	}
+}
+
+// TestOpenRouterAdapter_Stream_NonOKStatus_BodyNotLostToEarlyClose is the
+// regression test for the actual bug: Stream previously called
+// resp.Body.Close() BEFORE io.ReadAll(resp.Body), so a non-200 stream error
+// always carried an empty body — this asserts the real error body text
+// (not just a non-nil error) survives into the returned error.
+func TestOpenRouterAdapter_Stream_NonOKStatus_BodyNotLostToEarlyClose(t *testing.T) {
+	const wantMessage = "context length exceeded for this model"
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(`{"error":{"message":"` + wantMessage + `","code":"400","type":"invalid_request_error"}}`))
+	}))
+	defer server.Close()
+
+	adapter, err := NewOpenRouterAdapter("test-key", "test-model", server.URL, 0, 0, "", "")
+	if err != nil {
+		t.Fatalf("unexpected error constructing adapter: %v", err)
+	}
+
+	_, streamErr := adapter.Stream(context.Background(), Prompt{User: "hello"})
+	if streamErr == nil {
+		t.Fatal("expected an error from a 400 response, got nil")
+	}
+
+	var apiErr *APIStatusError
+	if !errors.As(streamErr, &apiErr) {
+		t.Fatalf("expected *APIStatusError, got %T: %v", streamErr, streamErr)
+	}
+	if apiErr.StatusCode != http.StatusBadRequest {
+		t.Fatalf("got status %d, want %d", apiErr.StatusCode, http.StatusBadRequest)
+	}
+	if apiErr.Body == "" {
+		t.Fatal("APIStatusError.Body is empty — the body-read-after-close bug regressed")
+	}
+	if !contains(apiErr.Body, wantMessage) {
+		t.Fatalf("APIStatusError.Body = %q, want it to contain %q", apiErr.Body, wantMessage)
+	}
+	if DefaultIsRetryable(streamErr) {
+		t.Fatal("a 400 (bad request) must NOT be classified retryable")
+	}
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (func() bool {
+		for i := 0; i+len(substr) <= len(s); i++ {
+			if s[i:i+len(substr)] == substr {
+				return true
+			}
+		}
+		return false
+	})()
+}

--- a/internal/llm/bentoml_adapter.go
+++ b/internal/llm/bentoml_adapter.go
@@ -38,6 +38,14 @@ type BentoMLConfig struct {
 
 	// HTTP configuration
 	HTTPTimeout time.Duration `json:"http_timeout,omitempty" toml:"http_timeout"`
+
+	// ResponseFormat, when non-nil, is passed through verbatim as the
+	// request body's "response_format" field. BentoML's OpenAI-compatible
+	// endpoint reuses OpenAIAdapterConfig's field.
+	ResponseFormat interface{} `json:"response_format,omitempty" toml:"response_format,omitempty"`
+
+	// CachePrompt, when true, sets the request body's "cache_prompt" field.
+	CachePrompt bool `json:"cache_prompt,omitempty" toml:"cache_prompt,omitempty"`
 }
 
 // BentoMLAdapter wraps the OpenAI adapter for BentoML inference servers.
@@ -86,6 +94,8 @@ func NewBentoMLAdapter(config BentoMLConfig) (*BentoMLAdapter, error) {
 		PresencePenalty:  config.PresencePenalty,
 		FrequencyPenalty: config.FrequencyPenalty,
 		Stop:             config.Stop,
+		ResponseFormat:   config.ResponseFormat,
+		CachePrompt:      config.CachePrompt,
 	}
 
 	openaiAdapter, err := NewOpenAIAdapterWithConfig(openaiConfig)

--- a/internal/llm/bentoml_adapter.go
+++ b/internal/llm/bentoml_adapter.go
@@ -111,7 +111,18 @@ func NewBentoMLAdapter(config BentoMLConfig) (*BentoMLAdapter, error) {
 	}, nil
 }
 
-// Call delegates to the embedded OpenAI adapter with retry logic
+// Call delegates to the embedded OpenAI adapter with retry logic.
+//
+// Only retries errors DefaultIsRetryable classifies as transient (429/5xx,
+// timeouts, context deadline) — previously this retried unconditionally,
+// including a 4xx (bad request, auth failure) that retrying can never fix.
+// Also worth knowing when configuring MaxRetries here alongside
+// v1beta.LLMConfig.MaxRetries/CircuitBreaker: when both are set, this loop
+// runs INSIDE CircuitBreakerProvider's own retry loop (ProviderFactory.
+// CreateProvider wraps every provider type uniformly), so the effective
+// attempt count multiplies (outer attempts) × (this loop's attempts) rather
+// than adding. Set at most one of them for this provider to avoid surprising
+// retry counts under sustained failure.
 func (b *BentoMLAdapter) Call(ctx context.Context, prompt Prompt) (Response, error) {
 	var lastErr error
 	for attempt := 0; attempt < b.maxRetries; attempt++ {
@@ -128,6 +139,9 @@ func (b *BentoMLAdapter) Call(ctx context.Context, prompt Prompt) (Response, err
 			return resp, nil
 		}
 		lastErr = err
+		if !DefaultIsRetryable(err) {
+			break
+		}
 	}
 	return Response{}, fmt.Errorf("max retries exceeded: %w", lastErr)
 }

--- a/internal/llm/circuit_breaker_provider.go
+++ b/internal/llm/circuit_breaker_provider.go
@@ -38,10 +38,21 @@ type RetryPolicy struct {
 	BackoffFunc func(attempt int) time.Duration
 }
 
-// DefaultIsRetryable classifies context deadline/cancellation and net.Error
+// DefaultIsRetryable classifies context deadline/cancellation, net.Error
 // (including timeouts surfaced through wrapped chains, e.g. an http.Client
-// body-read timeout) as retryable. errors.Is/As based, not string-matched,
-// so it survives error-message wording changes upstream.
+// body-read timeout), and an *APIStatusError with a 429 or 5xx status as
+// retryable. errors.Is/As based, not string-matched, so it survives
+// error-message wording changes upstream.
+//
+// A completed HTTP round-trip carrying a gateway error (502/503/524, a
+// Cloudflare edge error like 530, or a 429 rate limit) is not a net.Error —
+// it's a successful response with a non-2xx status, surfaced by this
+// package's adapters as *APIStatusError (openai_adapter.go). Without this
+// case, MaxRetries would only cover network/timeout failures and silently
+// not retry the exact class of failure most likely to be transient: the
+// origin/gateway itself being briefly unavailable. 4xx other than 429 (bad
+// request, auth failure, not found) is not retryable — retrying won't fix a
+// malformed request or bad credentials.
 func DefaultIsRetryable(err error) bool {
 	if err == nil {
 		return false
@@ -50,7 +61,14 @@ func DefaultIsRetryable(err error) bool {
 		return true
 	}
 	var netErr net.Error
-	return errors.As(err, &netErr)
+	if errors.As(err, &netErr) {
+		return true
+	}
+	var apiErr *APIStatusError
+	if errors.As(err, &apiErr) {
+		return apiErr.StatusCode == 429 || apiErr.StatusCode >= 500
+	}
+	return false
 }
 
 func defaultBackoff(attempt int) time.Duration {

--- a/internal/llm/circuit_breaker_provider.go
+++ b/internal/llm/circuit_breaker_provider.go
@@ -1,0 +1,166 @@
+package llm
+
+import (
+	"context"
+	"errors"
+	"net"
+	"time"
+)
+
+// CircuitBreaker is the minimal circuit-breaking seam CircuitBreakerProvider
+// needs. Satisfied structurally by
+// internal/core/error_handling.CircuitBreakerImplementation without this
+// package importing it: internal/core/error_handling imports core, and core
+// imports internal/llm (core/llm.go), so internal/llm -> internal/core/error_handling
+// would close an import cycle. Callers that CAN safely import both (e.g.
+// v1beta/provider_factory.go, which is downstream of both) construct the
+// concrete breaker and pass it in through ProviderConfig.CircuitBreaker.
+type CircuitBreaker interface {
+	Call(fn func() error) error
+}
+
+// RetryPolicy configures the retry loop CircuitBreakerProvider wraps around
+// a ModelProvider call.
+type RetryPolicy struct {
+	// MaxRetries is the number of retry attempts after the first try. Zero
+	// means no retries (the call still runs once).
+	MaxRetries int
+
+	// IsRetryable classifies whether err should trigger a retry. Defaults to
+	// DefaultIsRetryable when nil. Deliberately NOT the exact-string-match
+	// classification core.RetryPolicy.RetryableErrors/
+	// error_handling.RetrierImplementation.isRetryableError use — that
+	// approach breaks silently when an error's message wording changes.
+	IsRetryable func(err error) bool
+
+	// BackoffFunc computes the delay before attempt N (1-based). Defaults to
+	// exponential backoff with a 10s cap when nil.
+	BackoffFunc func(attempt int) time.Duration
+}
+
+// DefaultIsRetryable classifies context deadline/cancellation and net.Error
+// (including timeouts surfaced through wrapped chains, e.g. an http.Client
+// body-read timeout) as retryable. errors.Is/As based, not string-matched,
+// so it survives error-message wording changes upstream.
+func DefaultIsRetryable(err error) bool {
+	if err == nil {
+		return false
+	}
+	if errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled) {
+		return true
+	}
+	var netErr net.Error
+	return errors.As(err, &netErr)
+}
+
+func defaultBackoff(attempt int) time.Duration {
+	const base = 100 * time.Millisecond
+	const max = 10 * time.Second
+	if attempt <= 0 {
+		return base
+	}
+	d := base * time.Duration(uint(1)<<uint(attempt-1))
+	if d > max || d <= 0 {
+		d = max
+	}
+	return d
+}
+
+// CircuitBreakerProviderConfig configures CircuitBreakerProvider.
+type CircuitBreakerProviderConfig struct {
+	// Breaker, when non-nil, gates every call through Breaker.Call(fn) —
+	// an open circuit short-circuits immediately without touching the inner
+	// provider or sleeping through a retry loop. Nil disables
+	// circuit-breaking (retry-only behavior).
+	Breaker CircuitBreaker
+	Retry   RetryPolicy
+}
+
+// CircuitBreakerProvider decorates any ModelProvider with circuit-breaking
+// and retry, without the wrapped adapter knowing about either. It satisfies
+// ModelProvider itself, so every existing adapter (OpenAI, Anthropic, Azure,
+// Ollama, OpenRouter, HuggingFace, vLLM, FoundryLocal, BentoML, MLFlow) gets
+// this by having its constructor's return value wrapped once, centrally, in
+// ProviderFactory.CreateProvider — no per-adapter changes.
+type CircuitBreakerProvider struct {
+	inner  ModelProvider
+	config CircuitBreakerProviderConfig
+}
+
+// NewCircuitBreakerProvider wraps inner with circuit-breaking/retry per
+// config. Safe to call with a zero-value config.Retry (defaults apply) and a
+// nil config.Breaker (retry-only, no circuit-breaking).
+func NewCircuitBreakerProvider(inner ModelProvider, config CircuitBreakerProviderConfig) *CircuitBreakerProvider {
+	if config.Retry.IsRetryable == nil {
+		config.Retry.IsRetryable = DefaultIsRetryable
+	}
+	if config.Retry.BackoffFunc == nil {
+		config.Retry.BackoffFunc = defaultBackoff
+	}
+	return &CircuitBreakerProvider{inner: inner, config: config}
+}
+
+// call runs fn through the circuit breaker (if configured), then retries
+// per the retry policy, honoring ctx cancellation between attempts.
+func (p *CircuitBreakerProvider) call(ctx context.Context, fn func() error) error {
+	protected := fn
+	if p.config.Breaker != nil {
+		protected = func() error { return p.config.Breaker.Call(fn) }
+	}
+
+	var lastErr error
+	for attempt := 0; attempt <= p.config.Retry.MaxRetries; attempt++ {
+		lastErr = protected()
+		if lastErr == nil {
+			return nil
+		}
+		if !p.config.Retry.IsRetryable(lastErr) {
+			return lastErr
+		}
+		if attempt < p.config.Retry.MaxRetries {
+			select {
+			case <-ctx.Done():
+				return ctx.Err()
+			case <-time.After(p.config.Retry.BackoffFunc(attempt + 1)):
+			}
+		}
+	}
+	return lastErr
+}
+
+// Call implements ModelProvider.
+func (p *CircuitBreakerProvider) Call(ctx context.Context, prompt Prompt) (Response, error) {
+	var resp Response
+	err := p.call(ctx, func() error {
+		var callErr error
+		resp, callErr = p.inner.Call(ctx, prompt)
+		return callErr
+	})
+	return resp, err
+}
+
+// Stream implements ModelProvider. Only the connection-setup call
+// (inner.Stream returning before any token is delivered) is retried. Once a
+// channel is returned, tokens flow through unmodified: retrying mid-stream
+// would require buffering everything already sent to the caller and risks
+// double-emitting content already delivered.
+func (p *CircuitBreakerProvider) Stream(ctx context.Context, prompt Prompt) (<-chan Token, error) {
+	var out <-chan Token
+	err := p.call(ctx, func() error {
+		var streamErr error
+		out, streamErr = p.inner.Stream(ctx, prompt)
+		return streamErr
+	})
+	return out, err
+}
+
+// Embeddings implements ModelProvider.
+func (p *CircuitBreakerProvider) Embeddings(ctx context.Context, texts []string) ([][]float64, error) {
+	var embeddings [][]float64
+	err := p.call(ctx, func() error {
+		var callErr error
+		embeddings, callErr = p.inner.Embeddings(ctx, texts)
+		return callErr
+	})
+	return embeddings, err
+}

--- a/internal/llm/circuit_breaker_provider_test.go
+++ b/internal/llm/circuit_breaker_provider_test.go
@@ -1,0 +1,233 @@
+package llm
+
+import (
+	"context"
+	"errors"
+	"net"
+	"testing"
+	"time"
+)
+
+// fakeBreaker is a minimal CircuitBreaker test double that counts calls and
+// can be forced open.
+type fakeBreaker struct {
+	open  bool
+	calls int
+}
+
+func (b *fakeBreaker) Call(fn func() error) error {
+	b.calls++
+	if b.open {
+		return errors.New("circuit breaker is open")
+	}
+	return fn()
+}
+
+func noBackoff(int) time.Duration { return 0 }
+
+func TestCircuitBreakerProvider_CallSucceedsWithoutRetry(t *testing.T) {
+	inner := NewMockModelProvider()
+	inner.SetCallExpectation(Response{Content: "ok"}, nil)
+
+	p := NewCircuitBreakerProvider(inner, CircuitBreakerProviderConfig{
+		Retry: RetryPolicy{MaxRetries: 3, BackoffFunc: noBackoff},
+	})
+
+	resp, err := p.Call(context.Background(), Prompt{User: "hi"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Content != "ok" {
+		t.Fatalf("got %q, want %q", resp.Content, "ok")
+	}
+}
+
+func TestCircuitBreakerProvider_CallRetriesTransientThenSucceeds(t *testing.T) {
+	inner := NewMockModelProvider()
+	attempts := 0
+	inner.SetCallFunc(func(ctx context.Context, prompt Prompt) (Response, error) {
+		attempts++
+		if attempts < 3 {
+			return Response{}, context.DeadlineExceeded
+		}
+		return Response{Content: "recovered"}, nil
+	})
+
+	p := NewCircuitBreakerProvider(inner, CircuitBreakerProviderConfig{
+		Retry: RetryPolicy{MaxRetries: 3, BackoffFunc: noBackoff},
+	})
+
+	resp, err := p.Call(context.Background(), Prompt{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.Content != "recovered" {
+		t.Fatalf("got %q, want %q", resp.Content, "recovered")
+	}
+	if attempts != 3 {
+		t.Fatalf("got %d attempts, want 3", attempts)
+	}
+}
+
+func TestCircuitBreakerProvider_CallDoesNotRetryNonRetryableError(t *testing.T) {
+	inner := NewMockModelProvider()
+	attempts := 0
+	wantErr := errors.New("invalid api key")
+	inner.SetCallFunc(func(ctx context.Context, prompt Prompt) (Response, error) {
+		attempts++
+		return Response{}, wantErr
+	})
+
+	p := NewCircuitBreakerProvider(inner, CircuitBreakerProviderConfig{
+		Retry: RetryPolicy{MaxRetries: 3, BackoffFunc: noBackoff},
+	})
+
+	_, err := p.Call(context.Background(), Prompt{})
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("got err %v, want %v", err, wantErr)
+	}
+	if attempts != 1 {
+		t.Fatalf("got %d attempts, want 1 (non-retryable error must not retry)", attempts)
+	}
+}
+
+func TestCircuitBreakerProvider_CallExhaustsRetriesAndReturnsLastError(t *testing.T) {
+	inner := NewMockModelProvider()
+	attempts := 0
+	inner.SetCallFunc(func(ctx context.Context, prompt Prompt) (Response, error) {
+		attempts++
+		return Response{}, context.DeadlineExceeded
+	})
+
+	p := NewCircuitBreakerProvider(inner, CircuitBreakerProviderConfig{
+		Retry: RetryPolicy{MaxRetries: 2, BackoffFunc: noBackoff},
+	})
+
+	_, err := p.Call(context.Background(), Prompt{})
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("got err %v, want context.DeadlineExceeded", err)
+	}
+	if attempts != 3 { // initial attempt + 2 retries
+		t.Fatalf("got %d attempts, want 3", attempts)
+	}
+}
+
+func TestCircuitBreakerProvider_OpenBreakerShortCircuitsWithoutCallingInner(t *testing.T) {
+	inner := NewMockModelProvider()
+	inner.SetCallFunc(func(ctx context.Context, prompt Prompt) (Response, error) {
+		t.Fatal("inner provider must not be called while breaker is open")
+		return Response{}, nil
+	})
+
+	breaker := &fakeBreaker{open: true}
+	p := NewCircuitBreakerProvider(inner, CircuitBreakerProviderConfig{
+		Breaker: breaker,
+		Retry:   RetryPolicy{MaxRetries: 2, BackoffFunc: noBackoff, IsRetryable: func(error) bool { return false }},
+	})
+
+	_, err := p.Call(context.Background(), Prompt{})
+	if err == nil {
+		t.Fatal("expected error from open breaker, got nil")
+	}
+	if breaker.calls != 1 {
+		t.Fatalf("got %d breaker calls, want 1", breaker.calls)
+	}
+}
+
+func TestCircuitBreakerProvider_StreamRetriesConnectionSetupOnly(t *testing.T) {
+	inner := NewMockModelProvider()
+	attempts := 0
+	wantChan := make(chan Token, 1)
+	wantChan <- Token{Content: "tok"}
+	close(wantChan)
+
+	inner.SetStreamFunc(func(ctx context.Context, prompt Prompt) (<-chan Token, error) {
+		attempts++
+		if attempts < 2 {
+			return nil, context.DeadlineExceeded
+		}
+		return wantChan, nil
+	})
+
+	p := NewCircuitBreakerProvider(inner, CircuitBreakerProviderConfig{
+		Retry: RetryPolicy{MaxRetries: 2, BackoffFunc: noBackoff},
+	})
+
+	out, err := p.Stream(context.Background(), Prompt{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if attempts != 2 {
+		t.Fatalf("got %d attempts, want 2", attempts)
+	}
+	tok, ok := <-out
+	if !ok || tok.Content != "tok" {
+		t.Fatalf("got token %+v ok=%v, want Content=%q ok=true", tok, ok, "tok")
+	}
+}
+
+func TestCircuitBreakerProvider_ContextCancelledDuringBackoffAbortsRetry(t *testing.T) {
+	inner := NewMockModelProvider()
+	attempts := 0
+	inner.SetCallFunc(func(ctx context.Context, prompt Prompt) (Response, error) {
+		attempts++
+		return Response{}, context.DeadlineExceeded
+	})
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // already cancelled before the first backoff sleep
+
+	p := NewCircuitBreakerProvider(inner, CircuitBreakerProviderConfig{
+		Retry: RetryPolicy{MaxRetries: 5, BackoffFunc: func(int) time.Duration { return time.Hour }},
+	})
+
+	_, err := p.Call(ctx, Prompt{})
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("got err %v, want context.Canceled", err)
+	}
+	if attempts != 1 {
+		t.Fatalf("got %d attempts, want 1 (must abort at first backoff, not hang an hour)", attempts)
+	}
+}
+
+func TestDefaultIsRetryable(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"nil", nil, false},
+		{"deadline exceeded", context.DeadlineExceeded, true},
+		{"context canceled", context.Canceled, true},
+		{"net timeout", &net.DNSError{IsTimeout: true}, true},
+		{"generic error", errors.New("boom"), false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := DefaultIsRetryable(tc.err); got != tc.want {
+				t.Errorf("DefaultIsRetryable(%v) = %v, want %v", tc.err, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestProviderFactory_CreateProvider_WrapsWithCircuitBreakerOnlyWhenConfigured(t *testing.T) {
+	// Zero-value CircuitBreaker/RetryPolicy fields (every existing caller,
+	// today) must not change the returned provider's type — no wrap.
+	f := NewProviderFactory()
+	p, err := f.CreateProvider(ProviderConfig{Type: ProviderTypeMock})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, wrapped := p.(*CircuitBreakerProvider); wrapped {
+		t.Fatal("provider should not be wrapped when CircuitBreaker/RetryPolicy are unset")
+	}
+
+	p2, err := f.CreateProvider(ProviderConfig{Type: ProviderTypeMock, RetryPolicy: &RetryPolicy{MaxRetries: 1}})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, wrapped := p2.(*CircuitBreakerProvider); !wrapped {
+		t.Fatal("provider should be wrapped when RetryPolicy is set")
+	}
+}

--- a/internal/llm/circuit_breaker_provider_test.go
+++ b/internal/llm/circuit_breaker_provider_test.go
@@ -3,7 +3,10 @@ package llm
 import (
 	"context"
 	"errors"
+	"fmt"
 	"net"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 )
@@ -201,6 +204,15 @@ func TestDefaultIsRetryable(t *testing.T) {
 		{"context canceled", context.Canceled, true},
 		{"net timeout", &net.DNSError{IsTimeout: true}, true},
 		{"generic error", errors.New("boom"), false},
+		{"api status 530 (Cloudflare origin unreachable)", &APIStatusError{StatusCode: 530}, true},
+		{"api status 502", &APIStatusError{StatusCode: 502}, true},
+		{"api status 503", &APIStatusError{StatusCode: 503}, true},
+		{"api status 429 (rate limited)", &APIStatusError{StatusCode: 429}, true},
+		{"api status 500", &APIStatusError{StatusCode: 500}, true},
+		{"api status 401 (auth failure)", &APIStatusError{StatusCode: 401}, false},
+		{"api status 400 (bad request)", &APIStatusError{StatusCode: 400}, false},
+		{"api status 404", &APIStatusError{StatusCode: 404}, false},
+		{"wrapped api status 503", fmt.Errorf("call failed: %w", &APIStatusError{StatusCode: 503}), true},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -229,5 +241,50 @@ func TestProviderFactory_CreateProvider_WrapsWithCircuitBreakerOnlyWhenConfigure
 	}
 	if _, wrapped := p2.(*CircuitBreakerProvider); !wrapped {
 		t.Fatal("provider should be wrapped when RetryPolicy is set")
+	}
+}
+
+// TestCircuitBreakerProvider_RetriesRealAdapterGatewayError is an
+// end-to-end regression test for the exact failure class this fix targets:
+// a real OpenAI-compatible adapter hitting a gateway error (modeled here as
+// 530, a Cloudflare origin-unreachable status observed live against a real
+// endpoint) must be retried by CircuitBreakerProvider, not just by the
+// isolated DefaultIsRetryable table test above.
+func TestCircuitBreakerProvider_RetriesRealAdapterGatewayError(t *testing.T) {
+	attempts := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		attempts++
+		if attempts < 3 {
+			w.WriteHeader(530)
+			w.Write([]byte("error code: 1033"))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"choices":[{"message":{"content":"OK"},"finish_reason":"stop"}]}`))
+	}))
+	defer server.Close()
+
+	adapter, err := NewOpenAIAdapterWithConfig(OpenAIAdapterConfig{
+		APIKey:  "test-key",
+		Model:   "test-model",
+		BaseURL: server.URL,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error building adapter: %v", err)
+	}
+
+	p := NewCircuitBreakerProvider(adapter, CircuitBreakerProviderConfig{
+		Retry: RetryPolicy{MaxRetries: 3, BackoffFunc: noBackoff},
+	})
+
+	resp, err := p.Call(context.Background(), Prompt{User: "hello"})
+	if err != nil {
+		t.Fatalf("expected the 530s to be retried and the 3rd attempt to succeed, got: %v", err)
+	}
+	if attempts != 3 {
+		t.Fatalf("got %d attempts, want 3 (2 retried 530s + 1 success)", attempts)
+	}
+	if resp.Content != "OK" {
+		t.Fatalf("got content %q, want %q", resp.Content, "OK")
 	}
 }

--- a/internal/llm/factory.go
+++ b/internal/llm/factory.go
@@ -36,15 +36,14 @@ type ProviderConfig struct {
 
 	// ResponseFormat, when non-nil, is passed through to the OpenAI-compatible
 	// adapter's "response_format" request field (e.g. {"type":"json_object"}).
-	// Verified live 2026-07-10 against Cerebras/gpt-oss-120b: honored, clean
-	// JSON content with no markdown fencing.
+	// Verified live 2026-07-10 against a real OpenAI-compatible endpoint:
+	// honored cleanly, valid JSON content with no markdown fencing.
 	ResponseFormat interface{} `json:"response_format,omitempty" toml:"response_format,omitempty"`
 
 	// CachePrompt, when true, sets the OpenAI-compatible adapter's
 	// "cache_prompt" request field — llama.cpp's server flag to reuse a
 	// matching KV-cache prefix instead of re-prefilling it. Not yet verified
-	// live (no reachable llama.cpp endpoint at the time this was added —
-	// see cubejs-agentic-chat's ADR on this).
+	// live (no reachable llama.cpp endpoint at the time this was added).
 	CachePrompt bool `json:"cache_prompt,omitempty" toml:"cache_prompt,omitempty"`
 
 	// Azure-specific fields
@@ -115,6 +114,19 @@ type ProviderConfig struct {
 
 	// HTTP client configuration
 	HTTPTimeout time.Duration `json:"http_timeout,omitempty" toml:"http_timeout,omitempty"`
+
+	// CircuitBreaker, when non-nil, gates every provider call (Call/Stream
+	// connection-setup/Embeddings) through it. Not TOML/JSON-serializable by
+	// design — construct the concrete breaker in the caller (see
+	// v1beta/provider_factory.go) and set it here; nil disables
+	// circuit-breaking entirely (zero behavior change for existing callers).
+	CircuitBreaker CircuitBreaker `json:"-" toml:"-"`
+
+	// RetryPolicy, when non-nil, wraps every provider call with retry logic.
+	// nil (the zero value) disables retry — zero behavior change for
+	// existing callers, matching every other adapter's current "no retry"
+	// behavior.
+	RetryPolicy *RetryPolicy `json:"-" toml:"-"`
 }
 
 // ProviderFactory creates LLM providers based on configuration
@@ -147,32 +159,53 @@ func (f *ProviderFactory) CreateProvider(config ProviderConfig) (ModelProvider, 
 		f.httpClient = NewOptimizedHTTPClient(config.HTTPTimeout)
 	}
 
+	var provider ModelProvider
+	var err error
+
 	switch config.Type {
 	case ProviderTypeOpenAI:
-		return f.createOpenAIProvider(config)
+		provider, err = f.createOpenAIProvider(config)
 	case ProviderTypeAzureOpenAI:
-		return f.createAzureProvider(config)
+		provider, err = f.createAzureProvider(config)
 	case ProviderTypeOllama:
-		return f.createOllamaProvider(config)
+		provider, err = f.createOllamaProvider(config)
 	case ProviderTypeOpenRouter:
-		return f.createOpenRouterProvider(config)
+		provider, err = f.createOpenRouterProvider(config)
 	case ProviderTypeHuggingFace:
-		return f.createHuggingFaceProvider(config)
+		provider, err = f.createHuggingFaceProvider(config)
 	case ProviderTypeVLLM:
-		return f.createVLLMProvider(config)
+		provider, err = f.createVLLMProvider(config)
 	case ProviderTypeMLFlowGateway:
-		return f.createMLFlowGatewayProvider(config)
+		provider, err = f.createMLFlowGatewayProvider(config)
 	case ProviderTypeBentoML:
-		return f.createBentoMLProvider(config)
+		provider, err = f.createBentoMLProvider(config)
 	case ProviderTypeAnthropic:
-		return f.createAnthropicProvider(config)
+		provider, err = f.createAnthropicProvider(config)
 	case ProviderTypeFoundryLocal:
-		return f.createFoundryLocalProvider(config)
+		provider, err = f.createFoundryLocalProvider(config)
 	case ProviderTypeMock:
-		return f.createMockProvider(config)
+		provider, err = f.createMockProvider(config)
 	default:
 		return nil, fmt.Errorf("unsupported provider type: %s", config.Type)
 	}
+	if err != nil {
+		return nil, err
+	}
+
+	// Wrap uniformly for every provider type above — circuit-breaking/retry
+	// is a cross-cutting concern, not a per-adapter one. Opt-in: a config
+	// with both fields nil (every existing caller, today) wraps into a
+	// CircuitBreakerProvider whose call() loop degenerates to exactly one
+	// attempt with no breaker check, i.e. behaviorally identical to
+	// returning provider directly.
+	if config.CircuitBreaker != nil || config.RetryPolicy != nil {
+		cbConfig := CircuitBreakerProviderConfig{Breaker: config.CircuitBreaker}
+		if config.RetryPolicy != nil {
+			cbConfig.Retry = *config.RetryPolicy
+		}
+		return NewCircuitBreakerProvider(provider, cbConfig), nil
+	}
+	return provider, nil
 }
 
 // createOpenAIProvider creates an OpenAI provider

--- a/internal/llm/factory.go
+++ b/internal/llm/factory.go
@@ -40,6 +40,13 @@ type ProviderConfig struct {
 	// JSON content with no markdown fencing.
 	ResponseFormat interface{} `json:"response_format,omitempty" toml:"response_format,omitempty"`
 
+	// CachePrompt, when true, sets the OpenAI-compatible adapter's
+	// "cache_prompt" request field — llama.cpp's server flag to reuse a
+	// matching KV-cache prefix instead of re-prefilling it. Not yet verified
+	// live (no reachable llama.cpp endpoint at the time this was added —
+	// see cubejs-agentic-chat's ADR on this).
+	CachePrompt bool `json:"cache_prompt,omitempty" toml:"cache_prompt,omitempty"`
+
 	// Azure-specific fields
 	Endpoint            string `json:"endpoint,omitempty" toml:"endpoint,omitempty"`
 	ChatDeployment      string `json:"chat_deployment,omitempty" toml:"chat_deployment,omitempty"`
@@ -189,6 +196,7 @@ func (f *ProviderFactory) createOpenAIProvider(config ProviderConfig) (ModelProv
 		BaseURL:        config.BaseURL,
 		HTTPTimeout:    config.HTTPTimeout,
 		ResponseFormat: config.ResponseFormat,
+		CachePrompt:    config.CachePrompt,
 	}
 
 	return NewOpenAIAdapterWithConfig(adapterConfig)

--- a/internal/llm/factory.go
+++ b/internal/llm/factory.go
@@ -268,6 +268,7 @@ func (f *ProviderFactory) createAzureProvider(config ProviderConfig) (ModelProvi
 		EmbeddingDeployment: config.EmbeddingDeployment,
 		HTTPClient:          f.httpClient,
 		APIVersion:          config.APIVersion,
+		ResponseFormat:      config.ResponseFormat,
 	}
 
 	return NewAzureOpenAIAdapter(options)
@@ -307,7 +308,7 @@ func (f *ProviderFactory) createOpenRouterProvider(config ProviderConfig) (Model
 		model = "openai/gpt-3.5-turbo" // Default model
 	}
 
-	return NewOpenRouterAdapter(
+	adapter, err := NewOpenRouterAdapter(
 		config.APIKey,
 		model,
 		baseURL,
@@ -316,6 +317,12 @@ func (f *ProviderFactory) createOpenRouterProvider(config ProviderConfig) (Model
 		config.SiteURL,
 		config.SiteName,
 	)
+	if err != nil {
+		return nil, err
+	}
+	adapter.responseFormat = config.ResponseFormat
+	adapter.cachePrompt = config.CachePrompt
+	return adapter, nil
 }
 
 // createHuggingFaceProvider creates a Hugging Face provider
@@ -398,6 +405,8 @@ func (f *ProviderFactory) createVLLMProvider(config ProviderConfig) (ModelProvid
 		IgnoreEOS:         config.VLLMIgnoreEOS,
 		Stop:              config.VLLMStop,
 		HTTPTimeout:       config.HTTPTimeout,
+		ResponseFormat:    config.ResponseFormat,
+		CachePrompt:       config.CachePrompt,
 	}
 
 	return NewVLLMAdapter(vllmConfig)
@@ -429,6 +438,8 @@ func (f *ProviderFactory) createMLFlowGatewayProvider(config ProviderConfig) (Mo
 		MaxRetries:       config.MLFlowMaxRetries,
 		RetryDelay:       config.MLFlowRetryDelay,
 		HTTPTimeout:      config.HTTPTimeout,
+		ResponseFormat:   config.ResponseFormat,
+		CachePrompt:      config.CachePrompt,
 	}
 
 	return NewMLFlowGatewayAdapter(mlflowConfig)
@@ -462,6 +473,8 @@ func (f *ProviderFactory) createBentoMLProvider(config ProviderConfig) (ModelPro
 		MaxRetries:       config.BentoMLMaxRetries,
 		RetryDelay:       config.BentoMLRetryDelay,
 		HTTPTimeout:      config.HTTPTimeout,
+		ResponseFormat:   config.ResponseFormat,
+		CachePrompt:      config.CachePrompt,
 	}
 
 	return NewBentoMLAdapter(bentomlConfig)

--- a/internal/llm/factory.go
+++ b/internal/llm/factory.go
@@ -34,6 +34,12 @@ type ProviderConfig struct {
 	MaxTokens   int          `json:"max_tokens,omitempty" toml:"max_tokens,omitempty"`
 	Temperature float32      `json:"temperature,omitempty" toml:"temperature,omitempty"`
 
+	// ResponseFormat, when non-nil, is passed through to the OpenAI-compatible
+	// adapter's "response_format" request field (e.g. {"type":"json_object"}).
+	// Verified live 2026-07-10 against Cerebras/gpt-oss-120b: honored, clean
+	// JSON content with no markdown fencing.
+	ResponseFormat interface{} `json:"response_format,omitempty" toml:"response_format,omitempty"`
+
 	// Azure-specific fields
 	Endpoint            string `json:"endpoint,omitempty" toml:"endpoint,omitempty"`
 	ChatDeployment      string `json:"chat_deployment,omitempty" toml:"chat_deployment,omitempty"`
@@ -176,12 +182,13 @@ func (f *ProviderFactory) createOpenAIProvider(config ProviderConfig) (ModelProv
 
 	// Use NewOpenAIAdapterWithConfig to support BaseURL and other options
 	adapterConfig := OpenAIAdapterConfig{
-		APIKey:      config.APIKey,
-		Model:       config.Model,
-		MaxTokens:   config.MaxTokens,
-		Temperature: config.Temperature,
-		BaseURL:     config.BaseURL,
-		HTTPTimeout: config.HTTPTimeout,
+		APIKey:         config.APIKey,
+		Model:          config.Model,
+		MaxTokens:      config.MaxTokens,
+		Temperature:    config.Temperature,
+		BaseURL:        config.BaseURL,
+		HTTPTimeout:    config.HTTPTimeout,
+		ResponseFormat: config.ResponseFormat,
 	}
 
 	return NewOpenAIAdapterWithConfig(adapterConfig)

--- a/internal/llm/mlflow_adapter.go
+++ b/internal/llm/mlflow_adapter.go
@@ -40,6 +40,14 @@ type MLFlowGatewayConfig struct {
 
 	// HTTP configuration
 	HTTPTimeout time.Duration `json:"http_timeout,omitempty" toml:"http_timeout"`
+
+	// ResponseFormat, when non-nil, is passed through verbatim as the
+	// request body's "response_format" field. MLFlow Gateway routes are
+	// OpenAI-compatible, so this reuses OpenAIAdapterConfig's field.
+	ResponseFormat interface{} `json:"response_format,omitempty" toml:"response_format,omitempty"`
+
+	// CachePrompt, when true, sets the request body's "cache_prompt" field.
+	CachePrompt bool `json:"cache_prompt,omitempty" toml:"cache_prompt,omitempty"`
 }
 
 // MLFlowGatewayAdapter wraps the OpenAI adapter for MLFlow AI Gateway.
@@ -90,10 +98,12 @@ func NewMLFlowGatewayAdapter(config MLFlowGatewayConfig) (*MLFlowGatewayAdapter,
 		MaxTokens:    config.MaxTokens,
 		Temperature:  config.Temperature,
 		BaseURL:      baseURL,
-		ExtraHeaders: config.ExtraHeaders,
-		HTTPTimeout:  config.HTTPTimeout,
-		TopP:         config.TopP,
-		Stop:         config.Stop,
+		ExtraHeaders:   config.ExtraHeaders,
+		HTTPTimeout:    config.HTTPTimeout,
+		TopP:           config.TopP,
+		Stop:           config.Stop,
+		ResponseFormat: config.ResponseFormat,
+		CachePrompt:    config.CachePrompt,
 	}
 
 	openaiAdapter, err := NewOpenAIAdapterWithConfig(openaiConfig)

--- a/internal/llm/mlflow_adapter.go
+++ b/internal/llm/mlflow_adapter.go
@@ -119,7 +119,18 @@ func NewMLFlowGatewayAdapter(config MLFlowGatewayConfig) (*MLFlowGatewayAdapter,
 	}, nil
 }
 
-// Call delegates to the embedded OpenAI adapter with retry logic
+// Call delegates to the embedded OpenAI adapter with retry logic.
+//
+// Only retries errors DefaultIsRetryable classifies as transient (429/5xx,
+// timeouts, context deadline) — previously this retried unconditionally,
+// including a 4xx (bad request, auth failure) that retrying can never fix.
+// Also worth knowing when configuring MaxRetries here alongside
+// v1beta.LLMConfig.MaxRetries/CircuitBreaker: when both are set, this loop
+// runs INSIDE CircuitBreakerProvider's own retry loop (ProviderFactory.
+// CreateProvider wraps every provider type uniformly), so the effective
+// attempt count multiplies (outer attempts) × (this loop's attempts) rather
+// than adding. Set at most one of them for this provider to avoid surprising
+// retry counts under sustained failure.
 func (m *MLFlowGatewayAdapter) Call(ctx context.Context, prompt Prompt) (Response, error) {
 	var lastErr error
 	for attempt := 0; attempt < m.maxRetries; attempt++ {
@@ -136,7 +147,9 @@ func (m *MLFlowGatewayAdapter) Call(ctx context.Context, prompt Prompt) (Respons
 			return resp, nil
 		}
 		lastErr = err
-		// Continue retrying on error
+		if !DefaultIsRetryable(err) {
+			break
+		}
 	}
 	return Response{}, fmt.Errorf("max retries exceeded: %w", lastErr)
 }

--- a/internal/llm/mlflow_bentoml_retry_test.go
+++ b/internal/llm/mlflow_bentoml_retry_test.go
@@ -1,0 +1,143 @@
+package llm
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// Regression coverage for PR #157 review's nit: MLFlow/BentoML adapters had
+// their own internal retry loop that retried unconditionally, including a
+// 4xx (bad request/auth failure) that retrying can never fix. Both loops now
+// stop after the first non-retryable error, same classification as
+// DefaultIsRetryable/CircuitBreakerProvider.
+
+func TestMLFlowGatewayAdapter_Call_DoesNotRetryNonRetryableStatus(t *testing.T) {
+	var requests int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		w.WriteHeader(http.StatusBadRequest)
+		w.Write([]byte(`{"error":{"message":"bad request","type":"invalid_request_error"}}`))
+	}))
+	defer server.Close()
+
+	adapter, err := NewMLFlowGatewayAdapter(MLFlowGatewayConfig{
+		BaseURL:    server.URL,
+		ChatRoute:  "test-route",
+		MaxRetries: 3,
+		RetryDelay: time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error constructing adapter: %v", err)
+	}
+
+	_, callErr := adapter.Call(context.Background(), Prompt{User: "hello"})
+	if callErr == nil {
+		t.Fatal("expected an error from a 400 response, got nil")
+	}
+	if requests != 1 {
+		t.Fatalf("got %d requests, want 1 (a 400 must not be retried)", requests)
+	}
+}
+
+func TestMLFlowGatewayAdapter_Call_RetriesRetryableStatus(t *testing.T) {
+	var requests int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		if requests < 3 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			w.Write([]byte(`{"error":{"message":"unavailable"}}`))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"choices":[{"message":{"content":"ok"},"finish_reason":"stop"}]}`))
+	}))
+	defer server.Close()
+
+	adapter, err := NewMLFlowGatewayAdapter(MLFlowGatewayConfig{
+		BaseURL:    server.URL,
+		ChatRoute:  "test-route",
+		MaxRetries: 3,
+		RetryDelay: time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error constructing adapter: %v", err)
+	}
+
+	resp, callErr := adapter.Call(context.Background(), Prompt{User: "hello"})
+	if callErr != nil {
+		t.Fatalf("expected eventual success after retries, got error: %v", callErr)
+	}
+	if resp.Content != "ok" {
+		t.Fatalf("got content %q, want %q", resp.Content, "ok")
+	}
+	if requests != 3 {
+		t.Fatalf("got %d requests, want 3 (2 retryable failures + 1 success)", requests)
+	}
+}
+
+func TestBentoMLAdapter_Call_DoesNotRetryNonRetryableStatus(t *testing.T) {
+	var requests int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		w.WriteHeader(http.StatusUnauthorized)
+		w.Write([]byte(`{"error":{"message":"invalid api key","type":"invalid_request_error"}}`))
+	}))
+	defer server.Close()
+
+	adapter, err := NewBentoMLAdapter(BentoMLConfig{
+		BaseURL:    server.URL,
+		Model:      "test-model",
+		MaxRetries: 3,
+		RetryDelay: time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error constructing adapter: %v", err)
+	}
+
+	_, callErr := adapter.Call(context.Background(), Prompt{User: "hello"})
+	if callErr == nil {
+		t.Fatal("expected an error from a 401 response, got nil")
+	}
+	if requests != 1 {
+		t.Fatalf("got %d requests, want 1 (a 401 must not be retried)", requests)
+	}
+}
+
+func TestBentoMLAdapter_Call_RetriesRetryableStatus(t *testing.T) {
+	var requests int
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requests++
+		if requests < 2 {
+			w.WriteHeader(http.StatusTooManyRequests)
+			w.Write([]byte(`{"error":{"message":"rate limited"}}`))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"choices":[{"message":{"content":"ok"},"finish_reason":"stop"}]}`))
+	}))
+	defer server.Close()
+
+	adapter, err := NewBentoMLAdapter(BentoMLConfig{
+		BaseURL:    server.URL,
+		Model:      "test-model",
+		MaxRetries: 3,
+		RetryDelay: time.Millisecond,
+	})
+	if err != nil {
+		t.Fatalf("unexpected error constructing adapter: %v", err)
+	}
+
+	resp, callErr := adapter.Call(context.Background(), Prompt{User: "hello"})
+	if callErr != nil {
+		t.Fatalf("expected eventual success after retries, got error: %v", callErr)
+	}
+	if resp.Content != "ok" {
+		t.Fatalf("got content %q, want %q", resp.Content, "ok")
+	}
+	if requests != 2 {
+		t.Fatalf("got %d requests, want 2 (1 retryable failure + 1 success)", requests)
+	}
+}

--- a/internal/llm/openai_adapter.go
+++ b/internal/llm/openai_adapter.go
@@ -53,6 +53,13 @@ type OpenAIAdapterConfig struct {
 	FrequencyPenalty  float32
 	RepetitionPenalty float32
 	Stop              []string
+
+	// ResponseFormat, when non-nil, is passed through verbatim as the
+	// OpenAI-compatible "response_format" request field (e.g.
+	// map[string]interface{}{"type": "json_object"}). nil (the zero
+	// value) omits the field entirely — no behavior change for existing
+	// callers.
+	ResponseFormat interface{}
 }
 
 // OpenAIAdapter implements the ModelProvider interface for OpenAI-compatible APIs.
@@ -74,6 +81,8 @@ type OpenAIAdapter struct {
 	frequencyPenalty  float32
 	repetitionPenalty float32
 	stop              []string
+
+	responseFormat interface{}
 }
 
 // NewOpenAIAdapter creates a new OpenAIAdapter instance.
@@ -135,6 +144,7 @@ func NewOpenAIAdapterWithConfig(config OpenAIAdapterConfig) (*OpenAIAdapter, err
 		frequencyPenalty:  config.FrequencyPenalty,
 		repetitionPenalty: config.RepetitionPenalty,
 		stop:              config.Stop,
+		responseFormat:    config.ResponseFormat,
 	}, nil
 }
 
@@ -276,6 +286,9 @@ func (o *OpenAIAdapter) Call(ctx context.Context, prompt Prompt) (Response, erro
 	}
 	if len(o.stop) > 0 {
 		reqBody["stop"] = o.stop
+	}
+	if o.responseFormat != nil {
+		reqBody["response_format"] = o.responseFormat
 	}
 
 	requestBody, err := json.Marshal(reqBody)

--- a/internal/llm/openai_adapter.go
+++ b/internal/llm/openai_adapter.go
@@ -60,6 +60,12 @@ type OpenAIAdapterConfig struct {
 	// value) omits the field entirely — no behavior change for existing
 	// callers.
 	ResponseFormat interface{}
+
+	// CachePrompt, when true, sets the request body's "cache_prompt" field —
+	// llama.cpp's server flag to reuse a matching KV-cache prefix instead of
+	// re-prefilling it. false (the zero value) omits the field entirely, so
+	// non-llama.cpp OpenAI-compatible backends never see it.
+	CachePrompt bool
 }
 
 // OpenAIAdapter implements the ModelProvider interface for OpenAI-compatible APIs.
@@ -83,6 +89,7 @@ type OpenAIAdapter struct {
 	stop              []string
 
 	responseFormat interface{}
+	cachePrompt    bool
 }
 
 // NewOpenAIAdapter creates a new OpenAIAdapter instance.
@@ -145,6 +152,7 @@ func NewOpenAIAdapterWithConfig(config OpenAIAdapterConfig) (*OpenAIAdapter, err
 		repetitionPenalty: config.RepetitionPenalty,
 		stop:              config.Stop,
 		responseFormat:    config.ResponseFormat,
+		cachePrompt:       config.CachePrompt,
 	}, nil
 }
 
@@ -289,6 +297,9 @@ func (o *OpenAIAdapter) Call(ctx context.Context, prompt Prompt) (Response, erro
 	}
 	if o.responseFormat != nil {
 		reqBody["response_format"] = o.responseFormat
+	}
+	if o.cachePrompt {
+		reqBody["cache_prompt"] = true
 	}
 
 	requestBody, err := json.Marshal(reqBody)

--- a/internal/llm/openai_adapter.go
+++ b/internal/llm/openai_adapter.go
@@ -521,9 +521,12 @@ func (o *OpenAIAdapter) Stream(ctx context.Context, prompt Prompt) (<-chan Token
 	span.SetAttributes(attribute.Int("http.status_code", resp.StatusCode))
 
 	if resp.StatusCode != http.StatusOK {
-		resp.Body.Close()
+		// Read before Close — reading an already-closed response body
+		// returns empty/error, which silently dropped the actual error body
+		// on every non-200 stream-setup failure before this fix.
 		body, _ := io.ReadAll(resp.Body)
-		err := fmt.Errorf("API error: %d - %s", resp.StatusCode, string(body))
+		resp.Body.Close()
+		err := &APIStatusError{StatusCode: resp.StatusCode, Body: string(body)}
 		span.RecordError(err)
 		span.SetStatus(codes.Error, fmt.Sprintf("API error: status %d", resp.StatusCode))
 		return nil, err
@@ -667,7 +670,7 @@ func (o *OpenAIAdapter) Embeddings(ctx context.Context, texts []string) ([][]flo
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
-		return nil, fmt.Errorf("embeddings API error: %s", string(body))
+		return nil, &APIStatusError{StatusCode: resp.StatusCode, Body: string(body)}
 	}
 
 	var response struct {

--- a/internal/llm/openai_adapter.go
+++ b/internal/llm/openai_adapter.go
@@ -135,6 +135,22 @@ func (o *OpenAIAdapter) SetExtraHeaders(headers map[string]string) {
 	o.extraHeaders = headers
 }
 
+// setSessionHeader forwards a per-call session identifier as an outbound
+// X-Session-Id header, when the caller supplied one via
+// RunOptions.SessionID (agent_impl.go already threads this into ctx as
+// context.WithValue(ctx, "session_id", ...), but nothing previously read it
+// back out — every call looked session-less to the provider regardless of
+// what the caller passed). Several OpenAI-compatible gateways (session-aware
+// routers/caching proxies) use this header for sticky routing and cache
+// affinity; a static extraHeaders map (set once at adapter construction,
+// shared by every call for the adapter's lifetime) can't carry a value that
+// varies per call, so this reads it from ctx instead, per call.
+func setSessionHeader(req *http.Request, ctx context.Context) {
+	if sid, ok := ctx.Value("session_id").(string); ok && sid != "" {
+		req.Header.Set("X-Session-Id", sid)
+	}
+}
+
 // setHeaders sets common headers for requests
 func (o *OpenAIAdapter) setHeaders(req *http.Request) {
 	req.Header.Set("Content-Type", "application/json")
@@ -261,6 +277,7 @@ func (o *OpenAIAdapter) Call(ctx context.Context, prompt Prompt) (Response, erro
 		return Response{}, err
 	}
 	o.setHeaders(req)
+	setSessionHeader(req, ctx)
 
 	resp, err := o.httpClient.Do(req)
 	if err != nil {
@@ -451,6 +468,7 @@ func (o *OpenAIAdapter) Stream(ctx context.Context, prompt Prompt) (<-chan Token
 		return nil, fmt.Errorf("failed to create request: %w", err)
 	}
 	o.setHeaders(req)
+	setSessionHeader(req, ctx)
 
 	// Make the request
 	resp, err := o.httpClient.Do(req)
@@ -600,6 +618,7 @@ func (o *OpenAIAdapter) Embeddings(ctx context.Context, texts []string) ([][]flo
 		return nil, err
 	}
 	o.setHeaders(req)
+	setSessionHeader(req, ctx)
 
 	resp, err := o.httpClient.Do(req)
 	if err != nil {

--- a/internal/llm/openai_adapter.go
+++ b/internal/llm/openai_adapter.go
@@ -21,6 +21,21 @@ import (
 // DefaultOpenAIBaseURL is the default OpenAI API endpoint
 const DefaultOpenAIBaseURL = "https://api.openai.com/v1"
 
+// APIStatusError is returned when the OpenAI-compatible endpoint responds
+// with a non-200 status. StatusCode is preserved (previously discarded —
+// the error was a flat string built from the response body, giving callers
+// no structured way to classify e.g. a 502/503/524 gateway blip as
+// retry-worthy vs. a genuine 4xx client error) so downstream code can use
+// errors.As instead of matching substrings against the error text.
+type APIStatusError struct {
+	StatusCode int
+	Body       string
+}
+
+func (e *APIStatusError) Error() string {
+	return fmt.Sprintf("OpenAI API error (status %d): %s", e.StatusCode, e.Body)
+}
+
 // OpenAIAdapterConfig holds extended configuration for OpenAI-compatible adapters
 type OpenAIAdapterConfig struct {
 	APIKey       string
@@ -292,7 +307,7 @@ func (o *OpenAIAdapter) Call(ctx context.Context, prompt Prompt) (Response, erro
 
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
-		err := errors.New("OpenAI API error: " + string(body))
+		err := &APIStatusError{StatusCode: resp.StatusCode, Body: string(body)}
 		span.RecordError(err)
 		span.SetStatus(codes.Error, fmt.Sprintf("API error: status %d", resp.StatusCode))
 		return Response{}, err

--- a/internal/llm/openai_adapter.go
+++ b/internal/llm/openai_adapter.go
@@ -204,6 +204,53 @@ func (o *OpenAIAdapter) getBaseURL() string {
 }
 
 // Call implements the ModelProvider interface for a single request/response.
+// buildChatRequestBody assembles the Chat Completions request body shared by
+// Call (stream=false) and Stream (stream=true) — single source of truth so
+// the two call sites can't drift apart on it again. "stream" is always sent
+// explicitly, never omitted: some OpenAI-compatible gateways ignore an
+// absent field and default to SSE regardless (observed live against a real
+// gateway — a missing "stream" key on Call() made every response come back
+// as "data: {...}" chunks, which the non-streaming response parser then
+// failed to decode as a single JSON object, a json.SyntaxError on every
+// call). vLLM/MLFlow Gateway/BentoML/AI Foundry Local embed *OpenAIAdapter
+// for code reuse (see their own adapter files), so this fix covers them too
+// without touching each one individually.
+func (o *OpenAIAdapter) buildChatRequestBody(messages []map[string]interface{}, maxTokens int, temperature float32, stream bool) map[string]interface{} {
+	reqBody := map[string]interface{}{
+		"model":       o.model,
+		"messages":    messages,
+		"max_tokens":  maxTokens,
+		"temperature": temperature,
+		"stream":      stream,
+	}
+	// Extended sampling parameters, if set (for vLLM compatibility).
+	if o.topP > 0 {
+		reqBody["top_p"] = o.topP
+	}
+	if o.topK > 0 {
+		reqBody["top_k"] = o.topK
+	}
+	if o.presencePenalty != 0 {
+		reqBody["presence_penalty"] = o.presencePenalty
+	}
+	if o.frequencyPenalty != 0 {
+		reqBody["frequency_penalty"] = o.frequencyPenalty
+	}
+	if o.repetitionPenalty != 0 {
+		reqBody["repetition_penalty"] = o.repetitionPenalty
+	}
+	if len(o.stop) > 0 {
+		reqBody["stop"] = o.stop
+	}
+	if o.responseFormat != nil {
+		reqBody["response_format"] = o.responseFormat
+	}
+	if o.cachePrompt {
+		reqBody["cache_prompt"] = true
+	}
+	return reqBody
+}
+
 func (o *OpenAIAdapter) Call(ctx context.Context, prompt Prompt) (Response, error) {
 	// Create observability span
 	tracer := otel.Tracer("agenticgokit.llm")
@@ -268,39 +315,7 @@ func (o *OpenAIAdapter) Call(ctx context.Context, prompt Prompt) (Response, erro
 		"content": userContent,
 	})
 
-	// Build request body with extended parameters
-	reqBody := map[string]interface{}{
-		"model":       o.model,
-		"messages":    messages,
-		"max_tokens":  maxTokens,
-		"temperature": temperature,
-	}
-
-	// Add extended sampling parameters if set (for vLLM compatibility)
-	if o.topP > 0 {
-		reqBody["top_p"] = o.topP
-	}
-	if o.topK > 0 {
-		reqBody["top_k"] = o.topK
-	}
-	if o.presencePenalty != 0 {
-		reqBody["presence_penalty"] = o.presencePenalty
-	}
-	if o.frequencyPenalty != 0 {
-		reqBody["frequency_penalty"] = o.frequencyPenalty
-	}
-	if o.repetitionPenalty != 0 {
-		reqBody["repetition_penalty"] = o.repetitionPenalty
-	}
-	if len(o.stop) > 0 {
-		reqBody["stop"] = o.stop
-	}
-	if o.responseFormat != nil {
-		reqBody["response_format"] = o.responseFormat
-	}
-	if o.cachePrompt {
-		reqBody["cache_prompt"] = true
-	}
+	reqBody := o.buildChatRequestBody(messages, maxTokens, temperature, false)
 
 	requestBody, err := json.Marshal(reqBody)
 	if err != nil {
@@ -463,34 +478,7 @@ func (o *OpenAIAdapter) Stream(ctx context.Context, prompt Prompt) (<-chan Token
 		"content": userContent,
 	})
 
-	// Build request body with extended parameters
-	reqBody := map[string]interface{}{
-		"model":       o.model,
-		"messages":    messages,
-		"max_tokens":  maxTokens,
-		"temperature": temperature,
-		"stream":      true, // Enable streaming
-	}
-
-	// Add extended sampling parameters if set (for vLLM compatibility)
-	if o.topP > 0 {
-		reqBody["top_p"] = o.topP
-	}
-	if o.topK > 0 {
-		reqBody["top_k"] = o.topK
-	}
-	if o.presencePenalty != 0 {
-		reqBody["presence_penalty"] = o.presencePenalty
-	}
-	if o.frequencyPenalty != 0 {
-		reqBody["frequency_penalty"] = o.frequencyPenalty
-	}
-	if o.repetitionPenalty != 0 {
-		reqBody["repetition_penalty"] = o.repetitionPenalty
-	}
-	if len(o.stop) > 0 {
-		reqBody["stop"] = o.stop
-	}
+	reqBody := o.buildChatRequestBody(messages, maxTokens, temperature, true)
 
 	requestBody, err := json.Marshal(reqBody)
 	if err != nil {

--- a/internal/llm/openai_adapter_test.go
+++ b/internal/llm/openai_adapter_test.go
@@ -2,12 +2,72 @@ package llm
 
 import (
 	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
+
+// TestOpenAIAdapter_Call_ResponseFormat is hermetic (httptest, no live API
+// key needed) — asserts the "response_format" field's presence/absence in
+// the actual outbound request body, unlike TestOpenAIAdapter_Call above
+// which only exercises success/failure against a real endpoint.
+func TestOpenAIAdapter_Call_ResponseFormat(t *testing.T) {
+	t.Run("set when configured", func(t *testing.T) {
+		var gotBody map[string]interface{}
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			body, _ := io.ReadAll(r.Body)
+			require.NoError(t, json.Unmarshal(body, &gotBody))
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{"choices":[{"message":{"content":"{}"},"finish_reason":"stop"}]}`))
+		}))
+		defer server.Close()
+
+		adapter, err := NewOpenAIAdapterWithConfig(OpenAIAdapterConfig{
+			APIKey:         "test-key",
+			Model:          "test-model",
+			BaseURL:        server.URL,
+			ResponseFormat: map[string]interface{}{"type": "json_object"},
+		})
+		require.NoError(t, err)
+
+		_, err = adapter.Call(context.Background(), Prompt{User: "hello"})
+		require.NoError(t, err)
+
+		rf, ok := gotBody["response_format"].(map[string]interface{})
+		require.True(t, ok, "response_format missing from request body: %v", gotBody)
+		assert.Equal(t, "json_object", rf["type"])
+	})
+
+	t.Run("absent when not configured", func(t *testing.T) {
+		var gotBody map[string]interface{}
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			body, _ := io.ReadAll(r.Body)
+			require.NoError(t, json.Unmarshal(body, &gotBody))
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{"choices":[{"message":{"content":"ok"},"finish_reason":"stop"}]}`))
+		}))
+		defer server.Close()
+
+		adapter, err := NewOpenAIAdapterWithConfig(OpenAIAdapterConfig{
+			APIKey:  "test-key",
+			Model:   "test-model",
+			BaseURL: server.URL,
+		})
+		require.NoError(t, err)
+
+		_, err = adapter.Call(context.Background(), Prompt{User: "hello"})
+		require.NoError(t, err)
+
+		_, ok := gotBody["response_format"]
+		assert.False(t, ok, "response_format should be absent when not configured, got: %v", gotBody)
+	})
+}
 
 func TestOpenAIAdapter_Call(t *testing.T) {
 	t.Run("Valid prompt", func(t *testing.T) {

--- a/internal/llm/openai_adapter_test.go
+++ b/internal/llm/openai_adapter_test.go
@@ -69,6 +69,61 @@ func TestOpenAIAdapter_Call_ResponseFormat(t *testing.T) {
 	})
 }
 
+// TestOpenAIAdapter_Call_CachePrompt is hermetic (httptest, no live API key
+// needed) — asserts the "cache_prompt" field's presence/absence in the
+// actual outbound request body.
+func TestOpenAIAdapter_Call_CachePrompt(t *testing.T) {
+	t.Run("set when configured", func(t *testing.T) {
+		var gotBody map[string]interface{}
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			body, _ := io.ReadAll(r.Body)
+			require.NoError(t, json.Unmarshal(body, &gotBody))
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{"choices":[{"message":{"content":"ok"},"finish_reason":"stop"}]}`))
+		}))
+		defer server.Close()
+
+		adapter, err := NewOpenAIAdapterWithConfig(OpenAIAdapterConfig{
+			APIKey:      "test-key",
+			Model:       "test-model",
+			BaseURL:     server.URL,
+			CachePrompt: true,
+		})
+		require.NoError(t, err)
+
+		_, err = adapter.Call(context.Background(), Prompt{User: "hello"})
+		require.NoError(t, err)
+
+		cp, ok := gotBody["cache_prompt"].(bool)
+		require.True(t, ok, "cache_prompt missing from request body: %v", gotBody)
+		assert.True(t, cp)
+	})
+
+	t.Run("absent when not configured", func(t *testing.T) {
+		var gotBody map[string]interface{}
+		server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			body, _ := io.ReadAll(r.Body)
+			require.NoError(t, json.Unmarshal(body, &gotBody))
+			w.Header().Set("Content-Type", "application/json")
+			w.Write([]byte(`{"choices":[{"message":{"content":"ok"},"finish_reason":"stop"}]}`))
+		}))
+		defer server.Close()
+
+		adapter, err := NewOpenAIAdapterWithConfig(OpenAIAdapterConfig{
+			APIKey:  "test-key",
+			Model:   "test-model",
+			BaseURL: server.URL,
+		})
+		require.NoError(t, err)
+
+		_, err = adapter.Call(context.Background(), Prompt{User: "hello"})
+		require.NoError(t, err)
+
+		_, ok := gotBody["cache_prompt"]
+		assert.False(t, ok, "cache_prompt should be absent when not configured, got: %v", gotBody)
+	})
+}
+
 func TestOpenAIAdapter_Call(t *testing.T) {
 	t.Run("Valid prompt", func(t *testing.T) {
 		apiKey := os.Getenv("OPENAI_API_KEY")

--- a/internal/llm/openrouter_adapter.go
+++ b/internal/llm/openrouter_adapter.go
@@ -29,6 +29,14 @@ type OpenRouterAdapter struct {
 	siteURL     string // Optional: for rankings (HTTP-Referer header)
 	siteName    string // Optional: for rankings (X-Title header)
 	httpClient  *http.Client
+
+	// responseFormat/cachePrompt are set directly by factory.go
+	// (createOpenRouterProvider), same package, rather than adding params
+	// to NewOpenRouterAdapter's constructor and breaking its existing
+	// positional-argument callers (e.g. wrappers.go's
+	// NewOpenRouterAdapterWrapped).
+	responseFormat interface{}
+	cachePrompt    bool
 }
 
 // NewOpenRouterAdapter creates a new OpenRouterAdapter instance.
@@ -143,12 +151,20 @@ func (o *OpenRouterAdapter) Call(ctx context.Context, prompt Prompt) (Response, 
 	// Build messages array for Chat Completions API
 	messages := buildOpenRouterMessages(prompt)
 
-	requestBody, err := json.Marshal(map[string]interface{}{
+	reqBody := map[string]interface{}{
 		"model":       o.model,
 		"messages":    messages,
 		"max_tokens":  maxTokens,
 		"temperature": temperature,
-	})
+	}
+	if o.responseFormat != nil {
+		reqBody["response_format"] = o.responseFormat
+	}
+	if o.cachePrompt {
+		reqBody["cache_prompt"] = true
+	}
+
+	requestBody, err := json.Marshal(reqBody)
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "failed to marshal request")
@@ -322,13 +338,21 @@ func (o *OpenRouterAdapter) Stream(ctx context.Context, prompt Prompt) (<-chan T
 	messages := buildOpenRouterMessages(prompt)
 
 	// Create streaming request
-	requestBody, err := json.Marshal(map[string]interface{}{
+	streamReqBody := map[string]interface{}{
 		"model":       o.model,
 		"messages":    messages,
 		"max_tokens":  maxTokens,
 		"temperature": temperature,
 		"stream":      true, // Enable streaming
-	})
+	}
+	if o.responseFormat != nil {
+		streamReqBody["response_format"] = o.responseFormat
+	}
+	if o.cachePrompt {
+		streamReqBody["cache_prompt"] = true
+	}
+
+	requestBody, err := json.Marshal(streamReqBody)
 	if err != nil {
 		span.RecordError(err)
 		span.SetStatus(codes.Error, "failed to marshal request")

--- a/internal/llm/openrouter_adapter.go
+++ b/internal/llm/openrouter_adapter.go
@@ -101,6 +101,32 @@ func buildOpenRouterMessages(prompt Prompt) []map[string]interface{} {
 	return messages
 }
 
+// buildChatRequestBody assembles the Chat Completions request body shared by
+// Call (stream=false) and Stream (stream=true) — single source of truth so
+// the two call sites can't drift apart on it, mirroring OpenAIAdapter's own
+// buildChatRequestBody (openai_adapter.go). "stream" is always sent
+// explicitly, never omitted: some OpenAI-compatible gateways ignore an
+// absent field and default to SSE regardless (observed live — a missing
+// "stream" key on a non-streaming Call() made the gateway return
+// "data: {...}" chunks, which the non-streaming response parser then failed
+// to decode as a single JSON object).
+func (o *OpenRouterAdapter) buildChatRequestBody(messages []map[string]interface{}, maxTokens int, temperature float32, stream bool) map[string]interface{} {
+	reqBody := map[string]interface{}{
+		"model":       o.model,
+		"messages":    messages,
+		"max_tokens":  maxTokens,
+		"temperature": temperature,
+		"stream":      stream,
+	}
+	if o.responseFormat != nil {
+		reqBody["response_format"] = o.responseFormat
+	}
+	if o.cachePrompt {
+		reqBody["cache_prompt"] = true
+	}
+	return reqBody
+}
+
 // Call implements the ModelProvider interface for a single request/response.
 func (o *OpenRouterAdapter) Call(ctx context.Context, prompt Prompt) (Response, error) {
 	// Create observability span
@@ -151,18 +177,7 @@ func (o *OpenRouterAdapter) Call(ctx context.Context, prompt Prompt) (Response, 
 	// Build messages array for Chat Completions API
 	messages := buildOpenRouterMessages(prompt)
 
-	reqBody := map[string]interface{}{
-		"model":       o.model,
-		"messages":    messages,
-		"max_tokens":  maxTokens,
-		"temperature": temperature,
-	}
-	if o.responseFormat != nil {
-		reqBody["response_format"] = o.responseFormat
-	}
-	if o.cachePrompt {
-		reqBody["cache_prompt"] = true
-	}
+	reqBody := o.buildChatRequestBody(messages, maxTokens, temperature, false)
 
 	requestBody, err := json.Marshal(reqBody)
 	if err != nil {
@@ -338,19 +353,7 @@ func (o *OpenRouterAdapter) Stream(ctx context.Context, prompt Prompt) (<-chan T
 	messages := buildOpenRouterMessages(prompt)
 
 	// Create streaming request
-	streamReqBody := map[string]interface{}{
-		"model":       o.model,
-		"messages":    messages,
-		"max_tokens":  maxTokens,
-		"temperature": temperature,
-		"stream":      true, // Enable streaming
-	}
-	if o.responseFormat != nil {
-		streamReqBody["response_format"] = o.responseFormat
-	}
-	if o.cachePrompt {
-		streamReqBody["cache_prompt"] = true
-	}
+	streamReqBody := o.buildChatRequestBody(messages, maxTokens, temperature, true)
 
 	requestBody, err := json.Marshal(streamReqBody)
 	if err != nil {

--- a/internal/llm/openrouter_adapter.go
+++ b/internal/llm/openrouter_adapter.go
@@ -216,6 +216,10 @@ func (o *OpenRouterAdapter) Call(ctx context.Context, prompt Prompt) (Response, 
 	// Record HTTP status
 	span.SetAttributes(attribute.Int("http.status_code", resp.StatusCode))
 
+	// Returned as *APIStatusError (the same type openai_adapter.go/azure_
+	// adapter.go produce), not a plain fmt.Errorf, so CircuitBreakerProvider's
+	// DefaultIsRetryable can classify a 429/5xx as retryable via errors.As
+	// instead of silently treating every OpenRouter error as non-retryable.
 	if resp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(resp.Body)
 
@@ -229,13 +233,13 @@ func (o *OpenRouterAdapter) Call(ctx context.Context, prompt Prompt) (Response, 
 		}
 
 		if json.Unmarshal(body, &errorResp) == nil && errorResp.Error.Message != "" {
-			err := fmt.Errorf("OpenRouter API error [%s]: %s", errorResp.Error.Code, errorResp.Error.Message)
+			err := &APIStatusError{StatusCode: resp.StatusCode, Body: fmt.Sprintf("[%s]: %s", errorResp.Error.Code, errorResp.Error.Message)}
 			span.RecordError(err)
 			span.SetStatus(codes.Error, fmt.Sprintf("API error: %s", errorResp.Error.Code))
 			return Response{}, err
 		}
 
-		err := fmt.Errorf("OpenRouter API error: %d - %s", resp.StatusCode, string(body))
+		err := &APIStatusError{StatusCode: resp.StatusCode, Body: string(body)}
 		span.RecordError(err)
 		span.SetStatus(codes.Error, fmt.Sprintf("API error: status %d", resp.StatusCode))
 		return Response{}, err
@@ -393,9 +397,15 @@ func (o *OpenRouterAdapter) Stream(ctx context.Context, prompt Prompt) (<-chan T
 	// Record HTTP status
 	span.SetAttributes(attribute.Int("http.status_code", resp.StatusCode))
 
+	// Read the body BEFORE closing it (previously closed first, the same
+	// bug this PR's openai_adapter.go fix addresses for the OpenAI adapter
+	// — left in place here meant a non-200 stream error came back with an
+	// empty body every time). Also returned as *APIStatusError so
+	// CircuitBreakerProvider's DefaultIsRetryable can classify a 429/5xx as
+	// retryable.
 	if resp.StatusCode != http.StatusOK {
-		resp.Body.Close()
 		body, _ := io.ReadAll(resp.Body)
+		resp.Body.Close()
 
 		// Try to parse OpenRouter error format
 		var errorResp struct {
@@ -407,13 +417,13 @@ func (o *OpenRouterAdapter) Stream(ctx context.Context, prompt Prompt) (<-chan T
 		}
 
 		if json.Unmarshal(body, &errorResp) == nil && errorResp.Error.Message != "" {
-			err := fmt.Errorf("OpenRouter API error [%s]: %s", errorResp.Error.Code, errorResp.Error.Message)
+			err := &APIStatusError{StatusCode: resp.StatusCode, Body: fmt.Sprintf("[%s]: %s", errorResp.Error.Code, errorResp.Error.Message)}
 			span.RecordError(err)
 			span.SetStatus(codes.Error, fmt.Sprintf("API error: %s", errorResp.Error.Code))
 			return nil, err
 		}
 
-		err := fmt.Errorf("OpenRouter API error: %d - %s", resp.StatusCode, string(body))
+		err := &APIStatusError{StatusCode: resp.StatusCode, Body: string(body)}
 		span.RecordError(err)
 		span.SetStatus(codes.Error, fmt.Sprintf("API error: status %d", resp.StatusCode))
 		return nil, err

--- a/internal/llm/response_format_propagation_test.go
+++ b/internal/llm/response_format_propagation_test.go
@@ -1,0 +1,147 @@
+package llm
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// These tests assert that ResponseFormat (and, for the OpenAI-compatible
+// composed adapters, CachePrompt) actually reaches the outbound request
+// body for every adapter that claims to support it — not just OpenAI's own
+// adapter. vLLM/MLFlow/BentoML compose OpenAIAdapterConfig internally
+// (verified by inspection: "// Embed OpenAI adapter for code reuse"), so a
+// missing field there would silently no-op rather than error.
+
+func TestVLLMAdapter_Call_ResponseFormat(t *testing.T) {
+	var gotBody map[string]interface{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		require.NoError(t, json.Unmarshal(body, &gotBody))
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"choices":[{"message":{"content":"ok"},"finish_reason":"stop"}]}`))
+	}))
+	defer server.Close()
+
+	adapter, err := NewVLLMAdapter(VLLMConfig{
+		BaseURL:        server.URL,
+		Model:          "test-model",
+		ResponseFormat: map[string]interface{}{"type": "json_object"},
+	})
+	require.NoError(t, err)
+
+	_, err = adapter.Call(context.Background(), Prompt{User: "hello"})
+	require.NoError(t, err)
+
+	rf, ok := gotBody["response_format"].(map[string]interface{})
+	require.True(t, ok, "response_format missing from vLLM request body: %v", gotBody)
+	assert.Equal(t, "json_object", rf["type"])
+}
+
+func TestMLFlowGatewayAdapter_Call_ResponseFormat(t *testing.T) {
+	var gotBody map[string]interface{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		require.NoError(t, json.Unmarshal(body, &gotBody))
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"choices":[{"message":{"content":"ok"},"finish_reason":"stop"}]}`))
+	}))
+	defer server.Close()
+
+	adapter, err := NewMLFlowGatewayAdapter(MLFlowGatewayConfig{
+		BaseURL:        server.URL,
+		ChatRoute:      "test-route",
+		ResponseFormat: map[string]interface{}{"type": "json_object"},
+	})
+	require.NoError(t, err)
+
+	_, err = adapter.Call(context.Background(), Prompt{User: "hello"})
+	require.NoError(t, err)
+
+	rf, ok := gotBody["response_format"].(map[string]interface{})
+	require.True(t, ok, "response_format missing from MLFlow Gateway request body: %v", gotBody)
+	assert.Equal(t, "json_object", rf["type"])
+}
+
+func TestBentoMLAdapter_Call_ResponseFormat(t *testing.T) {
+	var gotBody map[string]interface{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		require.NoError(t, json.Unmarshal(body, &gotBody))
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"choices":[{"message":{"content":"ok"},"finish_reason":"stop"}]}`))
+	}))
+	defer server.Close()
+
+	adapter, err := NewBentoMLAdapter(BentoMLConfig{
+		BaseURL:        server.URL,
+		Model:          "test-model",
+		ResponseFormat: map[string]interface{}{"type": "json_object"},
+	})
+	require.NoError(t, err)
+
+	_, err = adapter.Call(context.Background(), Prompt{User: "hello"})
+	require.NoError(t, err)
+
+	rf, ok := gotBody["response_format"].(map[string]interface{})
+	require.True(t, ok, "response_format missing from BentoML request body: %v", gotBody)
+	assert.Equal(t, "json_object", rf["type"])
+}
+
+func TestOpenRouterAdapter_Call_ResponseFormat(t *testing.T) {
+	var gotBody map[string]interface{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		require.NoError(t, json.Unmarshal(body, &gotBody))
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"choices":[{"message":{"content":"ok"},"finish_reason":"stop"}]}`))
+	}))
+	defer server.Close()
+
+	// factory.go sets these fields directly (same package) after
+	// construction — replicate that here since NewOpenRouterAdapter's
+	// constructor intentionally keeps its existing positional signature.
+	adapter, err := NewOpenRouterAdapter("test-key", "test-model", server.URL, 100, 0.5, "", "")
+	require.NoError(t, err)
+	adapter.responseFormat = map[string]interface{}{"type": "json_object"}
+
+	_, err = adapter.Call(context.Background(), Prompt{User: "hello"})
+	require.NoError(t, err)
+
+	rf, ok := gotBody["response_format"].(map[string]interface{})
+	require.True(t, ok, "response_format missing from OpenRouter request body: %v", gotBody)
+	assert.Equal(t, "json_object", rf["type"])
+}
+
+func TestAzureOpenAIAdapter_Call_ResponseFormat(t *testing.T) {
+	var gotBody map[string]interface{}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		require.NoError(t, json.Unmarshal(body, &gotBody))
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"choices":[{"message":{"content":"ok"},"finish_reason":"stop"}],"usage":{}}`))
+	}))
+	defer server.Close()
+
+	adapter, err := NewAzureOpenAIAdapter(AzureOpenAIAdapterOptions{
+		Endpoint:            server.URL,
+		APIKey:              "test-key",
+		ChatDeployment:      "test-chat",
+		EmbeddingDeployment: "test-embed",
+		ResponseFormat:      map[string]interface{}{"type": "json_object"},
+	})
+	require.NoError(t, err)
+
+	_, err = adapter.Call(context.Background(), Prompt{User: "hello"})
+	require.NoError(t, err)
+
+	rf, ok := gotBody["response_format"].(map[string]interface{})
+	require.True(t, ok, "response_format missing from Azure OpenAI request body: %v", gotBody)
+	assert.Equal(t, "json_object", rf["type"])
+}

--- a/internal/llm/vllm_adapter.go
+++ b/internal/llm/vllm_adapter.go
@@ -37,6 +37,14 @@ type VLLMConfig struct {
 
 	// HTTP configuration
 	HTTPTimeout time.Duration `json:"http_timeout,omitempty" toml:"http_timeout"`
+
+	// ResponseFormat, when non-nil, is passed through verbatim as the
+	// request body's "response_format" field. vLLM serves an
+	// OpenAI-compatible API, so this reuses OpenAIAdapterConfig's field.
+	ResponseFormat interface{} `json:"response_format,omitempty" toml:"response_format,omitempty"`
+
+	// CachePrompt, when true, sets the request body's "cache_prompt" field.
+	CachePrompt bool `json:"cache_prompt,omitempty" toml:"cache_prompt,omitempty"`
 }
 
 // VLLMAdapter wraps the OpenAI adapter for vLLM inference servers.
@@ -71,6 +79,8 @@ func NewVLLMAdapter(config VLLMConfig) (*VLLMAdapter, error) {
 		FrequencyPenalty:  config.FrequencyPenalty,
 		RepetitionPenalty: config.RepetitionPenalty,
 		Stop:              config.Stop,
+		ResponseFormat:    config.ResponseFormat,
+		CachePrompt:       config.CachePrompt,
 	}
 
 	openaiAdapter, err := NewOpenAIAdapterWithConfig(openaiConfig)

--- a/internal/mcp/tool.go
+++ b/internal/mcp/tool.go
@@ -46,6 +46,16 @@ func (t *MCPTool) Name() string {
 	return fmt.Sprintf("mcp_%s_%s", t.serverName, t.name)
 }
 
+// Info returns the tool's name, description, and JSON-schema parameters.
+// This implements the FunctionTool interface.
+func (t *MCPTool) Info(ctx context.Context) (*core.FunctionDefinition, error) {
+	return &core.FunctionDefinition{
+		Name:        t.Name(),
+		Description: t.description,
+		Parameters:  t.schema,
+	}, nil
+}
+
 // Call executes the MCP tool with the given arguments.
 // This implements the FunctionTool interface.
 func (t *MCPTool) Call(ctx context.Context, args map[string]any) (map[string]any, error) {

--- a/internal/tools/compute_metric.go
+++ b/internal/tools/compute_metric.go
@@ -3,14 +3,39 @@ package tools
 import (
 	"context"
 	"fmt"
+
+	"github.com/agenticgokit/agenticgokit/core"
 )
 
 // ComputeMetricTool performs simple calculations.
 type ComputeMetricTool struct{}
 
+// computeMetricArgs is the typed shape of ComputeMetricTool's arguments.
+// Info() reflects this struct into a JSON schema instead of hand-authoring
+// one, so the advertised schema can't drift from what Call() decodes.
+type computeMetricArgs struct {
+	Operation string  `json:"operation" jsonschema:"enum=add,enum=subtract,enum=multiply,enum=divide,description=The arithmetic operation to perform."`
+	A         float64 `json:"a" jsonschema:"description=The first operand."`
+	B         float64 `json:"b" jsonschema:"description=The second operand."`
+}
+
 // Name returns the tool's name.
 func (t *ComputeMetricTool) Name() string {
 	return "compute_metric"
+}
+
+// Info returns the tool's name, description, and JSON-schema parameters.
+// This implements the FunctionTool interface.
+func (t *ComputeMetricTool) Info(ctx context.Context) (*core.FunctionDefinition, error) {
+	params, err := InferSchema[computeMetricArgs]()
+	if err != nil {
+		return nil, fmt.Errorf("compute_metric: infer schema: %w", err)
+	}
+	return &core.FunctionDefinition{
+		Name:        t.Name(),
+		Description: "Performs a basic arithmetic calculation (add, subtract, multiply, divide) on two numbers.",
+		Parameters:  params,
+	}, nil
 }
 
 // getFloat is a helper function to safely extract a float64 from the arguments map.

--- a/internal/tools/schema.go
+++ b/internal/tools/schema.go
@@ -1,0 +1,40 @@
+package tools
+
+import (
+	"encoding/json"
+
+	"github.com/invopop/jsonschema"
+)
+
+// InferSchema reflects Go struct T's fields and `json`/`jsonschema` tags into
+// a JSON Schema object, for use as core.FunctionDefinition.Parameters.
+//
+// Mirrors eino's utils.InferTool (github.com/eino-contrib/jsonschema-backed
+// goStruct2ParamsOneOf): the parameter schema is derived from a typed args
+// struct instead of hand-authored per tool, so the schema can't drift from
+// the struct Call() actually decodes.
+func InferSchema[T any]() (map[string]interface{}, error) {
+	r := &jsonschema.Reflector{
+		DoNotReference:            true,
+		ExpandedStruct:            true,
+		AllowAdditionalProperties: false,
+	}
+	var zero T
+	js := r.Reflect(zero)
+	// $schema/$id (the latter defaulting to a repo URL) describe the schema
+	// document itself, not the tool's parameters — a tool-call parameter
+	// schema doesn't need them, so clear before marshaling rather than
+	// stripping keys back out of the encoded map.
+	js.Version = ""
+	js.ID = ""
+
+	b, err := json.Marshal(js)
+	if err != nil {
+		return nil, err
+	}
+	var out map[string]interface{}
+	if err := json.Unmarshal(b, &out); err != nil {
+		return nil, err
+	}
+	return out, nil
+}

--- a/internal/tools/tool.go
+++ b/internal/tools/tool.go
@@ -4,6 +4,8 @@ import (
 	"context"
 	"fmt"
 	"sync"
+
+	"github.com/agenticgokit/agenticgokit/core"
 )
 
 // FunctionTool defines the interface for a callable tool that agents can use.
@@ -11,10 +13,14 @@ import (
 type FunctionTool interface {
 	// Name returns the unique identifier for the tool.
 	Name() string
+	// Info returns the tool's name, description, and JSON-schema parameters,
+	// letting a ChatModel decide whether and how to call the tool (mirrors
+	// eino's BaseTool.Info). Reuses core.FunctionDefinition since it's already
+	// the shape core.Prompt.Tools expects for native tool-calling.
+	Info(ctx context.Context) (*core.FunctionDefinition, error)
 	// Call executes the tool's logic with the given arguments.
 	// It returns a map containing the results or an error if the call fails.
 	Call(ctx context.Context, args map[string]any) (map[string]any, error)
-	// TODO: Add a Schema() method to describe parameters and return values for LLMs?
 }
 
 // ToolRegistry holds a collection of available FunctionTools.

--- a/internal/tools/tool_test.go
+++ b/internal/tools/tool_test.go
@@ -6,6 +6,8 @@ import (
 	"reflect"
 	"sort"
 	"testing"
+
+	"github.com/agenticgokit/agenticgokit/core"
 )
 
 // MockTool for testing registry
@@ -17,6 +19,10 @@ type MockTool struct {
 
 func (m *MockTool) Name() string {
 	return m.name
+}
+
+func (m *MockTool) Info(ctx context.Context) (*core.FunctionDefinition, error) {
+	return &core.FunctionDefinition{Name: m.name}, nil
 }
 
 func (m *MockTool) Call(ctx context.Context, args map[string]any) (map[string]any, error) {

--- a/internal/tools/web_search.go
+++ b/internal/tools/web_search.go
@@ -7,6 +7,8 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+
+	"github.com/agenticgokit/agenticgokit/core"
 )
 
 // HTTPClient is an interface for making HTTP requests.
@@ -48,6 +50,25 @@ func NewWebSearchTool() (*WebSearchTool, error) {
 // Name returns the tool's name.
 func (t *WebSearchTool) Name() string {
 	return "web_search"
+}
+
+// webSearchArgs is the typed shape of WebSearchTool's arguments.
+type webSearchArgs struct {
+	Query string `json:"query" jsonschema:"description=The search query."`
+}
+
+// Info returns the tool's name, description, and JSON-schema parameters.
+// This implements the FunctionTool interface.
+func (t *WebSearchTool) Info(ctx context.Context) (*core.FunctionDefinition, error) {
+	params, err := InferSchema[webSearchArgs]()
+	if err != nil {
+		return nil, fmt.Errorf("web_search: infer schema: %w", err)
+	}
+	return &core.FunctionDefinition{
+		Name:        t.Name(),
+		Description: "Searches the web using the Brave Search API and returns matching page titles, URLs, and snippets.",
+		Parameters:  params,
+	}, nil
 }
 
 // Call performs a web search using the Brave Search API.

--- a/plugins/mcp/unified/unified.go
+++ b/plugins/mcp/unified/unified.go
@@ -27,6 +27,15 @@ func logger() *zerolog.Logger {
 	return logging.GetLogger()
 }
 
+// maxSSELineSize bounds bufio.Scanner's per-line buffer for SSE frame
+// parsing below — bufio.Scanner's own default (64KB) silently truncates
+// scanning (Scan() returns false, Err() becomes bufio.ErrTooLong) on a
+// single "data:" line beyond that size, with no error surfaced unless the
+// caller checks Err(). Confirmed live 2026-07-16: a real MCP tool response
+// (a full-schema discovery call covering many resources) measured ~107KB in
+// one such line — comfortably past the default, nowhere near this bound.
+const maxSSELineSize = 10 * 1024 * 1024 // 10MB
+
 // normalizeToolArgs defensively unwraps arguments of the form:
 // {"input":"{\"k\":\"v\"}"} -> {"k":"v"}
 // This preserves direct JSON object arguments expected by many MCP tools.
@@ -238,8 +247,20 @@ func (h *authStreamingHTTPTransport) Send(message *mcp.Message) error {
 	if looksLikeSSE {
 		logger().Debug().Msg("[Streaming] Response is in SSE format, parsing...")
 
-		// Parse SSE format to extract JSON data
+		// Parse SSE format to extract JSON data. bufio.Scanner defaults to a
+		// 64KB max token (line) size — confirmed live 2026-07-16: a
+		// describe_data response (full schema, every cube) can exceed that
+		// in one "data:" line. When it does, Scan() stops silently (returns
+		// false, sets Err() to bufio.ErrTooLong) with messageData still "",
+		// and the code below previously treated that identically to "no
+		// data line present" — Send() returned nil (no error), Receive()
+		// then found nothing stored and returned the misleading
+		// "no response available", with no hint the real cause was a
+		// too-long line. maxSSELineSize gives real payloads headroom; Err()
+		// is now checked so a genuine overflow surfaces as a real error
+		// instead of a silent empty response.
 		scanner := bufio.NewScanner(bytes.NewReader(body))
+		scanner.Buffer(make([]byte, 0, 64*1024), maxSSELineSize)
 		var currentEvent string
 		var messageData string
 
@@ -254,6 +275,9 @@ func (h *authStreamingHTTPTransport) Send(message *mcp.Message) error {
 					break
 				}
 			}
+		}
+		if err := scanner.Err(); err != nil {
+			return fmt.Errorf("SSE response line exceeded %d bytes (or scan failed): %w", maxSSELineSize, err)
 		}
 
 		if messageData == "" {
@@ -407,6 +431,7 @@ func (h *authSSETransport) sendInitializeRequest(message *mcp.Message) error {
 	// event: endpoint
 	// data: <session-url>
 	scanner := bufio.NewScanner(resp.Body)
+	scanner.Buffer(make([]byte, 0, 64*1024), maxSSELineSize)
 	var currentEvent string
 	var sessionEndpoint string
 
@@ -519,6 +544,7 @@ func (h *authSSETransport) sendMessageToSession(message *mcp.Message) error {
 
 		// Read events from SSE stream until we get a message response
 		scanner := bufio.NewScanner(h.sseConnection.Body)
+		scanner.Buffer(make([]byte, 0, 64*1024), maxSSELineSize)
 		var currentEvent string
 		var messageData string
 

--- a/plugins/mcp/unified/unified.go
+++ b/plugins/mcp/unified/unified.go
@@ -132,8 +132,17 @@ func (h *authStreamingHTTPTransport) Close() error {
 }
 
 func (h *authStreamingHTTPTransport) Send(message *mcp.Message) error {
-	h.mu.RLock()
-	defer h.mu.RUnlock()
+	// Full write lock, not RLock: this mutates h.lastResponse and
+	// h.sessionID. Confirmed live 2026-07-11: this Go server is
+	// single-process, multi-session, and a single transport instance is
+	// shared across concurrent turns — RLock let two goroutines run
+	// Send/Receive concurrently and stomp on the shared lastResponse slot
+	// between each other's own Send/Receive pair (one call's stored
+	// response silently cleared or stolen by another call's Receive before
+	// its own Receive ran), surfacing as a bare "no response available"
+	// error with no corresponding request ever reaching the MCP server.
+	h.mu.Lock()
+	defer h.mu.Unlock()
 
 	if !h.connected {
 		return fmt.Errorf("transport not connected")
@@ -276,8 +285,10 @@ func (h *authStreamingHTTPTransport) Send(message *mcp.Message) error {
 }
 
 func (h *authStreamingHTTPTransport) Receive() (*mcp.Message, error) {
-	h.mu.RLock()
-	defer h.mu.RUnlock()
+	// Write lock — mutates h.lastResponse (clears it after reading). See
+	// Send's comment above for why RLock was wrong here.
+	h.mu.Lock()
+	defer h.mu.Unlock()
 
 	if !h.connected {
 		return nil, fmt.Errorf("transport not connected")
@@ -342,8 +353,12 @@ func (h *authSSETransport) Close() error {
 }
 
 func (h *authSSETransport) Send(message *mcp.Message) error {
-	h.mu.RLock()
-	defer h.mu.RUnlock()
+	// Write lock, not RLock — same reasoning as authStreamingHTTPTransport's
+	// Send just above: this mutates h.lastResponse/h.sessionURL/
+	// h.sseConnection, shared across concurrent callers of one transport
+	// instance.
+	h.mu.Lock()
+	defer h.mu.Unlock()
 
 	if !h.connected {
 		return fmt.Errorf("transport not connected")
@@ -572,8 +587,9 @@ func (h *authSSETransport) sendSessionRequest(message *mcp.Message) error {
 }
 
 func (h *authSSETransport) Receive() (*mcp.Message, error) {
-	h.mu.RLock()
-	defer h.mu.RUnlock()
+	// Write lock — mutates h.lastResponse (clears it after reading).
+	h.mu.Lock()
+	defer h.mu.Unlock()
 
 	if !h.connected {
 		return nil, fmt.Errorf("transport not connected")

--- a/plugins/mcp/unified/unified.go
+++ b/plugins/mcp/unified/unified.go
@@ -102,13 +102,13 @@ type authSSETransport struct {
 	sseConnection *http.Response
 }
 
-func newAuthStreamingHTTPTransport(baseURL, endpoint, token string) *authStreamingHTTPTransport {
+func newAuthStreamingHTTPTransport(baseURL, endpoint, token string, timeout time.Duration) *authStreamingHTTPTransport {
 	return &authStreamingHTTPTransport{
 		baseURL:   baseURL,
 		endpoint:  endpoint,
 		authToken: token,
 		client: &http.Client{
-			Timeout: 30 * time.Second,
+			Timeout: timeout,
 		},
 	}
 }
@@ -319,13 +319,13 @@ func (h *authStreamingHTTPTransport) IsConnected() bool {
 }
 
 // SSE Transport implementation
-func newAuthSSETransport(baseURL, endpoint, token string) *authSSETransport {
+func newAuthSSETransport(baseURL, endpoint, token string, timeout time.Duration) *authSSETransport {
 	return &authSSETransport{
 		baseURL:   baseURL,
 		endpoint:  endpoint,
 		authToken: token,
 		client: &http.Client{
-			Timeout: 30 * time.Second,
+			Timeout: timeout,
 		},
 	}
 }
@@ -946,6 +946,17 @@ func (m *unifiedMCPManager) discoverToolsFromServer(ctx context.Context, serverN
 
 // createClientForServer creates appropriate client based on server type
 func (m *unifiedMCPManager) createClientForServer(server *core.MCPServerConfig) (*client.Client, error) {
+	// ConnectionTimeout doubles as the per-call response-wait timeout here —
+	// every call builds a fresh client/session (no connection reuse across
+	// ExecuteTool invocations), so there's no separate "connect vs. call"
+	// distinction to preserve. Falls back to 30s (the previous hardcoded
+	// value) when unset, so callers that never configure it keep today's
+	// behavior.
+	timeout := m.config.ConnectionTimeout
+	if timeout <= 0 {
+		timeout = 30 * time.Second
+	}
+
 	newClient := func(tr transport.Transport) *client.Client {
 		logger := log.New(io.Discard, "", 0)
 		if v := os.Getenv("MCP_NAVIGATOR_DEBUG"); v != "" && v != "0" {
@@ -955,7 +966,7 @@ func (m *unifiedMCPManager) createClientForServer(server *core.MCPServerConfig) 
 		cfg := client.ClientConfig{
 			Name:    "agentflow-mcp-client",
 			Version: "1.0.0",
-			Timeout: 30 * time.Second,
+			Timeout: timeout,
 			Logger:  logger,
 		}
 
@@ -996,7 +1007,7 @@ func (m *unifiedMCPManager) createClientForServer(server *core.MCPServerConfig) 
 
 		// Always use the custom SSE transport — it handles SSE-formatted responses
 		// and session IDs correctly. Pass empty token when no auth is needed.
-		sseTransport := newAuthSSETransport(baseURL, ssePath, authToken)
+		sseTransport := newAuthSSETransport(baseURL, ssePath, authToken, timeout)
 		return newClient(sseTransport), nil
 
 	case "http_streaming":
@@ -1028,7 +1039,7 @@ func (m *unifiedMCPManager) createClientForServer(server *core.MCPServerConfig) 
 
 		// Always use the custom streaming transport — it handles SSE-formatted responses
 		// and session IDs correctly. Pass empty token when no auth is needed.
-		streamingTransport := newAuthStreamingHTTPTransport(baseURL, streamPath, authToken)
+		streamingTransport := newAuthStreamingHTTPTransport(baseURL, streamPath, authToken, timeout)
 		return newClient(streamingTransport), nil
 
 	case "websocket":

--- a/plugins/mcp/unified/unified.go
+++ b/plugins/mcp/unified/unified.go
@@ -213,9 +213,20 @@ func (h *authStreamingHTTPTransport) Send(message *mcp.Message) error {
 		return nil
 	}
 
-	// Check if response is in SSE format (starts with "event:" or "data:")
+	// Check if response is in SSE format. Not just a prefix check: a
+	// streamable-HTTP connection can emit a leading keep-alive comment line
+	// (e.g. ": ping\n\n") before the real "event: message\ndata: {...}"
+	// frame — io.ReadAll captures both concatenated, so the real frame is
+	// no longer at byte 0. A strict HasPrefix("event:") here falls through
+	// to the plain-JSON branch below, which chokes on the leading ':' with
+	// "invalid character ':' looking for beginning of value". Checking
+	// Content-Type and/or scanning for the markers anywhere in the body
+	// (not just at the start) survives a leading comment line.
 	bodyStr := string(body)
-	if strings.HasPrefix(bodyStr, "event:") || strings.HasPrefix(bodyStr, "data:") {
+	looksLikeSSE := strings.Contains(resp.Header.Get("Content-Type"), "text/event-stream") ||
+		strings.HasPrefix(bodyStr, "event:") || strings.HasPrefix(bodyStr, "data:") ||
+		strings.Contains(bodyStr, "\nevent:") || strings.Contains(bodyStr, "\ndata:")
+	if looksLikeSSE {
 		logger().Debug().Msg("[Streaming] Response is in SSE format, parsing...")
 
 		// Parse SSE format to extract JSON data

--- a/plugins/skills/skills.go
+++ b/plugins/skills/skills.go
@@ -1,0 +1,318 @@
+// Package skills implements progressive-disclosure access to a directory of
+// SKILL.md packages, as a real v1beta.Tool instead of an app hand-rolling its
+// own pseudo-tool interception (the pattern this generalizes: a production
+// AGK app built exactly this from scratch — SkillCatalog rendered into the
+// system prompt at boot, bodies fetched on demand via a load_skill tool call
+// — because no such primitive existed anywhere in the framework).
+//
+// Design intentionally deviates from this repo's usual plugin convention
+// (blank-import + init(), see plugins/logging/zerolog): a skill directory is
+// a runtime value the caller supplies (there's no fixed name to register at
+// import time, unlike a logging provider's static "zerolog" key), so this
+// package exposes an explicit Install(dir) instead. Call it once at startup;
+// it registers the tool via v1beta.RegisterInternalTool and hands back the
+// rendered catalog string to splice into the agent's SystemPrompt (e.g. via
+// core.FormatPromptString, the same GoTemplate path v1beta already runs
+// system prompts through on every call).
+//
+// Bodies are intentionally NOT pre-loaded into the catalog or the system
+// prompt — only frontmatter (name/trigger/description/tags) is read at
+// Install time. A skill's full body is read from disk fresh on every
+// load_skill call, keeping memory flat regardless of corpus size.
+package skills
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	v1beta "github.com/agenticgokit/agenticgokit/v1beta"
+)
+
+// Entry is one skill's boot-time index record. Body is deliberately not
+// held here — see package doc.
+type Entry struct {
+	Name        string   // directory basename, or frontmatter "name" if set — canonical id passed to load_skill
+	Title       string   // frontmatter title, falls back to Name
+	Trigger     string   // frontmatter trigger, falls back to Description
+	Description string   // frontmatter description
+	Tags        []string // frontmatter tags
+	Path        string   // absolute path to SKILL.md
+}
+
+// Catalog is the boot-time index of on-disk skills under one directory.
+type Catalog struct {
+	Dir     string
+	Entries []Entry
+	paths   map[string]string // name -> SKILL.md path, built once by LoadCatalog
+}
+
+// LoadCatalog walks dir for SKILL.md files (one per skill subdirectory) and
+// indexes their frontmatter. Returns an empty catalog (nil error) for an
+// empty dir; error only for real FS failures — matching WithMCP's own
+// fail-open shape (a bad/missing skills dir shouldn't crash agent Build()).
+func LoadCatalog(dir string) (Catalog, error) {
+	cat := Catalog{Dir: dir}
+	if dir == "" {
+		return cat, nil
+	}
+	info, err := os.Stat(dir)
+	if err != nil {
+		return cat, fmt.Errorf("skills: dir %q: %w", dir, err)
+	}
+	if !info.IsDir() {
+		return cat, fmt.Errorf("skills: %q is not a directory", dir)
+	}
+
+	err = filepath.WalkDir(dir, func(path string, d os.DirEntry, werr error) error {
+		if werr != nil {
+			return werr
+		}
+		if d.IsDir() {
+			return nil
+		}
+		if strings.ToUpper(filepath.Base(path)) != "SKILL.MD" {
+			return nil
+		}
+		raw, rerr := os.ReadFile(path)
+		if rerr != nil {
+			return rerr
+		}
+		fm, _ := splitFrontmatter(string(raw))
+		name := filepath.Base(filepath.Dir(path))
+		e := Entry{
+			Name:        name,
+			Title:       firstNonEmpty(yamlString(fm, "title"), name),
+			Trigger:     yamlString(fm, "trigger"),
+			Description: yamlString(fm, "description"),
+			Tags:        yamlList(fm, "tags"),
+			Path:        path,
+		}
+		if fmName := yamlString(fm, "name"); fmName != "" {
+			e.Name = fmName
+		}
+		cat.Entries = append(cat.Entries, e)
+		return nil
+	})
+	sort.Slice(cat.Entries, func(i, j int) bool { return cat.Entries[i].Name < cat.Entries[j].Name })
+	cat.paths = make(map[string]string, len(cat.Entries))
+	for _, e := range cat.Entries {
+		cat.paths[e.Name] = e.Path
+	}
+	return cat, err
+}
+
+// Render returns compact markdown for injection into a system prompt: one
+// line per skill (name, trigger, tags). Bodies excluded by design.
+func (c Catalog) Render() string {
+	if len(c.Entries) == 0 {
+		return ""
+	}
+	var b strings.Builder
+	for _, e := range c.Entries {
+		hint := firstNonEmpty(e.Trigger, e.Description, e.Title)
+		fmt.Fprintf(&b, "- %s — %s", e.Name, singleLine(hint, 240))
+		if len(e.Tags) > 0 {
+			fmt.Fprintf(&b, " [tags: %s]", strings.Join(e.Tags, ","))
+		}
+		b.WriteByte('\n')
+	}
+	return b.String()
+}
+
+// Names returns the name -> SKILL.md path index.
+func (c Catalog) Names() map[string]string {
+	if c.paths != nil {
+		return c.paths
+	}
+	out := make(map[string]string, len(c.Entries))
+	for _, e := range c.Entries {
+		out[e.Name] = e.Path
+	}
+	return out
+}
+
+// LoadBody reads one skill's full SKILL.md body from disk on demand. Path
+// traversal is rejected by requiring name to match a catalog entry — dot
+// segments/absolute paths never resolve, since only base names are indexed.
+func (c Catalog) LoadBody(name string) (string, error) {
+	name = strings.TrimSpace(name)
+	if name == "" {
+		return "", fmt.Errorf("skills: empty skill name")
+	}
+	if strings.ContainsAny(name, "/\\") || strings.Contains(name, "..") {
+		return "", fmt.Errorf("skills: invalid skill name %q", name)
+	}
+	path, ok := c.Names()[name]
+	if !ok {
+		return "", fmt.Errorf("skills: %q not in catalog", name)
+	}
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return "", fmt.Errorf("skills: read %q: %w", name, err)
+	}
+	return string(raw), nil
+}
+
+// loadSkillTool adapts a Catalog into a v1beta.Tool + v1beta.ToolWithSchema,
+// so it dispatches through every real path a registered internal tool
+// reaches: capabilities.Tools.Execute (via sliceToolManager), step 3.5's
+// native/LLM-decided auto-tool-exec, and the package-level
+// v1beta.ExecuteToolByName — instead of an app hand-rolling its own
+// interception in its execution-loop code.
+type loadSkillTool struct{ cat Catalog }
+
+func (t *loadSkillTool) Name() string { return "load_skill" }
+
+func (t *loadSkillTool) Description() string {
+	return "Load the full body of one on-demand skill package by name. Only names listed in the skill catalog above are valid."
+}
+
+func (t *loadSkillTool) JSONSchema() map[string]interface{} {
+	return map[string]interface{}{
+		"type": "object",
+		"properties": map[string]interface{}{
+			"name": map[string]interface{}{
+				"type":        "string",
+				"description": "Exact skill name from the catalog.",
+			},
+		},
+		"required": []string{"name"},
+	}
+}
+
+func (t *loadSkillTool) Execute(ctx context.Context, args map[string]interface{}) (*v1beta.ToolResult, error) {
+	name, _ := args["name"].(string)
+	body, err := t.cat.LoadBody(name)
+	if err != nil {
+		return &v1beta.ToolResult{Success: false, Error: err.Error()}, err
+	}
+	return &v1beta.ToolResult{Success: true, Content: body}, nil
+}
+
+// Install loads the skill catalog at dir, registers it as the "load_skill"
+// internal tool (v1beta.RegisterInternalTool — the same hook
+// DiscoverInternalTools/createTools already calls unconditionally as Step 1,
+// no MCP required), and returns the catalog's rendered index for the caller
+// to splice into its own SystemPrompt.
+//
+// Call once at startup, before Builder.Build() — v1beta.RegisterInternalTool
+// writes into a package-level registry with no per-agent scoping, so
+// Installing two different directories in the same process under the same
+// tool name last-write-wins. One skills directory per process is the
+// supported shape; namespace the tool name yourself (a second Install call
+// with a different Name()) if you genuinely need more than one.
+//
+// The caller MUST also set ToolsConfig.Enabled = true (even with no MCP
+// servers configured) — createTools() returns early otherwise and Step 1
+// (DiscoverInternalTools) never runs. Confirmed via provider_factory.go;
+// documented here since it's the one non-obvious prerequisite.
+func Install(dir string) (catalogRender string, err error) {
+	cat, err := LoadCatalog(dir)
+	if err != nil {
+		return "", err
+	}
+	v1beta.RegisterInternalTool("load_skill", func() v1beta.Tool {
+		return &loadSkillTool{cat: cat}
+	})
+	return cat.Render(), nil
+}
+
+// --- minimal YAML frontmatter parser: enough for the SKILL.md dialect ---
+
+func splitFrontmatter(s string) (string, string) {
+	if !strings.HasPrefix(s, "---") {
+		return "", s
+	}
+	rest := strings.TrimPrefix(s, "---")
+	rest = strings.TrimLeft(rest, "\r\n")
+	end := strings.Index(rest, "\n---")
+	if end < 0 {
+		return "", s
+	}
+	fm := rest[:end]
+	body := rest[end+len("\n---"):]
+	body = strings.TrimLeft(body, "\r\n")
+	return fm, body
+}
+
+func yamlString(fm, key string) string {
+	prefix := key + ":"
+	for _, line := range strings.Split(fm, "\n") {
+		t := strings.TrimSpace(line)
+		if !strings.HasPrefix(t, prefix) {
+			continue
+		}
+		if line != t {
+			continue // indented (nested) key
+		}
+		return strings.Trim(strings.TrimSpace(strings.TrimPrefix(t, prefix)), `"'`)
+	}
+	return ""
+}
+
+// yamlList returns the top-level list scalar values for key. Handles the
+// hyphenated form:
+//
+//	tags:
+//	  - cubejs
+//	  - analytics
+func yamlList(fm, key string) []string {
+	prefix := key + ":"
+	lines := strings.Split(fm, "\n")
+	var out []string
+	inList := false
+	for _, line := range lines {
+		t := strings.TrimSpace(line)
+		if strings.HasPrefix(t, prefix) && line == t {
+			val := strings.TrimSpace(strings.TrimPrefix(t, prefix))
+			if val != "" && val != "[]" {
+				val = strings.Trim(val, "[]")
+				for _, p := range strings.Split(val, ",") {
+					if s := strings.Trim(strings.TrimSpace(p), `"'`); s != "" {
+						out = append(out, s)
+					}
+				}
+				return out
+			}
+			inList = true
+			continue
+		}
+		if inList {
+			if t == "" || strings.HasPrefix(t, "#") {
+				continue
+			}
+			if !strings.HasPrefix(line, "  ") && !strings.HasPrefix(line, "\t") {
+				return out
+			}
+			t = strings.TrimSpace(strings.TrimPrefix(t, "-"))
+			if t != "" {
+				out = append(out, strings.Trim(t, `"'`))
+			}
+		}
+	}
+	return out
+}
+
+func firstNonEmpty(vs ...string) string {
+	for _, v := range vs {
+		if strings.TrimSpace(v) != "" {
+			return v
+		}
+	}
+	return ""
+}
+
+func singleLine(s string, max int) string {
+	s = strings.TrimSpace(s)
+	if i := strings.IndexByte(s, '\n'); i >= 0 {
+		s = s[:i]
+	}
+	if len(s) > max {
+		s = s[:max] + "…"
+	}
+	return s
+}

--- a/plugins/skills/skills.go
+++ b/plugins/skills/skills.go
@@ -5,19 +5,28 @@
 // system prompt at boot, bodies fetched on demand via a load_skill tool call
 // — because no such primitive existed anywhere in the framework).
 //
-// Design intentionally deviates from this repo's usual plugin convention
-// (blank-import + init(), see plugins/logging/zerolog): a skill directory is
-// a runtime value the caller supplies (there's no fixed name to register at
-// import time, unlike a logging provider's static "zerolog" key), so this
-// package exposes an explicit Install(dir) instead. Call it once at startup;
-// it registers the tool via v1beta.RegisterInternalTool and hands back the
-// rendered catalog string to splice into the agent's SystemPrompt (e.g. via
-// core.FormatPromptString, the same GoTemplate path v1beta already runs
-// system prompts through on every call).
+// Two ways to wire this in, both end up registering the same load_skill Tool:
+//
+//  1. Declarative: blank-import this package (`_ "…/plugins/skills"`, its
+//     init() self-registers via v1beta.SetSkillsProviderFactory — same
+//     convention as plugins/logging/zerolog) and set
+//     Config.Tools.Skills.Dir (TOML-loadable: [tools.skills] dir = "..."),
+//     matching how MCP servers are configured. Builder.Build() then loads
+//     the catalog, appends the tool, and splices the rendered catalog into
+//     SystemPrompt itself — nothing else to call.
+//  2. Imperative: call Install(dir) directly at startup, before Build() —
+//     for callers who need the rendered catalog string themselves (e.g. to
+//     fold into a hand-built SystemPrompt via core.FormatPromptString,
+//     before ever constructing a Config).
+//
+// A skill directory is a runtime value either way — there's no fixed name
+// to register at import time the way a logging provider has a static
+// string key, which is why (1) still needs an explicit Dir/Install call
+// even though the registration itself is init()-based.
 //
 // Bodies are intentionally NOT pre-loaded into the catalog or the system
 // prompt — only frontmatter (name/trigger/description/tags) is read at
-// Install time. A skill's full body is read from disk fresh on every
+// load time. A skill's full body is read from disk fresh on every
 // load_skill call, keeping memory flat regardless of corpus size.
 package skills
 
@@ -219,6 +228,37 @@ func Install(dir string) (catalogRender string, err error) {
 		return &loadSkillTool{cat: cat}
 	})
 	return cat.Render(), nil
+}
+
+// catalogProvider adapts a Catalog into v1beta.SkillsProvider — the
+// declarative path (ToolsConfig.Skills.Dir, TOML-loadable) below, as
+// opposed to Install's direct/imperative path above. Both end up building
+// the same loadSkillTool; this one also hands back the rendered catalog so
+// Builder.Build() can splice it into SystemPrompt itself, since a TOML
+// config has no Go call site to receive that string the way Install's
+// caller does.
+type catalogProvider struct{ cat Catalog }
+
+func (p *catalogProvider) Tool() v1beta.Tool { return &loadSkillTool{cat: p.cat} }
+func (p *catalogProvider) Catalog() string   { return p.cat.Render() }
+
+// init registers this package as the skills provider for
+// ToolsConfig.Skills.Dir (v1beta/skills_provider.go's SetSkillsProviderFactory
+// hook) — same self-registration convention as this repo's other plugins
+// (e.g. plugins/logging/zerolog's init()). A blank import
+// (`_ "github.com/agenticgokit/agenticgokit/plugins/skills"`) plus setting
+// Config.Tools.Skills.Dir in TOML or Go is then enough; no Install() call
+// needed for this path. Install() itself still works unchanged for callers
+// who prefer the direct/imperative style (e.g. when the catalog string is
+// needed before Build() runs, to fold into a hand-built SystemPrompt).
+func init() {
+	v1beta.SetSkillsProviderFactory(func(dir string) (v1beta.SkillsProvider, error) {
+		cat, err := LoadCatalog(dir)
+		if err != nil {
+			return nil, err
+		}
+		return &catalogProvider{cat: cat}, nil
+	})
 }
 
 // --- minimal YAML frontmatter parser: enough for the SKILL.md dialect ---

--- a/plugins/skills/skills_test.go
+++ b/plugins/skills/skills_test.go
@@ -1,0 +1,154 @@
+package skills
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	v1beta "github.com/agenticgokit/agenticgokit/v1beta"
+)
+
+func writeSkill(t *testing.T, root, name, frontmatter, body string) {
+	t.Helper()
+	dir := filepath.Join(root, name)
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	content := "---\n" + frontmatter + "\n---\n" + body
+	if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestLoadCatalog_IndexesFrontmatterOnly(t *testing.T) {
+	root := t.TempDir()
+	writeSkill(t, root, "kantar-segmentation-q-query",
+		"title: Kantar Shopping Mission Segmentation\ntrigger: User asks for Kantar segmentation\ntags:\n  - retail\n  - segmentation",
+		"## Concept\nLong body that should NOT be in the catalog render.")
+
+	cat, err := LoadCatalog(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cat.Entries) != 1 {
+		t.Fatalf("Entries = %d, want 1", len(cat.Entries))
+	}
+	e := cat.Entries[0]
+	if e.Name != "kantar-segmentation-q-query" {
+		t.Errorf("Name = %q", e.Name)
+	}
+	if e.Trigger != "User asks for Kantar segmentation" {
+		t.Errorf("Trigger = %q", e.Trigger)
+	}
+	if len(e.Tags) != 2 || e.Tags[0] != "retail" {
+		t.Errorf("Tags = %v", e.Tags)
+	}
+
+	render := cat.Render()
+	if !strings.Contains(render, "kantar-segmentation-q-query") {
+		t.Errorf("Render() missing skill name: %q", render)
+	}
+	if strings.Contains(render, "Long body") {
+		t.Errorf("Render() leaked the body, want frontmatter-only: %q", render)
+	}
+}
+
+func TestCatalog_LoadBody_RejectsPathTraversal(t *testing.T) {
+	root := t.TempDir()
+	writeSkill(t, root, "safe-skill", "title: Safe", "body text")
+
+	cat, err := LoadCatalog(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := cat.LoadBody("../../etc/passwd"); err == nil {
+		t.Error("LoadBody accepted a path-traversal name, want rejection")
+	}
+	if _, err := cat.LoadBody("does-not-exist"); err == nil {
+		t.Error("LoadBody accepted an unknown skill name, want rejection")
+	}
+	body, err := cat.LoadBody("safe-skill")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(body, "body text") {
+		t.Errorf("LoadBody = %q, want the real body", body)
+	}
+}
+
+// Reproduces the real 2026-07-16 production incident this whole plugin
+// generalizes: Planning loaded a skill, then re-requested the SAME skill
+// two iterations later because a hand-rolled loop's currentInput had
+// silently dropped the body. As a REAL v1beta.Tool, load_skill dispatches
+// through v1beta.ExecuteToolByName like any other registered tool — an app
+// no longer needs its own bespoke interception/dedup machinery just to call
+// it twice safely; both calls simply return the real body, deterministically,
+// straight from disk.
+func TestInstall_RegistersARealToolReachableThroughExecuteToolByName(t *testing.T) {
+	root := t.TempDir()
+	writeSkill(t, root, "kantar-segmentation-q-query",
+		"trigger: Kantar segmentation questions",
+		"Look for a dimension matching shopping mission / trip purpose.")
+
+	render, err := Install(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(render, "kantar-segmentation-q-query") {
+		t.Fatalf("Install's rendered catalog missing the skill: %q", render)
+	}
+
+	tools, err := v1beta.DiscoverInternalTools()
+	if err != nil {
+		t.Fatal(err)
+	}
+	var tool v1beta.Tool
+	for _, tl := range tools {
+		if tl.Name() == "load_skill" {
+			tool = tl
+			break
+		}
+	}
+	if tool == nil {
+		t.Fatal("load_skill not found among DiscoverInternalTools() results")
+	}
+
+	// Call it twice, exactly the sequence that bit the hand-rolled version —
+	// both must return the real body since there's no ephemeral currentInput
+	// string in between to lose it from.
+	for i := 0; i < 2; i++ {
+		result, err := tool.Execute(context.Background(), map[string]interface{}{"name": "kantar-segmentation-q-query"})
+		if err != nil {
+			t.Fatalf("call %d: %v", i, err)
+		}
+		body, _ := result.Content.(string)
+		if !strings.Contains(body, "shopping mission") {
+			t.Errorf("call %d: body = %q, want the real skill content", i, body)
+		}
+	}
+
+	if ws, ok := tool.(v1beta.ToolWithSchema); ok {
+		schema := ws.JSONSchema()
+		if schema["type"] != "object" {
+			t.Errorf("JSONSchema() type = %v, want object", schema["type"])
+		}
+	} else {
+		t.Error("load_skill tool does not implement ToolWithSchema — native tool-calling models get no schema")
+	}
+}
+
+func TestLoadCatalog_EmptyDirIsNotAnError(t *testing.T) {
+	cat, err := LoadCatalog("")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(cat.Entries) != 0 {
+		t.Errorf("Entries = %v, want empty", cat.Entries)
+	}
+	if cat.Render() != "" {
+		t.Errorf("Render() = %q, want empty for an empty catalog", cat.Render())
+	}
+}

--- a/plugins/skills/skills_test.go
+++ b/plugins/skills/skills_test.go
@@ -152,3 +152,34 @@ func TestLoadCatalog_EmptyDirIsNotAnError(t *testing.T) {
 		t.Errorf("Render() = %q, want empty for an empty catalog", cat.Render())
 	}
 }
+
+// Confirms this package's init() self-registers the declarative path
+// (v1beta.SetSkillsProviderFactory) purely by being imported — a caller
+// only has to set Config.Tools.Skills.Dir (TOML-loadable) and blank-import
+// this package; no Install() call needed. v1beta.GetSkillsProviderFactory
+// is the only external signal for "did init() actually run" short of a
+// live Build() call — see its doc comment.
+func TestInit_SelfRegistersDeclarativeFactory(t *testing.T) {
+	root := t.TempDir()
+	writeSkill(t, root, "declarative-skill", "trigger: test", "declarative body")
+
+	factory := v1beta.GetSkillsProviderFactory()
+	if factory == nil {
+		t.Fatal("v1beta.GetSkillsProviderFactory() = nil — this package's init() did not self-register")
+	}
+
+	provider, err := factory(root)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(provider.Catalog(), "declarative-skill") {
+		t.Errorf("Catalog() = %q, want it to list declarative-skill", provider.Catalog())
+	}
+	result, err := provider.Tool().Execute(context.Background(), map[string]interface{}{"name": "declarative-skill"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.Contains(result.Content.(string), "declarative body") {
+		t.Errorf("Tool().Execute content = %v, want the real body", result.Content)
+	}
+}

--- a/v1beta/agent.go
+++ b/v1beta/agent.go
@@ -484,15 +484,47 @@ type AgentMetrics struct {
 	SessionsActive   int           `json:"sessions_active"`
 }
 
-// AgentMiddleware defines the interface for agent middleware
-// Middleware can intercept and modify the agent execution flow
+// AgentMiddleware defines the interface for agent middleware.
+// Middleware can intercept and modify the agent execution flow.
+//
+// Wired 2026-07-14: this interface was previously declared but never
+// invoked anywhere (zero call sites in agent_impl.go/builder.go, zero
+// implementations anywhere in the repo — confirmed before this change).
+// Register middleware via the WithMiddleware Option; realAgent.execute runs
+// BeforeRun in registration order, then AfterRun in reverse order (LIFO),
+// matching standard middleware chaining. RunOptions.SkipMiddleware disables
+// a middleware for one run by Name().
+//
+// Deliberately shallow: BeforeRun/AfterRun only wrap the single outer
+// execute() call. They do NOT see per-attempt state from
+// llm.CircuitBreakerProvider's internal retries (those
+// happen inside a.llmProvider.Call(), invisible here), nor per-iteration
+// state from the reasoning/tool-continuation loop
+// (executeNativeToolsAndContinue's local iteration/maxIterations, currently
+// never exposed via context). Threading either through is a real scope
+// increase with no current consumer; revisit if a middleware actually needs
+// it. Also only wired for Run/RunWithOptions (the execute() choke point) —
+// RunStream/RunStreamWithOptions do not go through execute() and do not
+// invoke middleware.
 type AgentMiddleware interface {
-	// BeforeRun is called before the agent execution
-	// It can modify the context and input, or cancel the execution
+	// Name identifies this middleware for RunOptions.SkipMiddleware.
+	Name() string
+
+	// BeforeRun is called before the agent execution, in registration
+	// order. It can modify the context and input, or abort the run by
+	// returning a non-nil error (wrapped as ErrMiddlewareBeforeRun; no
+	// LLM call happens for a run aborted this way).
 	BeforeRun(ctx context.Context, input string) (context.Context, string, error)
 
-	// AfterRun is called after the agent execution
-	// It can modify the result or handle errors
+	// AfterRun is called after the agent execution (or after a prior
+	// middleware's AfterRun), in reverse registration order. It receives
+	// whatever result/err the previous stage produced and returns what the
+	// next stage (or the caller) sees — it may pass both through unchanged,
+	// replace the result, or replace/clear the error. Unlike BeforeRun's
+	// error, AfterRun's returned error is NOT wrapped as
+	// ErrMiddlewareAfterRun: a middleware here is expected to make
+	// deliberate error-replacement decisions (e.g. eino's RewriteError
+	// pattern), not just report its own infra failures.
 	AfterRun(ctx context.Context, input string, result *Result, err error) (*Result, error)
 }
 

--- a/v1beta/agent_impl.go
+++ b/v1beta/agent_impl.go
@@ -245,6 +245,32 @@ func newRealAgent(config *Config, handler HandlerFunc) (Agent, error) {
 			return nil, fmt.Errorf("failed to create tools: %w", err)
 		}
 		agent.tools = tools
+
+		// Skills (declarative, TOML-loadable): ToolsConfig.Skills.Dir names a
+		// directory, but the actual frontmatter-parsing/loading logic lives
+		// in a separate plugin (e.g. plugins/skills) to avoid v1beta
+		// depending on it — see SkillsProvider's doc comment (skills_
+		// provider.go) for why this is a registered-factory hook, not a
+		// direct call, same shape as ToolManagerFactory just above it in
+		// spirit. A Dir set with no factory registered is logged, not
+		// treated as an error: config alone can't distinguish a missing
+		// blank-import from a stale leftover value.
+		if config.Tools.Skills != nil && config.Tools.Skills.Dir != "" {
+			if factory := GetSkillsProviderFactory(); factory != nil {
+				provider, serr := factory(config.Tools.Skills.Dir)
+				if serr != nil {
+					Logger().Warn().Err(serr).Str("dir", config.Tools.Skills.Dir).Msg("failed to load skills provider")
+				} else if provider != nil {
+					agent.tools = append(agent.tools, provider.Tool())
+					if catalog := provider.Catalog(); catalog != "" {
+						config.SystemPrompt = config.SystemPrompt + "\n\n[Available skills — call load_skill(name) to fetch one's full body on demand]\n" + catalog
+					}
+				}
+			} else {
+				Logger().Warn().Str("dir", config.Tools.Skills.Dir).
+					Msg("ToolsConfig.Skills.Dir set but no skills provider registered — blank-import a skills plugin (e.g. plugins/skills) to enable it")
+			}
+		}
 	}
 
 	// Mark as initialized

--- a/v1beta/agent_impl.go
+++ b/v1beta/agent_impl.go
@@ -383,9 +383,17 @@ func (a *realAgent) executeInner(ctx context.Context, input string, opts *RunOpt
 		return nil, fmt.Errorf("agent not properly initialized: LLM provider is nil")
 	}
 
-	// Step 1: Build the prompt with system context and user input
+	// Step 1: Build the prompt with system context and user input.
+	// SystemPrompt goes through core.FormatPromptString (GoTemplate syntax)
+	// before use — a plain-text prompt with no {{ }} directives passes
+	// through unchanged, but callers can now build SystemPrompt with
+	// {{.Input}} or other vars instead of "+=" string concatenation.
+	systemPrompt, err := core.FormatPromptString(a.config.SystemPrompt, map[string]any{"Input": input}, core.FormatGoTemplate)
+	if err != nil {
+		return nil, fmt.Errorf("agent %s: format system prompt: %w", a.config.Name, err)
+	}
 	prompt := llm.Prompt{
-		System: a.config.SystemPrompt,
+		System: systemPrompt,
 		User:   input,
 	}
 
@@ -393,7 +401,7 @@ func (a *realAgent) executeInner(ctx context.Context, input string, opts *RunOpt
 	if observability.IsDetailedTracing() {
 		span.SetAttributes(
 			attribute.String(observability.AttrPromptUser, observability.TruncateForTrace(input, observability.MaxContentLength)),
-			attribute.String(observability.AttrPromptSystem, observability.TruncateForTrace(a.config.SystemPrompt, observability.MaxContentLength)),
+			attribute.String(observability.AttrPromptSystem, observability.TruncateForTrace(systemPrompt, observability.MaxContentLength)),
 		)
 	}
 
@@ -937,9 +945,22 @@ func (a *realAgent) RunStream(ctx context.Context, input string, opts ...StreamO
 
 		startTime := time.Now()
 
-		// Build prompt (similar to Run method)
+		// Build prompt (similar to Run method). SystemPrompt goes through
+		// core.FormatPromptString the same way the non-streaming path does —
+		// see executeInner for why.
+		systemPrompt, err := core.FormatPromptString(a.config.SystemPrompt, map[string]any{"Input": input}, core.FormatGoTemplate)
+		if err != nil {
+			span.RecordError(err)
+			span.SetStatus(codes.Error, err.Error())
+			writer.Write(&StreamChunk{
+				Type:  ChunkTypeError,
+				Error: fmt.Errorf("agent %s: format system prompt: %w", a.config.Name, err),
+			})
+			a.updateMetrics(startTime, true)
+			return
+		}
 		prompt := llm.Prompt{
-			System: a.config.SystemPrompt,
+			System: systemPrompt,
 			User:   input,
 			Parameters: llm.ModelParameters{
 				Temperature: convertFloat32ToFloat32Ptr(a.config.LLM.Temperature),
@@ -951,7 +972,7 @@ func (a *realAgent) RunStream(ctx context.Context, input string, opts ...StreamO
 		if observability.IsDetailedTracing() {
 			span.SetAttributes(
 				attribute.String(observability.AttrPromptUser, observability.TruncateForTrace(input, observability.MaxContentLength)),
-				attribute.String(observability.AttrPromptSystem, observability.TruncateForTrace(a.config.SystemPrompt, observability.MaxContentLength)),
+				attribute.String(observability.AttrPromptSystem, observability.TruncateForTrace(systemPrompt, observability.MaxContentLength)),
 			)
 		}
 

--- a/v1beta/agent_impl.go
+++ b/v1beta/agent_impl.go
@@ -88,6 +88,7 @@ type realAgent struct {
 	llmProvider    llm.ModelProvider // LLM provider (Ollama, OpenAI, Azure, etc.)
 	memoryProvider core.Memory       // Memory provider (optional, for context/RAG)
 	tools          []Tool            // Tools available to the agent (optional)
+	middlewares    []AgentMiddleware // Run around execute(); see AgentMiddleware doc comment
 
 	// Runtime state
 	initialized bool
@@ -155,6 +156,7 @@ func newRealAgent(config *Config, handler HandlerFunc) (Agent, error) {
 		handler:     handler,
 		initialized: false,
 		sessions:    make(map[string]*sessionState),
+		middlewares: config.Middlewares,
 		metrics: &agentMetrics{
 			totalRuns:     0,
 			totalErrors:   0,
@@ -188,11 +190,11 @@ func newRealAgent(config *Config, handler HandlerFunc) (Agent, error) {
 		// "unset" and just assumed true either way — meaning
 		// &MemoryConfig{Enabled: false} (the ONLY way to opt out of the
 		// nil-defaults-to-chromem behavior above) was silently overridden
-		// back to enabled. Confirmed live: cubejs-agentic-chat's Planning/
-		// Router/Consolidation agents all explicitly disable memory (they
-		// have their own memory-retrieval path and don't want this
-		// framework's automatic chromem-backed enrichment+auto-store), and
-		// every .Info() log line proved it was running anyway. A caller
+		// back to enabled. Confirmed live: a downstream agent that
+		// explicitly disables memory (it has its own memory-retrieval path
+		// and doesn't want this framework's automatic chromem-backed
+		// enrichment+auto-store) had every .Info() log line proving it was
+		// running anyway. A caller
 		// that provides a non-nil *MemoryConfig is explicit about intent by
 		// definition — trust config.Memory.Enabled as given; only fill in
 		// the embedding-provider smart-defaults below when they actually
@@ -294,8 +296,70 @@ func (a *realAgent) Run(ctx context.Context, input string) (*Result, error) {
 	return a.execute(ctx, input, nil)
 }
 
-// execute contains the core execution logic, shared between Run and RunWithOptions
+// execute wraps executeInner with AgentMiddleware's BeforeRun/AfterRun (see
+// AgentMiddleware doc comment for ordering and scope). With no middlewares
+// registered (a.middlewares is nil — every existing caller, today) this is
+// behaviorally identical to calling executeInner directly.
 func (a *realAgent) execute(ctx context.Context, input string, opts *RunOptions) (*Result, error) {
+	ctx, input, err := a.runBeforeMiddleware(ctx, input, opts)
+	if err != nil {
+		return nil, err
+	}
+	result, err := a.executeInner(ctx, input, opts)
+	return a.runAfterMiddleware(ctx, input, result, err, opts)
+}
+
+// skippedMiddleware returns a lookup set built from opts.SkipMiddleware.
+// Safe to call with a nil opts or empty SkipMiddleware; the returned nil map
+// makes every lookup false, so callers don't need a separate nil check.
+func skippedMiddleware(opts *RunOptions) map[string]bool {
+	if opts == nil || len(opts.SkipMiddleware) == 0 {
+		return nil
+	}
+	skip := make(map[string]bool, len(opts.SkipMiddleware))
+	for _, name := range opts.SkipMiddleware {
+		skip[name] = true
+	}
+	return skip
+}
+
+// runBeforeMiddleware runs each non-skipped middleware's BeforeRun in
+// registration order, threading ctx/input through the chain. The first
+// error aborts the run before executeInner is called (no LLM call happens).
+func (a *realAgent) runBeforeMiddleware(ctx context.Context, input string, opts *RunOptions) (context.Context, string, error) {
+	skip := skippedMiddleware(opts)
+	for _, mw := range a.middlewares {
+		if skip[mw.Name()] {
+			continue
+		}
+		var err error
+		ctx, input, err = mw.BeforeRun(ctx, input)
+		if err != nil {
+			return ctx, input, NewAgentErrorWithError(ErrMiddlewareBeforeRun,
+				fmt.Sprintf("middleware %q BeforeRun failed", mw.Name()), err)
+		}
+	}
+	return ctx, input, nil
+}
+
+// runAfterMiddleware runs each non-skipped middleware's AfterRun in reverse
+// registration order (LIFO), each stage seeing the result/err the previous
+// stage (or executeInner) produced. See AgentMiddleware doc comment for why
+// AfterRun's returned error is passed through unwrapped.
+func (a *realAgent) runAfterMiddleware(ctx context.Context, input string, result *Result, runErr error, opts *RunOptions) (*Result, error) {
+	skip := skippedMiddleware(opts)
+	for i := len(a.middlewares) - 1; i >= 0; i-- {
+		mw := a.middlewares[i]
+		if skip[mw.Name()] {
+			continue
+		}
+		result, runErr = mw.AfterRun(ctx, input, result, runErr)
+	}
+	return result, runErr
+}
+
+// executeInner contains the core execution logic, shared between Run and RunWithOptions
+func (a *realAgent) executeInner(ctx context.Context, input string, opts *RunOptions) (*Result, error) {
 	startTime := time.Now()
 
 	tracer := observability.GetTracer("agk.v1beta.agent")

--- a/v1beta/agent_impl.go
+++ b/v1beta/agent_impl.go
@@ -22,6 +22,14 @@ import (
 	"go.opentelemetry.io/otel/trace"
 )
 
+// APIStatusError is a re-export of internal/llm.APIStatusError — external
+// callers (Go's "internal" import rule blocks reaching internal/llm
+// directly from outside this module, even via a go.mod replace) can use
+// errors.As(err, &v1beta.APIStatusError{}) against a Run()/execute() error
+// to classify a non-200 LLM-endpoint response by its actual StatusCode
+// instead of matching substrings against the error text.
+type APIStatusError = llm.APIStatusError
+
 // addMultimodalDataToPrompt adds multimodal data from RunOptions to an llm.Prompt.
 // This is a helper to avoid code duplication between execute and streaming methods.
 func addMultimodalDataToPrompt(prompt *llm.Prompt, opts *RunOptions) {

--- a/v1beta/agent_impl.go
+++ b/v1beta/agent_impl.go
@@ -574,9 +574,21 @@ func (a *realAgent) executeInner(ctx context.Context, input string, opts *RunOpt
 				}
 				return resp.Content, nil
 			},
-			// Tools and Memory would be provided here if available
-			// Tools:  a.tools,
-			// Memory: a.memoryProvider,
+			// Tools: real as of this fix (sliceToolManager, capabilities_tools.go)
+			// — reads a.tools fresh so RunWithOptions' per-call ToolMode
+			// filtering (see :776-796) is respected. nil only when no tools
+			// were configured, same contract docs/custom-handlers.md's own
+			// "Capability Checks" section already tells callers to expect.
+			//
+			// Memory: still nil. a.memoryProvider is core.Memory (legacy,
+			// different method signatures — Store(ctx,content,tags...) vs
+			// v1beta.Memory's Store(ctx,content,opts...StoreOption), and no
+			// IngestDocument/SearchKnowledge/BuildContext at all) — cannot be
+			// wired without either a lossy adapter or an interface-level
+			// decision, tracked separately, not bundled into this fix.
+		}
+		if len(a.tools) > 0 {
+			capabilities.Tools = newSliceToolManager(a.tools)
 		}
 
 		handlerResponse, err := a.handler(ctx, finalResponse, capabilities)
@@ -1116,6 +1128,11 @@ func (a *realAgent) RunStream(ctx context.Context, input string, opts ...StreamO
 					}
 					return resp.Content, nil
 				},
+			}
+			// Mirrors execute()'s wiring above — see its comment for why
+			// Tools is real (sliceToolManager) and Memory is still nil.
+			if len(a.tools) > 0 {
+				capabilities.Tools = newSliceToolManager(a.tools)
 			}
 			handlerResponse, err := a.handler(streamCtx, finalContent, capabilities)
 			if err != nil {

--- a/v1beta/agent_impl.go
+++ b/v1beta/agent_impl.go
@@ -181,14 +181,22 @@ func newRealAgent(config *Config, handler HandlerFunc) (Agent, error) {
 				KnowledgeWeight: 0.7,
 			},
 		}
-	} else {
-		// If MemoryConfig is provided, ensure it's Enabled by default unless explicitly false
-		// Actually, we should probably just treat a non-nil MemoryConfig as wanting memory.
-		// But follow the Enabled flag if it's there.
-		// Simple fix: if a config is there, we default Enabled to true if not specified.
-		// Since we can't tell if it's explicitly false or just default, we'll assume
-		// if they provided a config object, they probably want it enabled.
-		config.Memory.Enabled = true
+	} else if config.Memory.Enabled {
+		// Fixed 2026-07-10: this branch used to unconditionally force
+		// config.Memory.Enabled = true regardless of what the caller set,
+		// with a comment admitting it couldn't tell "explicitly false" from
+		// "unset" and just assumed true either way — meaning
+		// &MemoryConfig{Enabled: false} (the ONLY way to opt out of the
+		// nil-defaults-to-chromem behavior above) was silently overridden
+		// back to enabled. Confirmed live: cubejs-agentic-chat's Planning/
+		// Router/Consolidation agents all explicitly disable memory (they
+		// have their own memory-retrieval path and don't want this
+		// framework's automatic chromem-backed enrichment+auto-store), and
+		// every .Info() log line proved it was running anyway. A caller
+		// that provides a non-nil *MemoryConfig is explicit about intent by
+		// definition — trust config.Memory.Enabled as given; only fill in
+		// the embedding-provider smart-defaults below when they actually
+		// asked for memory.
 
 		// Smart Default: If no embedding provider is specified, try to use the LLM provider
 		if config.Memory.Options == nil {

--- a/v1beta/builder.go
+++ b/v1beta/builder.go
@@ -117,6 +117,15 @@ func WithDebugMode(enabled bool) Option {
 	}
 }
 
+// WithMiddleware registers one or more AgentMiddleware, appended to any
+// already set. Order matters: BeforeRun runs in this order, AfterRun in
+// reverse (see AgentMiddleware doc comment).
+func WithMiddleware(mw ...AgentMiddleware) Option {
+	return func(c *Config) {
+		c.Middlewares = append(c.Middlewares, mw...)
+	}
+}
+
 // MemoryOption defines functional options for memory configuration
 type MemoryOption func(*MemoryConfig)
 

--- a/v1beta/builder.go
+++ b/v1beta/builder.go
@@ -234,6 +234,27 @@ func WithToolTimeout(timeout time.Duration) ToolOption {
 	}
 }
 
+// WithMCPConnectionTimeout overrides the MCP client's per-call timeout —
+// separate from WithToolTimeout's tc.Timeout, and separate from tc.MCP's own
+// ConnectionTimeout default (30s, set by WithMCP when tc.MCP is first
+// created). Call AFTER WithMCP so tc.MCP already exists. Confirmed live
+// 2026-07-15: plugins/mcp/unified.go hardcodes 30s in three places (the
+// mcp-navigator client's own response-wait timeout, and both the
+// authStreamingHTTPTransport/authSSETransport http.Client timeouts) with no
+// way to override from a consuming app — a legitimately slow-but-working MCP
+// tool call (e.g. a discovery tool probing many cubes/resources
+// sequentially) gets aborted at exactly 30s regardless of any other
+// configured timeout, surfacing as a confusing transport-level error instead
+// of a clean, expected timeout.
+func WithMCPConnectionTimeout(timeout time.Duration) ToolOption {
+	return func(tc *ToolsConfig) {
+		if tc.MCP == nil {
+			tc.MCP = &MCPConfig{Enabled: true}
+		}
+		tc.MCP.ConnectionTimeout = timeout
+	}
+}
+
 // WithMaxConcurrentTools sets the maximum concurrent tool executions
 func WithMaxConcurrentTools(max int) ToolOption {
 	return func(tc *ToolsConfig) {

--- a/v1beta/capabilities_tools.go
+++ b/v1beta/capabilities_tools.go
@@ -1,0 +1,112 @@
+package v1beta
+
+import (
+	"context"
+	"fmt"
+)
+
+// sliceToolManager adapts the already-discovered []Tool slice (populated by
+// createTools during Build(), consumed today only by step 3.5's
+// executeToolsAndContinue/executeNativeToolsAndContinue) into the ToolManager
+// interface, so a custom HandlerFunc's Capabilities.Tools is real instead of
+// always nil.
+//
+// Why this exists, not NewToolManager/basicToolManager: ToolManager's own
+// constructor (tools.go:159) falls back to basicToolManager whenever no
+// ToolManagerFactory is registered via SetToolManagerFactory — and nothing in
+// this module or its plugins/* ever calls that (confirmed repo-wide grep).
+// basicToolManager.Execute unconditionally returns "no tool plugin
+// registered" — every ToolManager built via NewToolManager in this codebase
+// is that non-functional stub today. Wiring capabilities.Tools to it would
+// compile and look wired without ever actually running a tool, silently
+// worse than the current nil (docs/v1beta/custom-handlers.md's own
+// "Tool-Augmented"/"Research Assistant" examples call capabilities.Tools.Execute
+// unconditionally and would get this error text back instead of a result).
+// sliceToolManager instead executes against the SAME []Tool the framework's
+// own auto-tool-exec step already resolved and connected (MCP included),
+// so a handler sees exactly the tools WithTools(...) configured.
+//
+// Built fresh per call (agent_impl.go's two Capabilities{} construction
+// sites), not cached on realAgent — a.tools is intentionally mutated
+// per-call by RunWithOptions' ToolMode="specific"/"none" filtering
+// (agent_impl.go:776-796), and a stale cached manager would silently ignore
+// that per-run restriction.
+type sliceToolManager struct {
+	tools []Tool
+}
+
+func newSliceToolManager(tools []Tool) ToolManager {
+	return &sliceToolManager{tools: tools}
+}
+
+func (m *sliceToolManager) Execute(ctx context.Context, name string, args map[string]interface{}) (*ToolResult, error) {
+	for _, t := range m.tools {
+		if t.Name() == name {
+			return t.Execute(ctx, args)
+		}
+	}
+	return &ToolResult{Success: false, Error: fmt.Sprintf("tool %q not found among this agent's configured tools", name)},
+		fmt.Errorf("tool %q not found", name)
+}
+
+func (m *sliceToolManager) List() []ToolInfo {
+	out := make([]ToolInfo, 0, len(m.tools))
+	for _, t := range m.tools {
+		info := ToolInfo{Name: t.Name(), Description: t.Description()}
+		if ws, ok := t.(ToolWithSchema); ok {
+			info.Parameters = ws.JSONSchema()
+		}
+		out = append(out, info)
+	}
+	return out
+}
+
+func (m *sliceToolManager) Available() []string {
+	out := make([]string, 0, len(m.tools))
+	for _, t := range m.tools {
+		out = append(out, t.Name())
+	}
+	return out
+}
+
+func (m *sliceToolManager) IsAvailable(name string) bool {
+	for _, t := range m.tools {
+		if t.Name() == name {
+			return true
+		}
+	}
+	return false
+}
+
+// MCP connection management, health, and metrics are intentionally NOT
+// no-op-succeed here: this adapter wraps a fixed snapshot of tools resolved
+// once at Build()/RunWithOptions time, and pretending an MCP reconnect or a
+// health check ran against it (returning a fake nil/empty success) is the
+// exact swallowed-error shape that already caused one real production
+// incident in this framework (the stdio transport argv-passing bug
+// surfacing only as "0 tools, suspiciously fast" instead of a build error —
+// see go-implementation-gotchas). A clear error instead tells the caller
+// what's actually true: reconfigure tools via WithTools(WithMCP(...)) and
+// rebuild/Clone() the agent, there is no dynamic reconnect at this layer.
+func (m *sliceToolManager) ConnectMCP(ctx context.Context, servers ...MCPServer) error {
+	return fmt.Errorf("sliceToolManager: dynamic MCP connection not supported; configure servers via WithTools(WithMCP(...)) and rebuild the agent")
+}
+
+func (m *sliceToolManager) DisconnectMCP(serverName string) error {
+	return fmt.Errorf("sliceToolManager: dynamic MCP disconnection not supported; tools are fixed at Build() time")
+}
+
+func (m *sliceToolManager) DiscoverMCP(ctx context.Context) ([]MCPServerInfo, error) {
+	return nil, fmt.Errorf("sliceToolManager: MCP server discovery not supported; use v1beta.DiscoverTools() or inspect config.Tools.MCP instead")
+}
+
+func (m *sliceToolManager) HealthCheck(ctx context.Context) map[string]MCPHealthStatus {
+	return map[string]MCPHealthStatus{}
+}
+
+func (m *sliceToolManager) GetMetrics() ToolMetrics {
+	return ToolMetrics{ToolMetrics: make(map[string]ToolSpecificMetrics)}
+}
+
+func (m *sliceToolManager) Initialize(ctx context.Context) error { return nil }
+func (m *sliceToolManager) Shutdown(ctx context.Context) error   { return nil }

--- a/v1beta/capabilities_tools_test.go
+++ b/v1beta/capabilities_tools_test.go
@@ -1,0 +1,91 @@
+package v1beta
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+type fakeCalcTool struct{ calls int }
+
+func (t *fakeCalcTool) Name() string        { return "calculator" }
+func (t *fakeCalcTool) Description() string { return "adds two numbers" }
+func (t *fakeCalcTool) Execute(ctx context.Context, args map[string]interface{}) (*ToolResult, error) {
+	t.calls++
+	return &ToolResult{Success: true, Content: 4}, nil
+}
+
+// Reproduces docs/v1beta/custom-handlers.md's own "Tool-Augmented" example
+// contract: a HandlerFunc calling capabilities.Tools.Execute(ctx, name, args)
+// directly. Before this fix, Capabilities.Tools was always nil at both
+// construction sites in agent_impl.go (commented out) — any handler written
+// exactly as the docs show would nil-pointer-panic on capabilities.Tools.Execute.
+func TestSliceToolManager_ExecuteRunsTheRealTool(t *testing.T) {
+	tool := &fakeCalcTool{}
+	tm := newSliceToolManager([]Tool{tool})
+
+	result, err := tm.Execute(context.Background(), "calculator", map[string]interface{}{"a": 2, "b": 2})
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if !result.Success || result.Content != 4 {
+		t.Errorf("Execute result = %+v, want Success=true Content=4", result)
+	}
+	if tool.calls != 1 {
+		t.Errorf("underlying tool called %d times, want 1", tool.calls)
+	}
+}
+
+func TestSliceToolManager_ExecuteUnknownToolIsAnHonestError(t *testing.T) {
+	tm := newSliceToolManager([]Tool{&fakeCalcTool{}})
+
+	result, err := tm.Execute(context.Background(), "web_search", nil)
+	if err == nil {
+		t.Fatal("expected an error for a tool not in this agent's configured list")
+	}
+	if result.Success {
+		t.Errorf("result.Success = true, want false: %+v", result)
+	}
+	if !strings.Contains(result.Error, "web_search") {
+		t.Errorf("result.Error = %q, want it to name the missing tool", result.Error)
+	}
+}
+
+func TestSliceToolManager_ListAvailableIsAvailable(t *testing.T) {
+	tm := newSliceToolManager([]Tool{&fakeCalcTool{}})
+
+	if !tm.IsAvailable("calculator") {
+		t.Error("IsAvailable(calculator) = false, want true")
+	}
+	if tm.IsAvailable("web_search") {
+		t.Error("IsAvailable(web_search) = true, want false")
+	}
+	avail := tm.Available()
+	if len(avail) != 1 || avail[0] != "calculator" {
+		t.Errorf("Available() = %v, want [calculator]", avail)
+	}
+	list := tm.List()
+	if len(list) != 1 || list[0].Name != "calculator" || list[0].Description != "adds two numbers" {
+		t.Errorf("List() = %+v, want one ToolInfo for calculator", list)
+	}
+}
+
+// ConnectMCP/DisconnectMCP/DiscoverMCP must fail loudly, not silently
+// no-op-succeed — this adapter wraps a fixed snapshot of tools, and a fake
+// success here would repeat the swallowed-error shape that already caused a
+// real production incident in this framework (stdio transport argv bug
+// surfacing as "0 tools" instead of a build error).
+func TestSliceToolManager_MCPOperationsFailLoudlyNotSilently(t *testing.T) {
+	tm := newSliceToolManager([]Tool{&fakeCalcTool{}})
+	ctx := context.Background()
+
+	if err := tm.ConnectMCP(ctx); err == nil {
+		t.Error("ConnectMCP: want an explicit error, got nil (silent no-op)")
+	}
+	if err := tm.DisconnectMCP("any"); err == nil {
+		t.Error("DisconnectMCP: want an explicit error, got nil (silent no-op)")
+	}
+	if _, err := tm.DiscoverMCP(ctx); err == nil {
+		t.Error("DiscoverMCP: want an explicit error, got nil (silent no-op)")
+	}
+}

--- a/v1beta/config.go
+++ b/v1beta/config.go
@@ -33,6 +33,12 @@ type Config struct {
 	Workflow  *WorkflowConfig  `toml:"workflow,omitempty"`
 	Tracing   *TracingConfig   `toml:"tracing,omitempty"`
 	Streaming *StreamingConfig `toml:"streaming,omitempty"`
+
+	// Middlewares run around every Run/RunWithOptions call, in registration
+	// order for BeforeRun and reverse order for AfterRun (see AgentMiddleware
+	// doc comment). Not TOML/JSON-serializable by design — set via
+	// WithMiddleware or directly. nil (the default) is zero behavior change.
+	Middlewares []AgentMiddleware `json:"-" toml:"-"`
 }
 
 // LLMConfig contains LLM provider configuration
@@ -68,14 +74,28 @@ type LLMConfig struct {
 	// Not yet verified live (no reachable llama.cpp endpoint when this was
 	// added).
 	CachePrompt bool `toml:"cache_prompt,omitempty"`
+
+	// MaxRetries, when > 0, wraps every provider Call/Stream(connection
+	// setup)/Embeddings with retry on transient errors (context
+	// deadline/cancellation, net.Error — see llm.DefaultIsRetryable). Zero
+	// (the default) disables retry — no behavior change for existing
+	// callers. Distinct from RunOptions.MaxRetries, which is agent-run-level
+	// and, as of this field's addition, still metadata-only.
+	MaxRetries int `toml:"max_retries,omitempty"`
+
+	// CircuitBreaker, when non-nil and Enabled, gates every provider call
+	// through a circuit breaker (reuses the same CircuitBreakerConfig shape
+	// already declared for ToolsConfig.CircuitBreaker). nil (the default)
+	// disables circuit-breaking — no behavior change for existing callers.
+	CircuitBreaker *CircuitBreakerConfig `toml:"circuit_breaker,omitempty"`
 }
 
 // JSONObjectResponseFormat returns the OpenAI-compatible "loose JSON"
 // response_format value — the model must return valid JSON, no schema
 // required. Broadly supported across OpenAI-compatible providers;
-// verified live 2026-07-10 against Cerebras/gpt-oss-120b (honored, clean
-// JSON content, no markdown fencing). Prefer this over hand-rolling the
-// map literal at call sites.
+// verified live 2026-07-10 against a real OpenAI-compatible endpoint
+// (honored cleanly: valid JSON content, no markdown fencing). Prefer this
+// over hand-rolling the map literal at call sites.
 func JSONObjectResponseFormat() interface{} {
 	return map[string]interface{}{"type": "json_object"}
 }

--- a/v1beta/config.go
+++ b/v1beta/config.go
@@ -55,6 +55,21 @@ type LLMConfig struct {
 	Modalities  []string `toml:"modalities,omitempty"`   // Supported modalities (text, image, audio, video)
 	OutputTypes []string `toml:"output_types,omitempty"` // Desired output types
 
+	// ResponseFormat, when non-nil, is passed through verbatim as the
+	// OpenAI-compatible "response_format" request field. nil (the zero
+	// value) omits the field entirely — no behavior change for existing
+	// callers. Use JSONObjectResponseFormat() for the common case.
+	ResponseFormat interface{} `toml:"response_format,omitempty"`
+}
+
+// JSONObjectResponseFormat returns the OpenAI-compatible "loose JSON"
+// response_format value — the model must return valid JSON, no schema
+// required. Broadly supported across OpenAI-compatible providers;
+// verified live 2026-07-10 against Cerebras/gpt-oss-120b (honored, clean
+// JSON content, no markdown fencing). Prefer this over hand-rolling the
+// map literal at call sites.
+func JSONObjectResponseFormat() interface{} {
+	return map[string]interface{}{"type": "json_object"}
 }
 
 // MemoryConfig contains memory and RAG configuration

--- a/v1beta/config.go
+++ b/v1beta/config.go
@@ -60,6 +60,14 @@ type LLMConfig struct {
 	// value) omits the field entirely — no behavior change for existing
 	// callers. Use JSONObjectResponseFormat() for the common case.
 	ResponseFormat interface{} `toml:"response_format,omitempty"`
+
+	// CachePrompt, when true, sets the OpenAI-compatible adapter's
+	// "cache_prompt" request field — llama.cpp's server flag to reuse a
+	// matching KV-cache prefix instead of re-prefilling it. false (the zero
+	// value) omits the field entirely — no-op on non-llama.cpp backends.
+	// Not yet verified live (no reachable llama.cpp endpoint when this was
+	// added).
+	CachePrompt bool `toml:"cache_prompt,omitempty"`
 }
 
 // JSONObjectResponseFormat returns the OpenAI-compatible "loose JSON"

--- a/v1beta/config.go
+++ b/v1beta/config.go
@@ -129,6 +129,22 @@ type ToolsConfig struct {
 	Cache            *CacheConfig          `toml:"cache,omitempty"`
 	CircuitBreaker   *CircuitBreakerConfig `toml:"circuit_breaker,omitempty"`
 	Reasoning        *ReasoningConfig      `toml:"reasoning,omitempty"` // Agent reasoning/continuation settings
+	Skills           *SkillsConfig         `toml:"skills,omitempty"`
+}
+
+// SkillsConfig declares a directory of on-demand-loadable skill packages
+// (SKILL.md files, frontmatter-indexed) for the load_skill internal tool.
+// Data only, same shape as MCPConfig.Servers — the actual frontmatter
+// parsing/loading logic lives in a separate plugin (e.g. plugins/skills),
+// not here, to avoid v1beta depending on that plugin (which itself imports
+// v1beta for Tool/ToolResult). Setting Dir has no effect unless a skills
+// plugin has registered a factory via SetSkillsProviderFactory (see
+// skills_provider.go) — createTools() logs a warning, not an error, if
+// Dir is set with no provider registered (config alone can't tell whether
+// that's a missing blank-import or a stale config left over from removing
+// one).
+type SkillsConfig struct {
+	Dir string `toml:"dir"`
 }
 
 // ReasoningConfig controls whether the agent uses continuation loops for reasoning

--- a/v1beta/middleware_test.go
+++ b/v1beta/middleware_test.go
@@ -1,0 +1,212 @@
+package v1beta
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/agenticgokit/agenticgokit/internal/llm"
+)
+
+// fakeMiddlewareProvider is a minimal llm.ModelProvider for middleware tests
+// — only Call is exercised by execute().
+type fakeMiddlewareProvider struct {
+	callFunc func(ctx context.Context, prompt llm.Prompt) (llm.Response, error)
+}
+
+func (f *fakeMiddlewareProvider) Call(ctx context.Context, prompt llm.Prompt) (llm.Response, error) {
+	if f.callFunc != nil {
+		return f.callFunc(ctx, prompt)
+	}
+	return llm.Response{Content: "default"}, nil
+}
+func (f *fakeMiddlewareProvider) Stream(ctx context.Context, prompt llm.Prompt) (<-chan llm.Token, error) {
+	return nil, errors.New("not implemented")
+}
+func (f *fakeMiddlewareProvider) Embeddings(ctx context.Context, texts []string) ([][]float64, error) {
+	return nil, errors.New("not implemented")
+}
+
+// recordingMiddleware records BeforeRun/AfterRun invocations and can be
+// configured to mutate input/result/err or abort.
+type recordingMiddleware struct {
+	name       string
+	calls      *[]string
+	beforeErr  error
+	beforeTag  string // appended to input in BeforeRun, if non-empty
+	afterErr   error
+	afterClear bool // if true, AfterRun clears an incoming error
+}
+
+func (m *recordingMiddleware) Name() string { return m.name }
+
+func (m *recordingMiddleware) BeforeRun(ctx context.Context, input string) (context.Context, string, error) {
+	*m.calls = append(*m.calls, "before:"+m.name)
+	if m.beforeErr != nil {
+		return ctx, input, m.beforeErr
+	}
+	if m.beforeTag != "" {
+		input += m.beforeTag
+	}
+	return ctx, input, nil
+}
+
+func (m *recordingMiddleware) AfterRun(ctx context.Context, input string, result *Result, err error) (*Result, error) {
+	*m.calls = append(*m.calls, "after:"+m.name)
+	if m.afterErr != nil {
+		return result, m.afterErr
+	}
+	if m.afterClear {
+		return result, nil
+	}
+	return result, err
+}
+
+func minimalAgent(provider llm.ModelProvider, middlewares []AgentMiddleware) *realAgent {
+	return &realAgent{
+		config: &Config{
+			Name: "test-agent",
+			LLM:  LLMConfig{Provider: "mock", Model: "mock-model"},
+		},
+		llmProvider: provider,
+		initialized: true,
+		metrics:     &agentMetrics{},
+		middlewares: middlewares,
+	}
+}
+
+func TestMiddleware_NilMiddlewaresIsNoOp(t *testing.T) {
+	agent := minimalAgent(&fakeMiddlewareProvider{}, nil)
+	result, err := agent.Run(context.Background(), "hi")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Content != "default" {
+		t.Fatalf("got %q, want %q", result.Content, "default")
+	}
+}
+
+func TestMiddleware_BeforeRunOrderAndInputMutation(t *testing.T) {
+	var calls []string
+	var gotInput string
+	provider := &fakeMiddlewareProvider{
+		callFunc: func(ctx context.Context, prompt llm.Prompt) (llm.Response, error) {
+			gotInput = prompt.User
+			return llm.Response{Content: "ok"}, nil
+		},
+	}
+	mw1 := &recordingMiddleware{name: "mw1", calls: &calls, beforeTag: "+mw1"}
+	mw2 := &recordingMiddleware{name: "mw2", calls: &calls, beforeTag: "+mw2"}
+
+	agent := minimalAgent(provider, []AgentMiddleware{mw1, mw2})
+	_, err := agent.Run(context.Background(), "input")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if gotInput != "input+mw1+mw2" {
+		t.Fatalf("got input %q, want %q (BeforeRun must run in registration order)", gotInput, "input+mw1+mw2")
+	}
+	wantCalls := []string{"before:mw1", "before:mw2", "after:mw2", "after:mw1"}
+	if !equalStrings(calls, wantCalls) {
+		t.Fatalf("got call order %v, want %v (AfterRun must run LIFO)", calls, wantCalls)
+	}
+}
+
+func TestMiddleware_BeforeRunErrorAbortsBeforeLLMCall(t *testing.T) {
+	var calls []string
+	llmCalled := false
+	provider := &fakeMiddlewareProvider{
+		callFunc: func(ctx context.Context, prompt llm.Prompt) (llm.Response, error) {
+			llmCalled = true
+			return llm.Response{Content: "should not happen"}, nil
+		},
+	}
+	wantErr := errors.New("boom")
+	mw := &recordingMiddleware{name: "mw", calls: &calls, beforeErr: wantErr}
+
+	agent := minimalAgent(provider, []AgentMiddleware{mw})
+	_, err := agent.Run(context.Background(), "input")
+
+	if err == nil {
+		t.Fatal("expected error, got nil")
+	}
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("got err %v, want wrapping %v", err, wantErr)
+	}
+	agentErr, ok := err.(*AgentError)
+	if !ok || agentErr.Code != ErrMiddlewareBeforeRun {
+		t.Fatalf("got err %v (type %T), want *AgentError with code %v", err, err, ErrMiddlewareBeforeRun)
+	}
+	if llmCalled {
+		t.Fatal("LLM must not be called when BeforeRun aborts the run")
+	}
+	if len(calls) != 1 || calls[0] != "before:mw" {
+		t.Fatalf("got calls %v, want only before:mw (no AfterRun on BeforeRun abort)", calls)
+	}
+}
+
+func TestMiddleware_AfterRunCanClearError(t *testing.T) {
+	provider := &fakeMiddlewareProvider{
+		callFunc: func(ctx context.Context, prompt llm.Prompt) (llm.Response, error) {
+			return llm.Response{}, errors.New("llm failed")
+		},
+	}
+	var calls []string
+	mw := &recordingMiddleware{name: "mw", calls: &calls, afterClear: true}
+
+	agent := minimalAgent(provider, []AgentMiddleware{mw})
+	_, err := agent.Run(context.Background(), "input")
+	if err != nil {
+		t.Fatalf("expected AfterRun to clear the error, got: %v", err)
+	}
+}
+
+func TestMiddleware_AfterRunErrorIsNotWrappedAsMiddlewareError(t *testing.T) {
+	provider := &fakeMiddlewareProvider{}
+	wantErr := errors.New("deliberate replacement")
+	var calls []string
+	mw := &recordingMiddleware{name: "mw", calls: &calls, afterErr: wantErr}
+
+	agent := minimalAgent(provider, []AgentMiddleware{mw})
+	_, err := agent.Run(context.Background(), "input")
+
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("got err %v, want %v unwrapped (not %v)", err, wantErr, ErrMiddlewareAfterRun)
+	}
+	if _, ok := err.(*AgentError); ok {
+		t.Fatal("AfterRun's returned error must not be wrapped as *AgentError/ErrMiddlewareAfterRun")
+	}
+}
+
+func TestMiddleware_SkipMiddlewareByName(t *testing.T) {
+	var calls []string
+	provider := &fakeMiddlewareProvider{}
+	mw1 := &recordingMiddleware{name: "mw1", calls: &calls}
+	mw2 := &recordingMiddleware{name: "mw2", calls: &calls}
+
+	agent := minimalAgent(provider, []AgentMiddleware{mw1, mw2})
+	_, err := agent.RunWithOptions(context.Background(), "input", &RunOptions{
+		SkipMiddleware: []string{"mw1"},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	wantCalls := []string{"before:mw2", "after:mw2"}
+	if !equalStrings(calls, wantCalls) {
+		t.Fatalf("got calls %v, want %v (mw1 must be fully skipped)", calls, wantCalls)
+	}
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/v1beta/provider_factory.go
+++ b/v1beta/provider_factory.go
@@ -7,6 +7,7 @@ import (
 	"time"
 
 	"github.com/agenticgokit/agenticgokit/core"
+	"github.com/agenticgokit/agenticgokit/internal/core/error_handling"
 	"github.com/agenticgokit/agenticgokit/internal/llm"
 
 	// Register memory providers
@@ -46,6 +47,18 @@ func createLLMProvider(config LLMConfig) (llm.ModelProvider, error) {
 
 	if llmConfig.Type == llm.ProviderTypeAzureOpenAI && llmConfig.Endpoint == "" && llmConfig.BaseURL != "" {
 		llmConfig.Endpoint = llmConfig.BaseURL
+	}
+
+	if config.MaxRetries > 0 {
+		llmConfig.RetryPolicy = &llm.RetryPolicy{MaxRetries: config.MaxRetries}
+	}
+	if config.CircuitBreaker != nil && config.CircuitBreaker.Enabled {
+		llmConfig.CircuitBreaker = error_handling.NewCircuitBreakerImplementation(&core.CircuitBreakerConfig{
+			FailureThreshold:   config.CircuitBreaker.FailureThreshold,
+			SuccessThreshold:   config.CircuitBreaker.SuccessThreshold,
+			Timeout:            config.CircuitBreaker.Timeout,
+			MaxConcurrentCalls: config.CircuitBreaker.HalfOpenMaxCalls,
+		})
 	}
 
 	// Use the internal/llm factory to create the provider

--- a/v1beta/provider_factory.go
+++ b/v1beta/provider_factory.go
@@ -40,6 +40,7 @@ func createLLMProvider(config LLMConfig) (llm.ModelProvider, error) {
 		ChatDeployment:      config.ChatDeployment,      // For Azure
 		EmbeddingDeployment: config.EmbeddingDeployment, // For Azure
 		APIVersion:          config.APIVersion,          // For Azure
+		ResponseFormat:      config.ResponseFormat,
 	}
 
 	if llmConfig.Type == llm.ProviderTypeAzureOpenAI && llmConfig.Endpoint == "" && llmConfig.BaseURL != "" {

--- a/v1beta/provider_factory.go
+++ b/v1beta/provider_factory.go
@@ -41,6 +41,7 @@ func createLLMProvider(config LLMConfig) (llm.ModelProvider, error) {
 		EmbeddingDeployment: config.EmbeddingDeployment, // For Azure
 		APIVersion:          config.APIVersion,          // For Azure
 		ResponseFormat:      config.ResponseFormat,
+		CachePrompt:         config.CachePrompt,
 	}
 
 	if llmConfig.Type == llm.ProviderTypeAzureOpenAI && llmConfig.Endpoint == "" && llmConfig.BaseURL != "" {

--- a/v1beta/provider_factory_test.go
+++ b/v1beta/provider_factory_test.go
@@ -1,0 +1,62 @@
+package v1beta
+
+import (
+	"testing"
+	"time"
+
+	"github.com/agenticgokit/agenticgokit/internal/llm"
+)
+
+func TestCreateLLMProvider_NoWrapWhenRetryAndCircuitBreakerUnset(t *testing.T) {
+	p, err := createLLMProvider(LLMConfig{Provider: "mock"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, wrapped := p.(*llm.CircuitBreakerProvider); wrapped {
+		t.Fatal("provider should not be wrapped when MaxRetries/CircuitBreaker are unset (default LLMConfig)")
+	}
+}
+
+func TestCreateLLMProvider_WrapsWhenMaxRetriesSet(t *testing.T) {
+	p, err := createLLMProvider(LLMConfig{Provider: "mock", MaxRetries: 3})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, wrapped := p.(*llm.CircuitBreakerProvider); !wrapped {
+		t.Fatal("provider should be wrapped when MaxRetries is set")
+	}
+}
+
+func TestCreateLLMProvider_WrapsWhenCircuitBreakerEnabled(t *testing.T) {
+	p, err := createLLMProvider(LLMConfig{
+		Provider: "mock",
+		CircuitBreaker: &CircuitBreakerConfig{
+			Enabled:          true,
+			FailureThreshold: 5,
+			SuccessThreshold: 2,
+			Timeout:          30 * time.Second,
+			HalfOpenMaxCalls: 2,
+		},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, wrapped := p.(*llm.CircuitBreakerProvider); !wrapped {
+		t.Fatal("provider should be wrapped when CircuitBreaker.Enabled is true")
+	}
+}
+
+func TestCreateLLMProvider_NoWrapWhenCircuitBreakerConfigDisabled(t *testing.T) {
+	// A non-nil CircuitBreaker config with Enabled: false must behave like
+	// no config at all — the struct being present isn't the trigger.
+	p, err := createLLMProvider(LLMConfig{
+		Provider:       "mock",
+		CircuitBreaker: &CircuitBreakerConfig{Enabled: false},
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if _, wrapped := p.(*llm.CircuitBreakerProvider); wrapped {
+		t.Fatal("provider should not be wrapped when CircuitBreaker.Enabled is false")
+	}
+}

--- a/v1beta/skills_provider.go
+++ b/v1beta/skills_provider.go
@@ -1,0 +1,52 @@
+package v1beta
+
+import "sync"
+
+// SkillsProvider is implemented by a skills-loading plugin (e.g.
+// plugins/skills) and returned by a registered SkillsProviderFactory. Kept
+// deliberately narrow — just enough for createTools() to wire the load_skill
+// tool in and splice the rendered catalog into the agent's SystemPrompt —
+// not a general plugin API.
+type SkillsProvider interface {
+	// Tool returns the load_skill Tool itself, ready to append to the
+	// agent's discovered []Tool slice.
+	Tool() Tool
+	// Catalog returns the boot-time frontmatter index rendered as markdown,
+	// for splicing into Config.SystemPrompt. Bodies are never included here
+	// — see the plugin's own doc comment for why (flat memory regardless of
+	// corpus size; only Tool().Execute reads a body, on demand).
+	Catalog() string
+}
+
+// SkillsProviderFactory builds a SkillsProvider for the skills directory
+// named in ToolsConfig.Skills.Dir.
+type SkillsProviderFactory func(dir string) (SkillsProvider, error)
+
+// SetSkillsProviderFactory registers the factory a skills plugin provides.
+// Same registration shape as SetToolManagerFactory (tools.go) and
+// RegisterLoggingProvider (core) — v1beta defines the hook, the plugin
+// self-registers via its own init() on blank import, so v1beta never needs
+// to depend on the plugin (which itself imports v1beta for Tool/ToolResult
+// — the dependency can only run one direction).
+func SetSkillsProviderFactory(factory SkillsProviderFactory) {
+	skillsFactoryMutex.Lock()
+	defer skillsFactoryMutex.Unlock()
+	skillsProviderFactory = factory
+}
+
+var (
+	skillsProviderFactory SkillsProviderFactory
+	skillsFactoryMutex    sync.RWMutex
+)
+
+// GetSkillsProviderFactory returns the currently registered factory, or nil
+// if no skills plugin has been blank-imported. Exported mainly so a plugin's
+// own tests can confirm its init() actually ran (there's no other external
+// signal for that short of a live Build() call), but also useful for a
+// caller that wants to detect/log a missing blank-import before relying on
+// ToolsConfig.Skills.Dir.
+func GetSkillsProviderFactory() SkillsProviderFactory {
+	skillsFactoryMutex.RLock()
+	defer skillsFactoryMutex.RUnlock()
+	return skillsProviderFactory
+}

--- a/v1beta/skills_provider_test.go
+++ b/v1beta/skills_provider_test.go
@@ -1,0 +1,120 @@
+package v1beta
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+type fakeSkillsTool struct{ name string }
+
+func (t *fakeSkillsTool) Name() string        { return t.name }
+func (t *fakeSkillsTool) Description() string { return "test skill loader" }
+func (t *fakeSkillsTool) Execute(ctx context.Context, args map[string]interface{}) (*ToolResult, error) {
+	return &ToolResult{Success: true, Content: "skill body"}, nil
+}
+
+type fakeSkillsProvider struct{ dir string }
+
+func (p *fakeSkillsProvider) Tool() Tool      { return &fakeSkillsTool{name: "load_skill"} }
+func (p *fakeSkillsProvider) Catalog() string { return "- fake-skill — a test skill\n" }
+
+// Verifies the declarative path end to end: ToolsConfig.Skills.Dir (the
+// TOML-loadable field) plus a registered SkillsProviderFactory (what a
+// blank-imported skills plugin, e.g. plugins/skills, does in its own
+// init()) is enough for Build() to both append the load_skill tool to
+// a.tools AND splice the rendered catalog into a.config.SystemPrompt —
+// no Install()-style Go call needed by the app at all.
+func TestBuild_WiresSkillsProviderFromToolsConfig(t *testing.T) {
+	SetSkillsProviderFactory(func(dir string) (SkillsProvider, error) {
+		if dir != "/fake/skills/dir" {
+			t.Errorf("factory called with dir = %q, want /fake/skills/dir", dir)
+		}
+		return &fakeSkillsProvider{dir: dir}, nil
+	})
+	defer SetSkillsProviderFactory(nil)
+
+	cfg := &Config{
+		Name:         "skills-probe",
+		LLM:          LLMConfig{Provider: "ollama", Model: "llama3", BaseURL: "http://localhost:1"},
+		SystemPrompt: "Base prompt.",
+		Tools: &ToolsConfig{
+			Enabled: true,
+			Skills:  &SkillsConfig{Dir: "/fake/skills/dir"},
+		},
+	}
+
+	agentIface, err := newRealAgent(cfg, nil)
+	if err != nil {
+		t.Fatalf("newRealAgent error: %v", err)
+	}
+	agent := agentIface.(*realAgent)
+
+	var found bool
+	for _, tl := range agent.tools {
+		if tl.Name() == "load_skill" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("agent.tools = %v, want load_skill among them", agent.tools)
+	}
+
+	if !strings.Contains(agent.config.SystemPrompt, "fake-skill") {
+		t.Errorf("SystemPrompt was not spliced with the rendered catalog: %q", agent.config.SystemPrompt)
+	}
+	if !strings.HasPrefix(agent.config.SystemPrompt, "Base prompt.") {
+		t.Errorf("SystemPrompt lost its original content: %q", agent.config.SystemPrompt)
+	}
+}
+
+// No factory registered: Dir set but nothing to load it — must not error
+// Build() (a missing blank-import shouldn't be fatal, just inert, same
+// fail-open shape as a bad/unreachable MCP server).
+func TestBuild_SkillsDirSetWithNoFactoryIsNotFatal(t *testing.T) {
+	SetSkillsProviderFactory(nil)
+
+	cfg := &Config{
+		Name:         "skills-probe-no-factory",
+		LLM:          LLMConfig{Provider: "ollama", Model: "llama3", BaseURL: "http://localhost:1"},
+		SystemPrompt: "Base prompt.",
+		Tools: &ToolsConfig{
+			Enabled: true,
+			Skills:  &SkillsConfig{Dir: "/fake/skills/dir"},
+		},
+	}
+
+	agentIface, err := newRealAgent(cfg, nil)
+	if err != nil {
+		t.Fatalf("newRealAgent error: %v, want no error (fail-open)", err)
+	}
+	agent := agentIface.(*realAgent)
+	if agent.config.SystemPrompt != "Base prompt." {
+		t.Errorf("SystemPrompt = %q, want unchanged when no factory is registered", agent.config.SystemPrompt)
+	}
+}
+
+// No Skills config at all: the common case, must be a complete no-op.
+func TestBuild_NoSkillsConfigIsANoOp(t *testing.T) {
+	SetSkillsProviderFactory(func(dir string) (SkillsProvider, error) {
+		t.Fatal("factory should never be called when ToolsConfig.Skills is nil")
+		return nil, nil
+	})
+	defer SetSkillsProviderFactory(nil)
+
+	cfg := &Config{
+		Name:         "skills-probe-no-config",
+		LLM:          LLMConfig{Provider: "ollama", Model: "llama3", BaseURL: "http://localhost:1"},
+		SystemPrompt: "Base prompt.",
+		Tools:        &ToolsConfig{Enabled: true},
+	}
+
+	agentIface, err := newRealAgent(cfg, nil)
+	if err != nil {
+		t.Fatalf("newRealAgent error: %v", err)
+	}
+	agent := agentIface.(*realAgent)
+	if agent.config.SystemPrompt != "Base prompt." {
+		t.Errorf("SystemPrompt = %q, want unchanged", agent.config.SystemPrompt)
+	}
+}


### PR DESCRIPTION
## Summary

Several independent, small fixes accumulated while running this fork against a real workload. Grouped here as one PR since they're all ahead of `master` together; happy to split into separate PRs if that's easier to review.

### Circuit-breaker/retry for ModelProvider (new)
- `internal/llm/circuit_breaker_provider.go`: `CircuitBreakerProvider` decorates any `ModelProvider` (`Call`/`Stream`/`Embeddings`) with circuit-breaking + retry, wired centrally in `ProviderFactory.CreateProvider` so every adapter type gets it uniformly, not just OpenAI's.
- Retry classification (`DefaultIsRetryable`) is `errors.Is`/`errors.As`-based (context deadline/cancel, `net.Error`) rather than exact string matching, so it survives upstream error-message wording changes.
- `v1beta.LLMConfig.MaxRetries`/`CircuitBreaker` (reuses the already-declared `CircuitBreakerConfig` shape from `ToolsConfig`) wire the concrete breaker through `createLLMProvider`. Both opt-in; zero value is unchanged behavior.
- Live-verified against a real OpenAI-compatible endpoint: real turn through `CircuitBreakerProvider -> OpenAI adapter -> gateway`, correct content/usage.

### Revive `AgentMiddleware` (previously dead code)
- `v1beta.AgentMiddleware` (`BeforeRun`/`AfterRun`) was declared but had zero call sites anywhere and zero implementations in the repo. Added `Name()` (needed for `RunOptions.SkipMiddleware` to mean anything) and wired `BeforeRun`/`AfterRun` around `realAgent.execute()` (the shared choke point for `Run`/`RunWithOptions`) via a new `WithMiddleware` Option.
- `BeforeRun` runs in registration order and can abort the run before any LLM call; `AfterRun` runs LIFO and its returned error passes through unwrapped (not coerced into a generic middleware error) since middleware is expected to make deliberate error-replacement decisions.
- Deliberately scoped: doesn't expose `CircuitBreakerProvider`'s internal retry attempts or the reasoning-loop's iteration count to middleware, and only wired for `Run`/`RunWithOptions`, not the streaming variants.
- 19 new hermetic tests across both changes.

### `response_format`/`cache_prompt` propagation to every OpenAI-compatible adapter
`ProviderConfig.ResponseFormat`/`CachePrompt` were declared on the shared config struct but only `openai_adapter.go` actually read them — vLLM, MLFlow Gateway, BentoML, OpenRouter, and Azure OpenAI silently dropped them if a caller set them.
- vLLM/MLFlow Gateway/BentoML already compose an internal `OpenAIAdapterConfig` ("Embed OpenAI adapter for code reuse") — just needed the fields threaded through.
- OpenRouter builds its own request body; added unexported fields set by the factory (same package) rather than changing `NewOpenRouterAdapter`'s existing positional signature.
- Azure OpenAI: same wire API family as OpenAI, added `ResponseFormat` to its request struct. `CachePrompt` intentionally *not* added — it's a llama.cpp self-hosted flag, doesn't apply to hosted Azure.
- Anthropic/Ollama/HuggingFace/FoundryLocal intentionally untouched — genuinely different wire protocols where forcing the field through would just move the silent-drop bug rather than fix it.
- 5 new hermetic tests (one per newly-wired adapter) assert the field's actual presence in the outbound request body.

### Smaller fixes (earlier commits in this branch)
- Fix data race in unified MCP transports (Send/Receive mutating state under `RLock`).
- Respect an explicit `MemoryConfig.Enabled = false` instead of forcing memory back on.
- Fix streamable-HTTP SSE detection tripping on a leading keep-alive comment.
- Preserve the original HTTP status code in the OpenAI adapter's non-200 error path.
- Forward `RunOptions.SessionID` as an outbound `X-Session-Id` header.
- Make the unified MCP manager's per-call timeout configurable (`v1beta.WithMCPConnectionTimeout`) instead of hardcoded 30s in three places — a legitimately slow-but-working discovery call was getting aborted regardless of any other configured timeout. Purely additive, existing callers unaffected. Confirmed live against a real Cube.js-backed MCP server.

## Test plan
- [x] `go build ./internal/llm/... ./v1beta/... ./internal/core/error_handling/... ./core/...`
- [x] `go vet ./internal/llm/... ./v1beta/...`
- [x] `go test ./internal/llm/... ./v1beta/...` — full existing suites green, plus 24 new tests across the circuit-breaker/middleware/response_format changes
- [x] Live call against a real OpenAI-compatible endpoint for the circuit-breaker wiring
