### PR TITLE
fix(v1beta): populate manifest token count

### DIFF
--- a/v1beta/agent_impl.go
+++ b/v1beta/agent_impl.go
@@ -1367,6 +1367,7 @@ func (a *realAgent) generateManifest() error {
 		if spanName, ok := span["Name"].(string); ok {
 			if strings.Contains(spanName, "llm") {
 				manifest.LLMCalls++
+				manifest.TotalTokens += traceSpanTokenCount(span)
 			}
 		}
 
@@ -1411,6 +1412,47 @@ func (a *realAgent) generateManifest() error {
 	}
 
 	return ioutil.WriteFile(manifestPath, manifestData, 0644)
+}
+
+// traceSpanTokenCount extracts token usage from an LLM span in the format
+// written by the OpenTelemetry stdout exporter. Provider spans record the
+// total directly; the component fields are fallbacks for providers that do
+// not emit the total attribute. Non-LLM spans are filtered by the caller so
+// agent spans cannot double-count the same request.
+func traceSpanTokenCount(span map[string]interface{}) int {
+	attributes, ok := span["Attributes"].([]interface{})
+	if !ok {
+		return 0
+	}
+
+	values := make(map[string]int)
+	for _, rawAttribute := range attributes {
+		attribute, ok := rawAttribute.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		key, ok := attribute["Key"].(string)
+		if !ok {
+			continue
+		}
+		value, ok := attribute["Value"].(map[string]interface{})
+		if !ok || value["Type"] != "INT64" {
+			continue
+		}
+		number, ok := value["Value"].(float64)
+		if !ok {
+			continue
+		}
+		values[key] = int(number)
+	}
+
+	if total, ok := values[observability.AttrLLMTotalTokens]; ok {
+		return total
+	}
+	if prompt, ok := values[observability.AttrLLMPromptTokens]; ok {
+		return prompt + values[observability.AttrLLMCompletionTokens]
+	}
+	return values[observability.AttrLLMTokensIn] + values[observability.AttrLLMTokensOut]
 }
 
 // =============================================================================

--- a/v1beta/agent_impl_test.go
+++ b/v1beta/agent_impl_test.go
@@ -2,6 +2,9 @@ package v1beta
 
 import (
 	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 
@@ -121,5 +124,72 @@ func TestStoreInMemoryReturnsNoErrorWithoutMemoryProvider(t *testing.T) {
 
 	if err := agent.storeInMemory(context.Background(), "user prompt", "assistant output"); err != nil {
 		t.Fatalf("expected nil error with no memory provider, got %v", err)
+	}
+}
+
+func TestGenerateManifestAggregatesLLMSpanTokens(t *testing.T) {
+	runDir := t.TempDir()
+	trace := []map[string]interface{}{
+		{
+			"Name":      "agk.agent.run",
+			"StartTime": "2026-01-01T00:00:00Z",
+			"EndTime":   "2026-01-01T00:00:01Z",
+			"Attributes": []map[string]interface{}{
+				{"Key": "agk.llm.tokens.input", "Value": map[string]interface{}{"Type": "INT64", "Value": 99}},
+				{"Key": "agk.llm.tokens.output", "Value": map[string]interface{}{"Type": "INT64", "Value": 101}},
+			},
+		},
+		{
+			"Name":      "llm.openai.call",
+			"StartTime": "2026-01-01T00:00:00Z",
+			"EndTime":   "2026-01-01T00:00:01Z",
+			"Attributes": []map[string]interface{}{
+				{"Key": "agk.llm.tokens.total", "Value": map[string]interface{}{"Type": "INT64", "Value": 7}},
+			},
+		},
+		{
+			"Name":      "llm.anthropic.call",
+			"StartTime": "2026-01-01T00:00:01Z",
+			"EndTime":   "2026-01-01T00:00:02Z",
+			"Attributes": []map[string]interface{}{
+				{"Key": "agk.llm.tokens.prompt", "Value": map[string]interface{}{"Type": "INT64", "Value": 4}},
+				{"Key": "agk.llm.tokens.completion", "Value": map[string]interface{}{"Type": "INT64", "Value": 6}},
+			},
+		},
+	}
+	var data []byte
+	for _, span := range trace {
+		encoded, err := json.Marshal(span)
+		if err != nil {
+			t.Fatalf("marshal trace fixture: %v", err)
+		}
+		data = append(data, encoded...)
+		data = append(data, '\n')
+	}
+	if err := os.WriteFile(filepath.Join(runDir, "trace.jsonl"), data, 0644); err != nil {
+		t.Fatalf("write trace fixture: %v", err)
+	}
+
+	agent := &realAgent{runDir: runDir, runID: "run-1", config: &Config{Name: "test-agent"}}
+	if err := agent.generateManifest(); err != nil {
+		t.Fatalf("generateManifest returned error: %v", err)
+	}
+
+	manifestData, err := os.ReadFile(filepath.Join(runDir, "manifest.json"))
+	if err != nil {
+		t.Fatalf("read generated manifest: %v", err)
+	}
+	var manifest struct {
+		LLMCalls    int `json:"llm_calls"`
+		TotalTokens int `json:"total_tokens"`
+	}
+	if err := json.Unmarshal(manifestData, &manifest); err != nil {
+		t.Fatalf("decode generated manifest: %v", err)
+	}
+	if manifest.LLMCalls != 2 {
+		t.Fatalf("expected 2 LLM calls, got %d", manifest.LLMCalls)
+	}
+	if manifest.TotalTokens != 17 {
+		t.Fatalf("expected 17 total tokens without root-span double counting, got %d", manifest.TotalTokens)
 	}
 }


### PR DESCRIPTION
## Summary
- populate `manifest.json` total tokens from LLM span attributes
- prefer an emitted total, with prompt/completion and input/output fallbacks
- count only provider LLM spans so parent agent attributes are not double-counted
- add a JSONL manifest regression test covering both attribute formats

Closes #138 for `total_tokens`. Cost estimation remains unchanged because traces do not currently expose a cost attribute and the repository has no authoritative pricing source.

## Validation
- `go test ./v1beta`
- `go test -race ./v1beta -run 'TestGenerateManifestAggregatesLLMSpanTokens|TestStoreInMemory'`
- mutation check: removing the aggregation made the new test fail with 0 instead of 17

`go test ./...` was also run; `v1beta` and non-environment-dependent packages pass, while existing example build conflicts and tests requiring live OpenAI/Ollama services fail in this checkout.

AI assistance was used to explore the trace flow and draft the focused implementation and test; the resulting diff and validation were reviewed manually.